### PR TITLE
Chore/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ TBD
 
 Pause the test for the specified number of milliseconds.
 
+> [!WARNING]  
+> Discouraged: Never pause in production. Tests that wait for an amount of time are inherently flaky. Use "wait for element" or "wait for an event" approaches - you can wait for an event your app dispatches.
+ 
 ```php
     $this->pause(5000); // Pause for 5 seconds
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ We can make use of the `playgroundUrl()` helper, to get its URL during the test.
 
 We can provide a URI that will be appended, e.g: `playgroundUrl('/test/interactive-elements')`.
 
+Attention: we can use `->visit('/foo')`, using the base URL, without the helper.
+
+The helper exists for assertion scenarios, like:
+
+```php
+$this->visit('/test/interactive-elements')
+    ->assertUrlIs(playgroundUrl('/test/interactive-elements'))
+```
+
+
 ### Routes and views for testing
 
 Check the `playground/resources/views/test-pages` folder for existing views.


### PR DESCRIPTION
- Clarify the `playgroundUrl` helper
- Discourage use of `pause` in production