### PR TITLE
feat(operations): adds page screenshot to the party

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/.temp/e2e/runtime.spec.js

--- a/.temp/e2e/runtime.spec.js
+++ b/.temp/e2e/runtime.spec.js
@@ -1,6 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('runtime', async ({ page }) => {
-    await page.goto('https://laravel.com');
-await expect(page).toHaveTitle(/Laravel/);
-});

--- a/src/Operations/PageScreenshot.php
+++ b/src/Operations/PageScreenshot.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+use function sprintf;
+
+final readonly class PageScreenshot implements Operation
+{
+
+
+    public function __construct(
+        private string $path,
+        private bool $fullPage = false,
+    ) {
+        //
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function compile(): string
+    {
+        return sprintf(
+            "await page.screenshot({ path: '%s', fullPage: %s });",
+             $this->path,
+            $this->fullPage ? 'true' : 'false'
+        );
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -35,6 +35,16 @@ final class PendingTest
     }
 
     /**
+     * Takes a screenshot of the page.
+     */
+    public function pageScreenshot(string $path, bool $fullPage = false): self
+    {
+        $this->operations[] = new Operations\PageScreenshot($path, $fullPage);
+
+        return $this;
+    }
+
+    /**
      * Build the test result.
      */
     public function build(): void

--- a/tests/Feature/Operations/PageScreenshotTest.php
+++ b/tests/Feature/Operations/PageScreenshotTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+use function Pest\Browser\visit;
+
+it('takes a full page screenshot of laravel.com', function () {
+
+    $filePath = __DIR__ . '/laravel-full-page.png';
+
+    visit('https://laravel.com')
+        ->pageScreenshot(
+            path: $filePath,
+            fullPage: true
+        );
+
+    expect(file_exists($filePath))
+        ->toBeTrue();
+
+    unlink($filePath);
+
+});
+
+it('takes a screenshot of laravel.com', function () {
+
+    $filePath = __DIR__.'/laravel.png';
+
+    visit('https://laravel.com')
+        ->pageScreenshot(
+            path: $filePath
+        );
+
+    expect(file_exists($filePath))
+        ->toBeTrue();
+
+    unlink($filePath);
+
+});


### PR DESCRIPTION
This pull request introduces a new feature for taking page screenshots in the browser. 
The most important changes include the addition of a `PageScreenshot` class, a new method in `PendingTest`, and corresponding tests.

New feature for page screenshots:

* [`src/Operations/PageScreenshot.php`](diffhunk://#diff-eb7c8d475457f0053d1f73c0404fd03f11273c9fe91c94c6c9f69fa8e7a2ebc4R1-R32): Added a new `PageScreenshot` class that implements the `Operation` interface, allowing the capture of screenshots with optional full-page capability.
* [`src/PendingTest.php`](diffhunk://#diff-337a351796ddcce4a5b7a3198a253d699a0c403a48a328524756421193d09795R37-R46): Introduced a new method `pageScreenshot` to add `PageScreenshot` operations to the test.

Tests for the new feature:

* [`tests/Feature/Operations/PageScreenshotTest.php`](diffhunk://#diff-453845ea5fbd858e7d55787a923ef879c920f7304bd9790365d93e938cfa3d50R1-R36): Added tests to verify the functionality of the `PageScreenshot` operation, ensuring screenshots are taken correctly and files are created and removed as expected.

Removal of outdated test:

* [`.temp/e2e/runtime.spec.js`](diffhunk://#diff-c50f3d6f98886069140c22ca805d97ba20886554800ea8d6ee244ca35ee67152L1-L6): Removed runtime.spec.js from the repo.