### PR TITLE
refactor: `assertDontSee` should ignore case by default

### DIFF
--- a/src/Operations/AssertDontSee.php
+++ b/src/Operations/AssertDontSee.php
@@ -13,7 +13,7 @@ final readonly class AssertDontSee implements Operation
      */
     public function __construct(
         private string $text,
-        private bool $ignoreCase = false,
+        private bool $ignoreCase = true,
     ) {
         //
     }

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -110,7 +110,7 @@ final class PendingTest
     /**
      * Checks if the page does not contain the given text.
      */
-    public function assertDontSee(string $text, bool $ignoreCase = false): self
+    public function assertDontSee(string $text, bool $ignoreCase = true): self
     {
         $this->operations[] = new Operations\AssertDontSee($text, $ignoreCase);
 

--- a/tests/Browser/Operations/AssertDontSeeTest.php
+++ b/tests/Browser/Operations/AssertDontSeeTest.php
@@ -2,17 +2,22 @@
 
 declare(strict_types=1);
 
-test('assert does not see', function () {
-    $this->visit('https://laravel.com')
-        ->assertDontSee('The PHP Foobar');
-});
-
-test('assert does not see ignoring case', function () {
+test('assert does not see ignoring case by default', function () {
     $this->visit('https://laravel.com')
         ->assertDontSee('the php foobar');
+
+    expect(function () {
+        $this->visit('https://laravel.com')
+            ->assertDontSee('the php framework');
+    })->toThrow(Exception::class);
 });
 
-test('assert does not see escaping regex special characters', function () {
+test('assert does not see without ignoring case', function () {
     $this->visit('https://laravel.com')
-        ->assertDontSee('I tried (some) different ecosystems');
+        ->assertDontSee('The PHP Foobar', false);
+
+    expect(function () {
+        $this->visit('https://laravel.com')
+            ->assertDontSee('The PHP Framework', false);
+    })->toThrow(Exception::class);
 });

--- a/tests/Browser/Operations/AssertDontSeeTest.php
+++ b/tests/Browser/Operations/AssertDontSeeTest.php
@@ -3,15 +3,16 @@
 declare(strict_types=1);
 
 test('assert does not see', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
-        ->assertDontSee('The PHP Framework For Artisans test');
+    $this->visit('https://laravel.com')
+        ->assertDontSee('The PHP Foobar');
 });
 
 test('assert does not see ignoring case', function () {
-    $url = 'https://laravel.com';
+    $this->visit('https://laravel.com')
+        ->assertDontSee('the php foobar');
+});
 
-    $this->visit($url)
-        ->assertDontSee('the php framework for artisans test', true);
+test('assert does not see escaping regex special characters', function () {
+    $this->visit('https://laravel.com')
+        ->assertDontSee('I tried (some) different ecosystems');
 });


### PR DESCRIPTION
I don't think it makes sense for `assertDontSee()` to be case sensitive by default. Even if it's what Dusk uses currently.

Usually when you're making sure some text is not on the page, you want to make sure that for example `Foo Bar` or even `foo bar` are not present. It feels like it could lead more to a false-positive in a test suite if we use `assertDontSee("Foo Bar")` and the HTML has `foo bar` but the test is green.

To me, it makes more sense for it to be case insensitive by default, which is the opposite of how `assertSee()` works.

I might be wrong, feel free to ignore this.