### PR TITLE
Add playground URL helper

### DIFF
--- a/tests/Browser/Operations/AssertUrlIsTest.php
+++ b/tests/Browser/Operations/AssertUrlIsTest.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 test('assert url is', function (): void {
     $this->visit('/')
-        ->assertUrlIs('http://localhost:9357');
+        ->assertUrlIs(playgroundUrl());
 });

--- a/tests/Browser/Operations/BackTest.php
+++ b/tests/Browser/Operations/BackTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-test('navigates forward', function (): void {
+test('navigates back', function (): void {
     $this->visit('/')
         ->clickLink('Get Started')
         ->assertUrlIs('https://pestphp.com/docs/installation')
         ->back()
-        ->assertUrlIs('http://localhost:9357');
+        ->assertUrlIs(playgroundUrl());
 });

--- a/tests/Browser/Operations/ForwardTest.php
+++ b/tests/Browser/Operations/ForwardTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-test('navigates back', function (): void {
+test('navigates forward', function (): void {
     $this->visit('/')
         ->clickLink('Get Started')
         ->assertUrlIs('https://pestphp.com/docs/installation')
         ->back()
-        ->assertUrlIs('http://localhost:9357')
+        ->assertUrlIs(playgroundUrl())
         ->forward()
         ->assertUrlIs('https://pestphp.com/docs/installation');
 });

--- a/tests/Browser/Operations/PauseTest.php
+++ b/tests/Browser/Operations/PauseTest.php
@@ -3,17 +3,17 @@
 declare(strict_types=1);
 
 it('pause', function (): void {
-    $this->visit('https://laravel.com')
-        ->clickLink('Get Started')
-        ->pause(5000)
-        ->assertUrlIs('https://laravel.com/docs/11.x');
+    $this->visit(playgroundUrl('/test/interactive-elements'))
+        ->assertDontSee('I appear after 2 seconds')
+        ->pause(2200)
+        ->assertSee('I appear after 2 seconds');
 });
 
 test('throws an exception when pause is negative', function (): void {
     expect(function () {
         $this->visit('https://laravel.com')
             ->clickLink('Get Started')
-            ->pause(-5000)
+            ->pause(-1000)
             ->assertUrlIs('https://laravel.com/docs/11.x');
     })
         ->toThrow(

--- a/tests/Browser/Operations/RefreshTest.php
+++ b/tests/Browser/Operations/RefreshTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 test('refreshes', function (): void {
     $this->visit('/')
-        ->assertUrlIs('http://localhost:9357')
+        ->assertUrlIs(playgroundUrl())
         ->assertSee('Pest is a testing framework')
         ->refresh()
-        ->assertUrlIs('http://localhost:9357')
+        ->assertUrlIs(playgroundUrl())
         ->assertSee('Pest is a testing framework');
 });

--- a/tests/Browser/Operations/VisitTest.php
+++ b/tests/Browser/Operations/VisitTest.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 test('visit', function (): void {
     $this->visit('/')
-        ->assertUrlIs('http://localhost:9357');
+        ->assertUrlIs(playgroundUrl());
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,3 +20,8 @@ function cleanupScreenshots(): void
 
     file_exists($basePath) && rmdir($basePath);
 }
+
+function playgroundUrl($uri = null): string
+{
+    return 'http://localhost:9357'.$uri;
+}


### PR DESCRIPTION
To not hardcode the URL everywhere, we get it from a single source of truth.