### PR TITLE
feat: add toNotHaveTitle operation

### DIFF
--- a/src/Operations/ToNotHaveTitle.php
+++ b/src/Operations/ToNotHaveTitle.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+/**
+ * @internal
+ */
+final readonly class ToNotHaveTitle implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private string $title,
+    ) {
+        //
+    }
+
+    public function compile(): string
+    {
+        return sprintf('await expect(page).not.toHaveTitle(/%s/);', $this->title);
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -35,6 +35,16 @@ final class PendingTest
     }
 
     /**
+     * Checks if the page does not have a title.
+     */
+    public function toNotHaveTitle(string $title): self
+    {
+        $this->operations[] = new Operations\ToNotHaveTitle($title);
+
+        return $this;
+    }
+
+    /**
      * Build the test result.
      */
     public function build(): void

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -11,3 +11,8 @@ it('may have a title at laravel', function () {
     visit('https://laravel.com')
         ->toHaveTitle('Laravel');
 });
+
+it('should not have the title "Laravel Dusk"', function () {
+    visit('https://laravel.com')
+        ->toNotHaveTitle('Laravel Dusk');
+});


### PR DESCRIPTION
Implements the [`.not` property option](https://playwright.dev/docs/api/class-pageassertions#page-assertions-not) on the `toHaveTitle` method as a distinct Operation class. 