### PR TITLE
[FIX] assertSee test

### DIFF
--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -73,6 +73,8 @@ final class PendingTest
     public function assertSee(string $text, bool $ignoreCase = false): self
     {
         $this->operations[] = new Operations\AssertSee($text, $ignoreCase);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Was getting: 

```
vendor/bin/pest --filter AssertSeeTest

   FAIL  Tests\Browser\Operations\AssertSeeTest
  ⨯ assert sees                                                                                                                                                                                                                                                                                 9.57s  
  ⨯ assert sees ignoring case                                                                                                                                                                                                                                                                   9.00s  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  
   FAILED  Tests\Browser\Operations\AssertSeeTest > assert sees                                                                                                                                                                                                                            TypeError   
  Pest\Browser\PendingTest::assertSee(): Return value must be of type Pest\Browser\PendingTest, none returned

  at src\PendingTest.php:76
     72▕      */
     73▕     public function assertSee(string $text, bool $ignoreCase = false): self
     74▕     {
     75▕         $this->operations[] = new Operations\AssertSee($text, $ignoreCase);
  ➜  76▕     }
     77▕ 
     78▕     /**
     79▕      * Checks if the page does not contain the given text.
     80▕      */

  1   src\PendingTest.php:76
  2   tests\Browser\Operations\AssertSeeTest.php:9

  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  
   FAILED  Tests\Browser\Operations\AssertSeeTest > assert sees ignoring case                                                                                                                                                                                                              TypeError   
  Pest\Browser\PendingTest::assertSee(): Return value must be of type Pest\Browser\PendingTest, none returned

  at src\PendingTest.php:76
     72▕      */
     73▕     public function assertSee(string $text, bool $ignoreCase = false): self
     74▕     {
     75▕         $this->operations[] = new Operations\AssertSee($text, $ignoreCase);
  ➜  76▕     }
     77▕ 
     78▕     /**
     79▕      * Checks if the page does not contain the given text.
     80▕      */

  1   src\PendingTest.php:76
  2   tests\Browser\Operations\AssertSeeTest.php:16


  Tests:    2 failed (2 assertions)
  Duration: 19.09s
```


Now with the fix, I get

```
vendor/bin/pest --filter AssertSeeTest

   PASS  Tests\Browser\Operations\AssertSeeTest
  ✓ assert sees                                                                                                                                                                                                                                                                                 9.44s  
  ✓ assert sees ignoring case                                                                                                                                                                                                                                                                  12.49s  

  Tests:    2 passed (2 assertions)
  Duration: 22.54s
  ```