### PR TITLE
chore: Move lint to the first test item

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,10 +50,10 @@
         "test:types": "phpstan",
         "test:refactor": "rector --dry-run",
         "test": [
+            "@test:lint",
             "@test:type-coverage",
             "@test:typos",
             "@test:unit",
-            "@test:lint",
             "@test:types",
             "@test:refactor"
         ]


### PR DESCRIPTION
Seems more logical to me to do linting first, as avoids unit tests running etc. Means an early return for styling issues.