### PR TITLE
feat: support both regex and non regex titles

### DIFF
--- a/src/Operations/ToHaveTitle.php
+++ b/src/Operations/ToHaveTitle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Browser\Operations;
 
 use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Support\Str;
 
 /**
  * @internal
@@ -22,6 +23,8 @@ final readonly class ToHaveTitle implements Operation
 
     public function compile(): string
     {
-        return sprintf("await expect(page).toHaveTitle(/%s/);", $this->title);
+        $title = Str::isRegex($this->title) ? $this->title : json_encode($this->title);
+
+        return sprintf('await expect(page).toHaveTitle(%s);', $title);
     }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Support;
+
+/**
+ * @internal
+ */
+final class Str
+{
+    /**
+     * Check if the given string is a regex.
+     */
+    public static function isRegex(string $target): bool
+    {
+        if (strlen($target) < 2) {
+            return false;
+        }
+
+        return ($delimiter = substr($target, 0, 1)) === substr($target, -1, 1) && preg_match('/[^a-zA-Z0-9]/', $delimiter);
+    }
+}

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -18,6 +18,16 @@ final class Str
             return false;
         }
 
-        return ($delimiter = substr($target, 0, 1)) === substr($target, -1, 1) && preg_match('/[^a-zA-Z0-9]/', $delimiter);
+        // If the first and last characters are not the same, it's not a regex
+        if (($delimiter = substr($target, 0, 1)) !== substr($target, -1, 1)) {
+            return false;
+        }
+
+        // If the delimiter is alphanumeric, it's not a regex
+        if (! preg_match('/[^a-zA-Z0-9]/', $delimiter)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -4,10 +4,14 @@ use function Pest\Browser\visit;
 
 it('may have a title at playwright', function () {
     visit('https://playwright.dev/')
-        ->toHaveTitle('Playwright');
+        ->toHaveTitle('Fast and reliable end-to-end testing for modern web apps | Playwright')
+        ->toHaveTitle('/testing/')
+        ->toHaveTitle('/.*Playwright$/');
 });
 
 it('may have a title at laravel', function () {
     visit('https://laravel.com')
-        ->toHaveTitle('Laravel');
+        ->toHaveTitle('Laravel - The PHP Framework For Web Artisans')
+        ->toHaveTitle('/Framework/')
+        ->toHaveTitle('/.*Artisans$/');
 });


### PR DESCRIPTION
Add support for both regex and non regex matching of titles.

The existing `toHaveTitle` expectation requires an string that will always be considered and compiled as regex, which can be limiting or prone to errors in cases where we need to match the exact title of a page.

PS: you may want to port that `Str::isRegex` to `Pest\Support\Str` namespace.