### PR TITLE
fix: ignore temp folder

### DIFF
--- a/.temp/e2e/.gitignore
+++ b/.temp/e2e/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.temp/e2e/runtime.spec.js
+++ b/.temp/e2e/runtime.spec.js
@@ -1,6 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('runtime', async ({ page }) => {
-    await page.goto('https://laravel.com');
-await expect(page).toHaveTitle(/Laravel/);
-});


### PR DESCRIPTION
The temp folder was being committed to the repository, along with all of its runtime-generated contents.