### PR TITLE
Add AssertMatchesScreenshot & AssertNotMatchesScreenshot operations

### DIFF
--- a/src/Operations/AssertMatchesScreenshot.php
+++ b/src/Operations/AssertMatchesScreenshot.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+use Pest\TestSuite;
+
+/**
+ * @internal description
+ */
+final readonly class AssertMatchesScreenshot implements Operation
+{
+    /**
+     * The path to already present screenshot.
+     */
+    private string $path;
+
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(string $filename)
+    {
+        $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
+
+        $this->path = $basePath.'/'.$filename;
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        return "await expect(page).toHaveScreenshot('$this->path')";
+    }
+}

--- a/src/Operations/AssertNotMatchesScreenshot.php
+++ b/src/Operations/AssertNotMatchesScreenshot.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+use Pest\TestSuite;
+
+/**
+ * @internal
+ */
+final readonly class AssertNotMatchesScreenshot implements Operation
+{
+    /**
+     * The path to already present screenshot.
+     */
+    private string $path;
+
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(string $filename)
+    {
+        $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
+
+        $this->path = $basePath.'/'.$filename;
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        return "await expect(page).not.toHaveScreenshot('$this->path')";
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -78,6 +78,26 @@ final class PendingTest
     }
 
     /**
+     * Determines if the screenshot matches stored screenshot
+     */
+    public function assertMatchesScreenshot(string $filename): self
+    {
+        $this->operations[] = new Operations\AssertMatchesScreenshot($filename);
+
+        return $this;
+    }
+
+    /**
+     * Determines if the screenshot doesn't match stored screenshot
+     */
+    public function assertNotMatchesScreenshot(string $filename): self
+    {
+        $this->operations[] = new Operations\AssertNotMatchesScreenshot($filename);
+
+        return $this;
+    }
+
+    /**
      * Checks if the page has a title.
      */
     public function assertTitle(string $title): self

--- a/tests/Browser/Operations/AssertMatchesScreenshotTest.php
+++ b/tests/Browser/Operations/AssertMatchesScreenshotTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+test('assert page matches a screenshot', function () {
+    $this->visit('https://example.com')
+        ->screenshot('example.png')
+        ->assertMatchesScreenshot('example.png');
+});

--- a/tests/Browser/Operations/AssertNotMatchesScreenshotTest.php
+++ b/tests/Browser/Operations/AssertNotMatchesScreenshotTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+test('assert page not matches a screenshot', function () {
+    $this->visit('https://example.com')
+        ->screenshot('example.png')
+        ->assertMatchesScreenshot('example.png');
+
+    $this->visit('https://laravel.com')
+        ->assertNotMatchesScreenshot('example.png');
+});


### PR DESCRIPTION
Changes:
- Added `Operations\AssertMatchesScreenshot` to check whether the page's current screenshot matches with stored screenshot
- Added `Operations\AssertNotMatchesScreenshot` operation to check whether the page's current screenshot doesn't match with stored screenshot

Used `toHaveScreenshot()` api instead of `toMatchScreenshot()` as suggested [here](https://playwright.dev/docs/api/class-snapshotassertions)