### PR TITLE
WIP - Cleanup screenshots (help requested)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 .temp/e2e
+/tests/screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 .temp/e2e
-/tests/screenshots
+/tests/Browser/screenshots

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,6 @@
             "src/Autoload.php"
         ]
     },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
-        }
-    },
     "require-dev": {
         "laravel/pint": "^1.20",
         "pestphp/pest-dev-tools": "^3.4.0"

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,11 @@
             "src/Autoload.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "require-dev": {
         "laravel/pint": "^1.20",
         "pestphp/pest-dev-tools": "^3.4.0"

--- a/tests/Browser/Operations/ScreenshotTest.php
+++ b/tests/Browser/Operations/ScreenshotTest.php
@@ -6,18 +6,6 @@ use Pest\TestSuite;
 
 use function Pest\Browser\visit;
 
-afterEach(function () {
-    $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
-
-    foreach (glob($basePath.'/*') as $file) {
-        if (is_file($file)) {
-            unlink($file);
-        }
-    }
-
-    rmdir($basePath);
-});
-
 it('takes a screenshot', function (): void {
     $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
 
@@ -33,7 +21,9 @@ it('takes a screenshot and generates a path', function (): void {
     visit('https://laravel.com')
         ->screenshot();
 
-    $files = glob($basePath.'/*');
+    $testName = mb_ltrim(test()->name(), '__pest_evaluable_'); // @phpstan-ignore-line
+
+    $files = glob($basePath.DIRECTORY_SEPARATOR.'*'.$testName.'*');
 
     expect(count($files))->toBe(1);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\TestSuite;
+
+pest()->beforeAll(function () {
+    cleanupScreenshots();
+})
+    ->afterAll(function () {
+        cleanupScreenshots();
+    });
+
+function cleanupScreenshots(): void
+{
+    foreach (glob(TestSuite::getInstance()->testPath.'/Browser/screenshots/*') as $file) {
+        if (is_file($file)) {
+            unlink($file);
+        }
+    }
+
+    rmdir(TestSuite::getInstance()->testPath.'/Browser/screenshots');
+}


### PR DESCRIPTION
As @nunomaduro suggested during his most recent livestream, I've extracted the logic to cleanup the downloaded screenshots, but I'm having an issue.  No matter what I do, I cannot get the `beforeAll()` and `afterAll()` methods in `tests/Pest.php` to run.  I feel like I'm missing something simple here, but I can't figure out what I'm doing wrong.  

Could really use a hand here.