### PR TITLE
fix: adjust method name from toNotHaveTitle() to assertTitleIsNot() 

### DIFF
--- a/src/Operations/AssertTitleIsNot.php
+++ b/src/Operations/AssertTitleIsNot.php
@@ -9,7 +9,7 @@ use Pest\Browser\Contracts\Operation;
 /**
  * @internal
  */
-final readonly class ToNotHaveTitle implements Operation
+final readonly class AssertTitleIsNot implements Operation
 {
     /**
      * Creates an operation instance.

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -62,7 +62,7 @@ final class PendingTest
     /**
      * Checks if the page does not have a title.
      */
-    public function asserTitleIsNot(string $title): self
+    public function assertTitleIsNot(string $title): self
     {
         $this->operations[] = new Operations\AssertTitleIsNot($title);
 

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -62,9 +62,9 @@ final class PendingTest
     /**
      * Checks if the page does not have a title.
      */
-    public function toNotHaveTitle(string $title): self
+    public function asserTitleIsNot(string $title): self
     {
-        $this->operations[] = new Operations\ToNotHaveTitle($title);
+        $this->operations[] = new Operations\AssertTitleIsNot($title);
 
         return $this;
     }

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -26,5 +26,5 @@ it('may click the "get started" button at laravel', function () {
 
 it('should not have the title "Laravel Dusk"', function () {
     visit('https://laravel.com')
-        ->asserTitleIsNot('Laravel Dusk');
+        ->assertTitleIsNot('Laravel Dusk');
 });

--- a/tests/Example.php
+++ b/tests/Example.php
@@ -26,5 +26,5 @@ it('may click the "get started" button at laravel', function () {
 
 it('should not have the title "Laravel Dusk"', function () {
     visit('https://laravel.com')
-        ->toNotHaveTitle('Laravel Dusk');
+        ->asserTitleIsNot('Laravel Dusk');
 });


### PR DESCRIPTION
Adjusts `toNotHaveTitle()` to `assertTitleIsNot()` in order to mimic the Dusk API.