### PR TITLE
feat: Add `setTimeout` operation for test timeout control

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Pauses the execution for a specified number of milliseconds.
 ### setTimeout
 
 Changes the timeout for the currently running test to the given value in milliseconds.
+This feature works well in combination with [pause](#pause) when necessary or in other relevant scenarios.
 
 ```php
     $this->setTimeout(10000); // set timeout for test execution to 10 seconds

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ TBD
 - [doubleClick](#doubleClick)
 - [forward](#forward)
 - [pause](#pause)
+- [setTimeout](#setTimeout)
 - [refresh](#refresh)
 - [rightClick](#rightClick)
 - [screenshot](#screenshot)
@@ -201,6 +202,14 @@ Pauses the execution for a specified number of milliseconds.
 
 ```php
     $this->pause(5000); // Pause for 5 seconds
+```
+
+### setTimeout
+
+Changes the timeout for the currently running test to the given value in milliseconds.
+
+```php
+    $this->setTimeout(10000); // set timeout for test execution to 10 seconds
 ```
 
 ### refresh

--- a/src/Operations/SetTimeout.php
+++ b/src/Operations/SetTimeout.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Operations;
+
+use Pest\Browser\Contracts\Operation;
+
+/**
+ * @internal
+ */
+final readonly class SetTimeout implements Operation
+{
+    /**
+     * Creates an operation instance.
+     */
+    public function __construct(
+        private int $milliseconds
+    ) {
+        //
+    }
+
+    /**
+     * Compile the operation.
+     */
+    public function compile(): string
+    {
+        return sprintf('test.setTimeout(%d);', $this->milliseconds);
+    }
+}

--- a/src/PendingTest.php
+++ b/src/PendingTest.php
@@ -378,6 +378,22 @@ final class PendingTest
     }
 
     /**
+     * Sets the timeout for the test.
+     *
+     * @param  int  $milliseconds  The number of milliseconds to wait before timing out. Default is 30000.
+     */
+    public function setTimeout(int $milliseconds = 30000): self
+    {
+        if ($milliseconds <= 0) {
+            throw new InvalidArgumentException('The number of milliseconds must be greater than 0.');
+        }
+
+        array_unshift($this->operations, new Operations\SetTimeout($milliseconds));
+
+        return $this;
+    }
+
+    /**
      * Checks if the given element is visible.
      */
     public function assertVisible(string $selector): self

--- a/tests/Browser/Operations/SetTimeoutTest.php
+++ b/tests/Browser/Operations/SetTimeoutTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+it('setTimeout', function (): void {
+    $this->visit('/test/interactive-elements')
+        ->assertDontSee('I appear after 2 seconds')
+        ->setTimeout(12000)
+        ->pause(2200)
+        ->assertSee('I appear after 2 seconds');
+});
+
+test('throws an exception when setTimeout is less than pause', function (): void {
+    expect(function () {
+        $this->visit('/test/interactive-elements')
+            ->setTimeout(5000)
+            ->pause(7000);
+    })->toThrow(
+        ProcessFailedException::class,
+        'Test timeout of 5000ms exceeded.'
+    );
+});
+
+test('throws an exception when setTimeout is negative', function (): void {
+    expect(function () {
+        $this->visit('/')
+            ->clickLink('Get Started')
+            ->setTimeout(-1000)
+            ->assertUrlIs(playgroundUrl());
+    })
+        ->toThrow(
+            InvalidArgumentException::class,
+            'The number of milliseconds must be greater than 0.'
+        );
+});


### PR DESCRIPTION
**The `setTimeout` is an operation to control test timeouts in milliseconds.** 

This feature allows setting custom timeouts during test execution, providing better control over test duration. It enhances the flexibility and customization of test suites by dynamically adjusting test timeouts as needed, ensuring efficient test execution.

📌 **Playwright Documentation:**  
🔗 [TestInfo `setTimeout`](https://playwright.dev/docs/api/class-testinfo#test-info-set-timeout)

### **Usage Example:**
```php
it('setTimeout', function (): void {
    $this->visit('/test/interactive-elements')
        ->assertDontSee('I appear after 2 seconds')
        ->setTimeout(12000)
        ->pause(2200)
        ->assertSee('I appear after 2 seconds');
});
```

This feature works well in combination with `pause` when necessary or in other relevant scenarios.

Looking forward to discussing any improvements or necessary adjustments! 😊