### PR TITLE
Update tests for playground

### DIFF
--- a/playground/app/View/Components/TestPagesNavMenu.php
+++ b/playground/app/View/Components/TestPagesNavMenu.php
@@ -1,23 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\View\Components;
 
 use Closure;
+use File;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 use Symfony\Component\Finder\SplFileInfo;
 
-class TestPagesNavMenu extends Component
+final class TestPagesNavMenu extends Component
 {
     public Collection $pages;
+
     /**
      * Create a new component instance.
      */
     public function __construct()
     {
-        $this->pages = collect(\File::allFiles(resource_path('views/test-pages')))
+        $this->pages = collect(File::allFiles(resource_path('views/test-pages')))
             ->map(fn (SplFileInfo $viewFile) => $viewFile->getFilename())
             ->map(fn (string $filename) => Str::chopEnd($filename, '.blade.php'));
     }

--- a/playground/resources/views/test-pages/interactive-elements.blade.php
+++ b/playground/resources/views/test-pages/interactive-elements.blade.php
@@ -9,6 +9,15 @@
 
         </h1>
 
+        <div class="h-12"></div>
+
+        <div
+            id="i-have-data-testid"
+            data-testid="i-exist-to-be-seen"
+        >
+            I'm an element with a data-attribute.
+        </div>
+
 
     </section>
 @endsection

--- a/tests/Browser/Operations/AssertAttributeContainsTest.php
+++ b/tests/Browser/Operations/AssertAttributeContainsTest.php
@@ -3,9 +3,6 @@
 declare(strict_types=1);
 
 test('assert attribute contains', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
-        ->assertAttributeContains('html', 'data-theme', 'ight');
-
+    $this->visit(playgroundUrl('/test/interactive-elements'))
+        ->assertAttributeContains('#i-have-data-testid', 'data-testid', 'to-be-seen');
 });

--- a/tests/Browser/Operations/AssertAttributeMissingTest.php
+++ b/tests/Browser/Operations/AssertAttributeMissingTest.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 test('assert attribute missing', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
-        ->assertAttributeMissing('html', 'data-test-attribute-missing');
+    $this->visit(playgroundUrl('/test/interactive-elements'))
+        ->assertAttributeMissing('#i-have-data-testid', 'attr-that-does-not-exist-on-the-element');
 });

--- a/tests/Browser/Operations/AssertAttributeTest.php
+++ b/tests/Browser/Operations/AssertAttributeTest.php
@@ -3,9 +3,6 @@
 declare(strict_types=1);
 
 test('assert attribute', function () {
-    $url = 'https://laravel.com';
-
-    $this->visit($url)
-        ->assertAttribute('html', 'data-theme', 'light');
-
+    $this->visit(playgroundUrl('/test/interactive-elements'))
+        ->assertAttribute('#i-have-data-testid', 'data-testid', 'i-exist-to-be-seen');
 });


### PR DESCRIPTION
These tests were adjusted for using the playground, instead of external pages.

assertAttribute
assertAttributeContains
assertAttributeMissing
