### PR TITLE
Add assertVisible and assertMissing assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Pause the test for the specified number of milliseconds.
 - [assertAttribute](#assertattribute)
 - [assertDontSee](#assertdontsee)
 - [assertDontSee](#assertdontsee)
+- [assertVisible](#assertvisible)
+- [assertMissing](#assertmissing)
 
 #### assertAttribute
 
@@ -90,5 +92,31 @@ test('assert does not see', function () {
 
     $this->visit($url)
         ->assertDontSee('we are a streaming service');
+});
+```
+
+#### assertVisible
+
+Assert that an element with the given selector is visible:
+
+```php
+test('assert visible', function () {
+    $url = 'https://laravel.com';
+
+    $this->visit($url)
+        ->assertVisible('h1:visible');
+});
+```
+
+#### assertMissing
+
+Assert that an element with the given selector is hidden:
+
+```php
+test('assert missing', function () {
+    $url = 'https://laravel.com';
+
+    $this->visit($url)
+        ->assertMissing('a.hidden');
 });
 ```

--- a/src/Operations/AssertMissing.php
+++ b/src/Operations/AssertMissing.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+final class AssertMissing implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private string $selector,
+    ) {
+        //
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        $escapedSelector = str_replace("'", "\'", $this->selector);
+
+        return "await expect(page.locator('{$escapedSelector}')).toBeHidden();";
+    }
+}

--- a/src/Operations/AssertVisible.php
+++ b/src/Operations/AssertVisible.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+final class AssertVisible implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private string $selector,
+    ) {
+        //
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        $escapedSelector = str_replace("'", "\'", $this->selector);
+
+        return "await expect(page.locator('{$escapedSelector}')).toBeVisible();";
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -205,6 +205,26 @@ final class PendingTest
     }
 
     /**
+     * Checks if the given element is visible.
+     */
+    public function assertVisible(string $selector): self
+    {
+        $this->operations[] = new Operations\AssertVisible($selector);
+
+        return $this;
+    }
+
+    /**
+     * Checks if the given element is not visible.
+     */
+    public function assertMissing(string $selector): self
+    {
+        $this->operations[] = new Operations\AssertMissing($selector);
+
+        return $this;
+    }
+
+    /**
      * Compile the JavaScript test file.
      */
     public function compile(): TestResult

--- a/tests/Browser/Operations/AssertMissingTest.php
+++ b/tests/Browser/Operations/AssertMissingTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+describe('assert missing', function () {
+    it('passes when the given element is not visible', function () {
+        $this->visit('https://laravel.com')
+            ->assertMissing('.DocSearch-Button-Keys');
+    });
+
+    it('fails when the given element is visible', function () {
+        $this->visit('https://laravel.com')
+            ->assertMissing('body');
+    })->throws(ProcessFailedException::class);
+});

--- a/tests/Browser/Operations/AssertVisibleTest.php
+++ b/tests/Browser/Operations/AssertVisibleTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+describe('assert visible', function () {
+    it('passes when the given element is visible', function () {
+        $this->visit('https://laravel.com')
+            ->assertVisible('body');
+    });
+
+    it('fails when the given element is not visible', function () {
+        $this->visit('https://laravel.com')
+            ->assertVisible('.DocSearch-Button-Keys');
+    })->throws(ProcessFailedException::class);
+});


### PR DESCRIPTION
Add assertVisible (https://laravel.com/docs/11.x/dusk#assert-visible) and assertMissing (https://laravel.com/docs/11.x/dusk#assert-missing) assertions.

⚠️I used Dusk assertion names. But I don't think `missing` is a good name for such assertion. Would be better to have `assertHidden` instead. Probably, we can add this method to the PendingTest as an alias to `assertMissing`.