### PR TITLE
feat: Use html fixtures over real urls

### DIFF
--- a/tests/Browser/Operations/AssertDontSeeTest.php
+++ b/tests/Browser/Operations/AssertDontSeeTest.php
@@ -3,15 +3,11 @@
 declare(strict_types=1);
 
 test('assert does not see', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
+    $this->visit(htmlFixture('default'))
         ->assertDontSee('The PHP Framework For Artisans test');
 });
 
 test('assert does not see ignoring case', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
+    $this->visit(htmlFixture('default'))
         ->assertDontSee('the php framework for artisans test', true);
 });

--- a/tests/Browser/Operations/AssertSeeTest.php
+++ b/tests/Browser/Operations/AssertSeeTest.php
@@ -3,15 +3,11 @@
 declare(strict_types=1);
 
 test('assert sees', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
-        ->assertSee('The PHP Framework');
+    $this->visit(htmlfixture('default'))
+        ->assertSee('Test Page');
 });
 
 test('assert sees ignoring case', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
-        ->assertSee('the php framework', true);
+    $this->visit(htmlfixture('default'))
+        ->assertSee('test page', true);
 });

--- a/tests/Browser/Operations/AssertTitleContainsTest.php
+++ b/tests/Browser/Operations/AssertTitleContainsTest.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 test('assert title contains', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
-        ->assertTitleContains('Laravel');
+    $this->visit(htmlfixture('default'))
+        ->assertTitleContains('Browser Test');
 });

--- a/tests/Browser/Operations/AssertTitleTest.php
+++ b/tests/Browser/Operations/AssertTitleTest.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 test('assert title', function (): void {
-    $url = 'https://laravel.com';
+    $browser = $this->visit(htmlfixture('default'));
 
-    $browser = $this->visit($url);
-
-    $browser->assertTitle('Laravel - The PHP Framework For Web Artisans');
+    $browser->assertTitle('Pest Browser Test');
 });

--- a/tests/Browser/Operations/AssertUrlIsTest.php
+++ b/tests/Browser/Operations/AssertUrlIsTest.php
@@ -3,9 +3,10 @@
 declare(strict_types=1);
 
 test('assert url is', function (): void {
-    $url = 'https://laravel.com';
 
-    $browser = $this->visit($url);
+    $faked = htmlfixture('default');
 
-    $browser->assertUrlIs($url);
+    $browser = $this->visit($faked);
+
+    $browser->assertUrlIs($faked);
 });

--- a/tests/Browser/Operations/ClickLinkTest.php
+++ b/tests/Browser/Operations/ClickLinkTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 it('clicks a link', function (): void {
-    $this->visit('https://laravel.com')
-        ->clickLink('Get Started')
-        ->assertUrlIs('https://laravel.com/docs/11.x');
+    $faked = htmlfixture('default');
+
+    $this->visit($faked)
+        ->clickLink('Click me')
+        ->assertUrlIs($faked.'?query=boom');
 });

--- a/tests/Browser/Operations/ScreenshotTest.php
+++ b/tests/Browser/Operations/ScreenshotTest.php
@@ -7,7 +7,7 @@ use Pest\TestSuite;
 it('takes a screenshot', function (): void {
     $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
 
-    $this->visit('https://laravel.com')
+    $this->visit(htmlfixture('default'))
         ->screenshot('laravel.png');
 
     expect(file_exists($basePath.'/laravel.png'))->toBeTrue();
@@ -16,7 +16,7 @@ it('takes a screenshot', function (): void {
 it('takes a screenshot and generates a path', function (): void {
     $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
 
-    $this->visit('https://laravel.com')
+    $this->visit(htmlfixture('default'))
         ->screenshot();
 
     $testName = mb_ltrim(test()->name(), '__pest_evaluable_'); // @phpstan-ignore-line

--- a/tests/Browser/Operations/VisitTest.php
+++ b/tests/Browser/Operations/VisitTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 test('visit', function (): void {
-    $url = 'https://laravel.com';
+    $faked = htmlfixture('default');
 
-    $browser = $this->visit($url);
+    $browser = $this->visit($faked);
 
-    $browser->assertUrlIs($url);
+    $browser->assertUrlIs($faked);
 });

--- a/tests/Fixtures/html/default.html
+++ b/tests/Fixtures/html/default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta property="theme-color" content="#ffffff">
+        <title>Pest Browser Test</title>
+    </head>
+    <body>
+        <h1>Test Page</h1>
+        <a class="click" href="?query=boom">Click me</a>
+    </body>
+</html>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,3 +20,17 @@ function cleanupScreenshots(): void
 
     file_exists($basePath) && rmdir($basePath);
 }
+
+function htmlfixture($filename): string
+{
+    $file = __DIR__.'/Fixtures/html/'.$filename.'.html';
+
+    // We do so it works with Playwright correctly.
+    $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);
+
+    if (! file_exists($file)) {
+        throw new RuntimeException("File '{$filename}' not found in fixture path: ({$file}");
+    }
+
+    return 'file://'.$file;
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,11 +21,11 @@ function cleanupScreenshots(): void
     file_exists($basePath) && rmdir($basePath);
 }
 
-function htmlfixture($filename): string
+function htmlfixture(string $filename): string
 {
     $file = __DIR__.'/Fixtures/html/'.$filename.'.html';
 
-    // We do so it works with Playwright correctly.
+    // We do so it works with Playwright correctly in a Windows environment.
     $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);
 
     if (! file_exists($file)) {


### PR DESCRIPTION
## What it adds:
- This adds fixtures over using real urls  (we can pass file::// into the url so it loads as if it's a domain) 


## Why:
- If the website url tests we are using fails to load,  or even changes, it could introduce failing tests even though the tests are valid.
- Using fixtures should increase speed 🕺🏻 
- With adding more and more tests, we can ensure our expected behaviour is doing what we actually intend without relying on an external site 

Feel free to change it, i.e. the method names or whatever you see best. But I think it's a worthwhile addition. Or just lemme know what to change and I'll sort it when I get chance 🫡  give me a nudge and happy to implement on any tests that have been added to main 
