### PR TITLE
feat: Add `when` operation for conditional actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ TBD
 - [pause](#pause)
 - [refresh](#refresh)
 - [rightClick](#rightClick)
+- [when](#when)
 - [screenshot](#screenshot)
 - [visit](#visit)
 
@@ -225,6 +226,23 @@ Takes a full-page screenshot of the current page and saves it under `/Browser/sc
 
 ```php
 $this->screenshot('filename');
+```
+
+### when
+
+The when operation in Pest Browser allows you to execute different actions based on whether a specific condition is met when visiting a webpage. This feature provides dynamic test execution, enhancing the flexibility of browser tests.
+
+```php
+$this->when(
+        new Pest\Browser\Conditions\See('Laravel - The PHP Framework For Web Artisans'),
+        function (Pest\Browser\PendingTest $browser): void {
+            $browser->clickLink('Get Started')
+                ->assertSee('Installation');
+        },
+        function (Pest\Browser\PendingTest $browser): void {
+            $browser->assertSee('Laravel');
+        }
+    );
 ```
 
 ### visit

--- a/src/Conditions/See.php
+++ b/src/Conditions/See.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Conditions;
+
+use Pest\Browser\Contracts\Condition;
+
+final readonly class See implements Condition
+{
+    /**
+     * Creates a condition instance.
+     */
+    public function __construct(private string $text)
+    {
+        //
+    }
+
+    /**
+     * Compile the condition.
+     */
+    public function compile(): string
+    {
+        $escapedText = json_encode($this->text);
+
+        return sprintf('(await page.locator(\'body\').textContent()).includes(%s)', $escapedText);
+    }
+}

--- a/src/Contracts/Condition.php
+++ b/src/Contracts/Condition.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Contracts;
+
+/**
+ * @internal
+ */
+interface Condition
+{
+    /**
+     * Compile the condition to JavaScript code.
+     */
+    public function compile(): string;
+}

--- a/src/Operations/When.php
+++ b/src/Operations/When.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Closure;
+use Pest\Browser\Contracts\Condition;
+use Pest\Browser\Contracts\Operation;
+use Pest\Browser\PendingTest;
+
+final readonly class When implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private Condition $condition,
+        private Closure $then,
+        private ?Closure $else = null
+    ) {
+        //
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        $conditionContent = $this->condition->compile();
+
+        $thenContent = $this->compileCallbackOperations($this->then);
+
+        if (is_null($this->else)) {
+            return <<<JS
+                if (({$conditionContent})) {
+                {$thenContent}
+                    }
+                JS;
+        }
+
+        $elseContent = $this->compileCallbackOperations($this->else);
+
+        return <<<JS
+                if (({$conditionContent})) {
+                {$thenContent}
+                    } else {
+                {$elseContent}
+                    }
+                JS;
+    }
+
+    /**
+     * Compile the operations in callback.
+     */
+    private function compileCallbackOperations(Closure $closure): string
+    {
+        $operations = $this->collectCallbackOperations($closure);
+
+        return implode(
+            "\n",
+            array_map(
+                static fn (Operation $operation): string => "\t\t{$operation->compile()}",
+                $operations,
+            ),
+        );
+    }
+
+    /**
+     * Collect the operations in callback.
+     *
+     * @return array<int, Operation>
+     */
+    private function collectCallbackOperations(Closure $closure): array
+    {
+        $thenTest = new PendingTest(compileTest: false);
+
+        ($closure)($thenTest);
+
+        return $thenTest->operations;
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Pest\Browser;
 
 use Closure;
-use Pest\Browser\Contracts\Condition;
 use InvalidArgumentException;
+use Pest\Browser\Contracts\Condition;
 use Pest\Browser\Contracts\Operation;
 use Pest\Browser\ValueObjects\TestResult;
 

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Browser;
 
+use Closure;
+use Pest\Browser\Contracts\Condition;
 use InvalidArgumentException;
 use Pest\Browser\Contracts\Operation;
 use Pest\Browser\ValueObjects\TestResult;
@@ -18,13 +20,22 @@ final class PendingTest
      *
      * @var array<int, Operation>
      */
-    private array $operations = [];
+    public array $operations = [];
+
+    /**
+     * Creates a new pending test instance.
+     */
+    public function __construct(private readonly bool $compileTest = true) {}
 
     /**
      * Ends the chain and builds the test result.
      */
     public function __destruct()
     {
+        if (! $this->compileTest) {
+            return;
+        }
+
         $this->compile();
     }
 
@@ -463,6 +474,25 @@ final class PendingTest
     public function uncheck(string $selector): self
     {
         $this->operations[] = new Operations\UnCheck($selector);
+
+        return $this;
+    }
+
+    /**
+     * Adds a "when" condition to perform an action based on the condition evaluation.
+     *
+     * This method registers a condition to be checked. If the condition is met, the provided
+     * `$then` callback is executed. If the condition is not met, the optional `$else` callback
+     * can be executed (if provided).
+     *
+     * @param  Condition  $condition  The condition to evaluate.
+     * @param  Closure  $then  The callback to execute when the condition is true.
+     * @param  Closure|null  $else  The callback to execute when the condition is false. Default is null.
+     * @return self Returns the current instance to allow method chaining.
+     */
+    public function when(Condition $condition, Closure $then, ?Closure $else = null): self
+    {
+        $this->operations[] = new Operations\When($condition, $then, $else);
 
         return $this;
     }

--- a/tests/Browser/Operations/WhenTest.php
+++ b/tests/Browser/Operations/WhenTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+test('when', function (): void {
+    $url = 'https://laravel.com';
+
+    $browser = $this->visit($url);
+
+    $browser->when(
+        new Pest\Browser\Conditions\See('Laravel - The PHP Framework For Web Artisans'),
+        function (Pest\Browser\PendingTest $browser): void {
+            $browser->clickLink('Get Started')
+                ->assertSee('Installation');
+        },
+        function (Pest\Browser\PendingTest $browser): void {
+            $browser->assertSee('Laravel');
+        }
+    );
+});
+
+test('when using only the then callback', function (): void {
+    $url = 'https://laravel.com';
+
+    $browser = $this->visit($url);
+
+    $browser->when(
+        new Pest\Browser\Conditions\See('Laravel - The PHP Framework For Web Artisans'),
+        function (Pest\Browser\PendingTest $browser): void {
+            $browser->clickLink('Get Started')
+                ->assertSee('Installation');
+        }
+    );
+});


### PR DESCRIPTION
I have implemented the `when` operation for tests with the ability to set `then` and `else` callbacks.
This will provide more flexibility for customers when using it.

I would be happy to receive any comments or recommendations.

Example:

**With both callbacks (`then` and `else`):**
```PHP
$url = 'https://laravel.com';

$browser = $this->visit($url);

$browser->when(
    new Pest\Browser\Conditions\See('Laravel - The PHP Framework For Web Artisans'),
    function (Pest\Browser\PendingTest $browser): void {
        $browser->clickLink('Get Started')
            ->assertSee('Installation');
    },
    function (Pest\Browser\PendingTest $browser): void {
        $browser->assertSee('Laravel');
    }
);
```

**Only `then` callback:**

```PHP
$url = 'https://laravel.com';

$browser = $this->visit($url);

$browser->when(
    new Pest\Browser\Conditions\See('Laravel - The PHP Framework For Web Artisans'),
    function (Pest\Browser\PendingTest $browser): void {
        $browser->clickLink('Get Started')
            ->assertSee('Installation');
    }
);
```

_Compile result:_
```JS
import { test, expect } from '@playwright/test';

test('runtime', async ({ page }) => {
	await page.goto('https://laravel.com');
	if (((await page.locator('body').textContent()).includes("Laravel - The PHP Framework For Web Artisans"))) {
		await page.locator('a').filter({ hasText: /Get Started/i }).click();
		await expect(page.locator('body')).toHaveText(/Installation/);
        }
});
```