### PR TITLE
feat: created new operations - AssertSchemaIs & AssertSchemaIsNot

### DIFF
--- a/src/Operations/AssertSchemaIs.php
+++ b/src/Operations/AssertSchemaIs.php
@@ -13,8 +13,7 @@ final readonly class AssertSchemaIs implements Operation
      */
     public function __construct(
         private string $schema
-    )
-    {
+    ) {
         //
     }
 

--- a/src/Operations/AssertSchemaIs.php
+++ b/src/Operations/AssertSchemaIs.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+final readonly class AssertSchemaIs implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private string $schema
+    )
+    {
+        //
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        return sprintf("await expect(new URL(await page.url()).protocol).toBe('%s:');", $this->schema);
+    }
+}

--- a/src/Operations/AssertSchemaIsNot.php
+++ b/src/Operations/AssertSchemaIsNot.php
@@ -13,8 +13,7 @@ final readonly class AssertSchemaIsNot implements Operation
      */
     public function __construct(
         private string $schema
-    )
-    {
+    ) {
         //
     }
 

--- a/src/Operations/AssertSchemaIsNot.php
+++ b/src/Operations/AssertSchemaIsNot.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+final readonly class AssertSchemaIsNot implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private string $schema
+    )
+    {
+        //
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        return sprintf("await expect(new URL(await page.url()).protocol).not.toBe('%s:');", $this->schema);
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -128,6 +128,26 @@ final class PendingTest
     }
 
     /**
+     * Checks if the URL schema matches the given schema.
+     */
+    public function assertSchemaIs(string $schema): self
+    {
+        $this->operations[] = new Operations\AssertSchemaIs($schema);
+
+        return $this;
+    }
+
+    /**
+     * Checks if the URL schema does not match the given schema.
+     */
+    public function assertSchemaIsNot(string $schema): self
+    {
+        $this->operations[] = new Operations\AssertSchemaIsNot($schema);
+
+        return $this;
+    }
+
+    /**
      * Clicks some text on the page.
      */
     public function clickLink(string $text, string $selector = 'a'): self

--- a/tests/Browser/Operations/AssertSchemaIs.php
+++ b/tests/Browser/Operations/AssertSchemaIs.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+test('assert schema', function () {
+    $url = 'https://laravel.com';
+
+    $this->visit($url)
+        ->assertSchemaIs('https');
+});

--- a/tests/Browser/Operations/AssertSchemaIsNot.php
+++ b/tests/Browser/Operations/AssertSchemaIsNot.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+test('assert schema is not', function () {
+    $url = 'https://laravel.com';
+
+    $this->visit($url)
+        ->assertSchemaIsNot('http');
+});


### PR DESCRIPTION
Follow [Dusk API](https://laravel.com/docs/11.x/dusk#assert-scheme-is)

```
$url = 'https://laravel.com';
$this->visit($url)
        ->assertSchemaIs('https');
```
AND
```
$url = 'https://laravel.com';
$this->visit($url)
    ->assertSchemaIsNot('http');
```