### PR TITLE
feat: add assertTitleContains

### DIFF
--- a/src/Operations/AssertTitleContains.php
+++ b/src/Operations/AssertTitleContains.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+final readonly class AssertTitleContains implements Operation
+{
+    public function __construct(
+        private string $title,
+    ) {
+        //
+    }
+
+    public function compile(): string
+    {
+        return sprintf('await expect(await page.title()).toMatch(/%s/);', $this->title);
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -57,6 +57,13 @@ final class PendingTest
         return $this;
     }
 
+    public function assertTitleContains(string $title): self
+    {
+        $this->operations[] = new Operations\AssertTitleContains($title);
+
+        return $this;
+    }
+
     /**
      * Checks if the page has a URL.
      */

--- a/tests/Browser/Operations/AssertTitleContainsTest.php
+++ b/tests/Browser/Operations/AssertTitleContainsTest.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+test('assert title contains', function () {
+    $url = 'https://laravel.com';
+
+    $browser = $this->visit($url);
+
+    $browser->assertTitleContains('Laravel');
+});

--- a/tests/Browser/Operations/AssertTitleContainsTest.php
+++ b/tests/Browser/Operations/AssertTitleContainsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 test('assert title contains', function () {
     $url = 'https://laravel.com';
 
-    $browser = $this->visit($url);
-
-    $browser->assertTitleContains('Laravel');
+    $this->visit($url)
+        ->assertTitleContains('Laravel');
 });


### PR DESCRIPTION
This adds assertTitleContains. It follows Dusk's [signature](https://github.com/laravel/dusk/blob/541ca2d2004ae4ed04446b9e712b68180fca158c/src/Concerns/MakesAssertions.php#L41). I needed a second await on `page.title()` as it's an async method.

If you need more information, let me know!