### PR TITLE
feat: Add `pause` operation to PendingTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,21 @@ test('assert does not see', function () {
         ->assertDontSee('we are a streaming service');
 });
 ```
+
+### Available Operations
+
+#### pause
+
+It will pause the process for the specified number of milliseconds you provide.
+
+Pause the test execution for 5 seconds:
+
+```php
+test('pause', function () {
+    $url = 'https://laravel.com';
+
+    $this->visit($url)
+        ->pause(5000)
+        ->assertSee('Laravel');
+});
+```

--- a/src/Operations/Pause.php
+++ b/src/Operations/Pause.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+/**
+ * @internal
+ */
+final readonly class Pause implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private int $milliseconds
+    ) {
+        //
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        return sprintf('await (new Promise(resolve => setTimeout(resolve, %d)));', $this->milliseconds);
+    }
+}

--- a/src/Operations/Pause.php
+++ b/src/Operations/Pause.php
@@ -25,6 +25,6 @@ final readonly class Pause implements Operation
      */
     public function compile(): string
     {
-        return sprintf('await (new Promise(resolve => setTimeout(resolve, %d)));', $this->milliseconds);
+        return sprintf('await page.waitForTimeout(%d);', $this->milliseconds);
     }
 }

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser;
 
+use InvalidArgumentException;
 use Pest\Browser\Contracts\Operation;
 use Pest\Browser\ValueObjects\TestResult;
 
@@ -173,6 +174,22 @@ final class PendingTest
     public function clickLink(string $text, string $selector = 'a'): self
     {
         $this->operations[] = new Operations\ClickLink($text, $selector);
+
+        return $this;
+    }
+
+    /**
+     * Pauses the execution for a specified number of milliseconds.
+     *
+     * @param  int  $milliseconds  The number of milliseconds to pause. Default is 1000.
+     */
+    public function pause(int $milliseconds = 1000): self
+    {
+        if ($milliseconds <= 0) {
+            throw new InvalidArgumentException('The number of milliseconds must be greater than 0.');
+        }
+
+        $this->operations[] = new Operations\Pause($milliseconds);
 
         return $this;
     }

--- a/tests/Browser/Operations/PauseTest.php
+++ b/tests/Browser/Operations/PauseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+it('pause', function (): void {
+    $this->visit('https://laravel.com')
+        ->clickLink('Get Started')
+        ->pause(5000)
+        ->assertUrlIs('https://laravel.com/docs/11.x');
+});
+
+test('throws an exception when pause is negative', function (): void {
+    expect(function () {
+        $this->visit('https://laravel.com')
+            ->clickLink('Get Started')
+            ->pause(-5000)
+            ->assertUrlIs('https://laravel.com/docs/11.x');
+    })
+        ->toThrow(
+            InvalidArgumentException::class,
+            'The number of milliseconds must be greater than 0.'
+        );
+});


### PR DESCRIPTION
This is a pull request that adds a method similar to Laravel Dusk's `pause` (https://laravel.com/docs/11.x/dusk#waiting).

It will pause for a specified number of milliseconds, which the user can set in the method (default is set to 1000 ms).

Example:

```PHP
$this->visit('https://laravel.com')
        ->clickLink('Get Started')
        ->pause(5000)
        ->assertUrlIs('https://laravel.com/docs/11.x');
```