### PR TITLE
feat: process failed assertions

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -7,7 +7,8 @@
             "str",
             "dont",
             "doesnt",
-            "uncheck"
+            "uncheck",
+            "args"
         ],
         "paths": []
     }

--- a/src/Contracts/Operation.php
+++ b/src/Contracts/Operation.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Contracts;
 
+use Pest\Browser\Exceptions\BrowserOperationException;
+use Pest\Browser\ValueObjects\TestResult;
+
 /**
  * @internal
  */
@@ -13,4 +16,11 @@ interface Operation
      * Compile the operation to JavaScript code.
      */
     public function compile(): string;
+
+    /**
+     * Fail the operation and throw an exception.
+     *
+     * @throws BrowserOperationException
+     */
+    public function fail(TestResult $testResult): void;
 }

--- a/src/Exceptions/BrowserOperationException.php
+++ b/src/Exceptions/BrowserOperationException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Exceptions;
+
+use NunoMaduro\Collision\Contracts\RenderableOnCollisionEditor;
+use PHPUnit\Framework\AssertionFailedError;
+use Whoops\Exception\Frame;
+
+final class BrowserOperationException extends AssertionFailedError implements RenderableOnCollisionEditor
+{
+    /**
+     * Creates a new exception instance.
+     */
+    public function __construct(string $message, string $file, int $line)
+    {
+        parent::__construct($message);
+
+        $this->file = $file;
+        $this->line = $line;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toCollisionEditor(): Frame
+    {
+        return new Frame([
+            'file' => $this->file,
+            'line' => $this->line,
+        ]);
+    }
+}

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser;
+
+use Pest\Browser\Contracts\Operation as OperationContract;
+use Pest\Browser\Exceptions\BrowserOperationException;
+use Pest\Browser\ValueObjects\OperationTrace;
+use Pest\Browser\ValueObjects\TestResult;
+
+/**
+ * @internal
+ */
+abstract readonly class Operation implements OperationContract
+{
+    /**
+     * Trace of the operation call.
+     */
+    public OperationTrace $trace;
+
+    /**
+     * Construct a new instance.
+     */
+    public function __construct()
+    {
+        $this->trace = OperationTrace::create();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    abstract public function compile(): string;
+
+    /**
+     * {@inheritDoc}
+     */
+    final public function fail(TestResult $testResult): void
+    {
+        $message = sprintf(
+            '[%s] Failed %s operation',
+            $testResult->browser,
+            $this->trace->method
+        );
+
+        if (is_array($this->trace->args)) {
+            $message = sprintf(
+                '%s with arguments: %s',
+                $message,
+                implode(', ', array_map(
+                    fn (mixed $arg): string => is_string($arg) ? $arg : (string) json_encode($arg),
+                    $this->trace->args
+                ))
+            );
+        }
+
+        if ($testResult->actualValue !== null || $testResult->expectedValue !== null) {
+            $message .= sprintf(
+                "\n  Expected: %s\n  Actual: %s",
+                is_string($testResult->expectedValue) ? $testResult->expectedValue : json_encode($testResult->expectedValue),
+                is_string($testResult->actualValue) ? $testResult->actualValue : json_encode($testResult->actualValue)
+            );
+        }
+
+        throw new BrowserOperationException($message, $this->trace->file, $this->trace->line);
+    }
+}

--- a/src/Operations/AssertAttribute.php
+++ b/src/Operations/AssertAttribute.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertAttribute implements Operation
+final readonly class AssertAttribute extends Operation
 {
     /**
      * Creates an operation instance.
@@ -16,7 +16,7 @@ final readonly class AssertAttribute implements Operation
         private string $attribute,
         private string $value
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertAttributeContains.php
+++ b/src/Operations/AssertAttributeContains.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertAttributeContains implements Operation
+final readonly class AssertAttributeContains extends Operation
 {
     /**
      * Creates an operation instance.
@@ -16,7 +16,7 @@ final readonly class AssertAttributeContains implements Operation
         private string $attribute,
         private string $value
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertAttributeDoesntContain.php
+++ b/src/Operations/AssertAttributeDoesntContain.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertAttributeDoesntContain implements Operation
+final readonly class AssertAttributeDoesntContain extends Operation
 {
     /**
      * Creates an operation instance.
@@ -16,7 +16,7 @@ final readonly class AssertAttributeDoesntContain implements Operation
         private string $attribute,
         private string $value
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertAttributeMissing.php
+++ b/src/Operations/AssertAttributeMissing.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertAttributeMissing implements Operation
+final readonly class AssertAttributeMissing extends Operation
 {
     /**
      * Creates an operation instance.
@@ -15,7 +15,7 @@ final readonly class AssertAttributeMissing implements Operation
         private string $selector,
         private string $attribute
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertChecked.php
+++ b/src/Operations/AssertChecked.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertChecked implements Operation
+final readonly class AssertChecked extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertChecked implements Operation
     public function __construct(
         private string $element,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertDontSee.php
+++ b/src/Operations/AssertDontSee.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertDontSee implements Operation
+final readonly class AssertDontSee extends Operation
 {
     /**
      * Creates an operation instance.
@@ -15,7 +15,7 @@ final readonly class AssertDontSee implements Operation
         private string $text,
         private bool $ignoreCase = false,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertHostIs.php
+++ b/src/Operations/AssertHostIs.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertHostIs implements Operation
+final readonly class AssertHostIs extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertHostIs implements Operation
     public function __construct(
         private string $host,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertHostIsNot.php
+++ b/src/Operations/AssertHostIsNot.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertHostIsNot implements Operation
+final readonly class AssertHostIsNot extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertHostIsNot implements Operation
     public function __construct(
         private string $host,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertMissing.php
+++ b/src/Operations/AssertMissing.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertMissing implements Operation
+final readonly class AssertMissing extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertMissing implements Operation
     public function __construct(
         private string $selector,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertNotChecked.php
+++ b/src/Operations/AssertNotChecked.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertNotChecked implements Operation
+final readonly class AssertNotChecked extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertNotChecked implements Operation
     public function __construct(
         private string $element,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertNotPresent.php
+++ b/src/Operations/AssertNotPresent.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertNotPresent implements Operation
+final readonly class AssertNotPresent extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertNotPresent implements Operation
     public function __construct(
         private string $selector
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertPathBeginsWith.php
+++ b/src/Operations/AssertPathBeginsWith.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertPathBeginsWith implements Operation
+final readonly class AssertPathBeginsWith extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertPathBeginsWith implements Operation
     public function __construct(
         private string $path,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertPathContains.php
+++ b/src/Operations/AssertPathContains.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertPathContains implements Operation
+final readonly class AssertPathContains extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertPathContains implements Operation
     public function __construct(
         private string $path,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertPathEndsWith.php
+++ b/src/Operations/AssertPathEndsWith.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertPathEndsWith implements Operation
+final readonly class AssertPathEndsWith extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertPathEndsWith implements Operation
     public function __construct(
         private string $path,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertPathIs.php
+++ b/src/Operations/AssertPathIs.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertPathIs implements Operation
+final readonly class AssertPathIs extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertPathIs implements Operation
     public function __construct(
         private string $path,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertPathIsNot.php
+++ b/src/Operations/AssertPathIsNot.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertPathIsNot implements Operation
+final readonly class AssertPathIsNot extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertPathIsNot implements Operation
     public function __construct(
         private string $path,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertPresent.php
+++ b/src/Operations/AssertPresent.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertPresent implements Operation
+final readonly class AssertPresent extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertPresent implements Operation
     public function __construct(
         private string $selector
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertQueryStringHas.php
+++ b/src/Operations/AssertQueryStringHas.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertQueryStringHas implements Operation
+final readonly class AssertQueryStringHas extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,9 @@ final readonly class AssertQueryStringHas implements Operation
     public function __construct(
         private string $name,
         private ?string $value = null,
-    ) {}
+    ) {
+        parent::__construct();
+    }
 
     /**
      * Compile the operation.

--- a/src/Operations/AssertQueryStringMissing.php
+++ b/src/Operations/AssertQueryStringMissing.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertQueryStringMissing implements Operation
+final readonly class AssertQueryStringMissing extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,9 @@ final readonly class AssertQueryStringMissing implements Operation
     public function __construct(
         private string $name,
         private ?string $value = null,
-    ) {}
+    ) {
+        parent::__construct();
+    }
 
     /**
      * Compile the operation.

--- a/src/Operations/AssertSchemeIs.php
+++ b/src/Operations/AssertSchemeIs.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertSchemeIs implements Operation
+final readonly class AssertSchemeIs extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertSchemeIs implements Operation
     public function __construct(
         private string $scheme
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertSchemeIsNot.php
+++ b/src/Operations/AssertSchemeIsNot.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertSchemeIsNot implements Operation
+final readonly class AssertSchemeIsNot extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertSchemeIsNot implements Operation
     public function __construct(
         private string $scheme
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertScript.php
+++ b/src/Operations/AssertScript.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class AssertScript implements Operation
+final readonly class AssertScript extends Operation
 {
     /**
      * Creates an operation instance.
@@ -20,7 +20,7 @@ final readonly class AssertScript implements Operation
         private string $expression,
         private string|bool|int|float|array|null $expected = true,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertSee.php
+++ b/src/Operations/AssertSee.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertSee implements Operation
+final readonly class AssertSee extends Operation
 {
     /**
      * Creates an operation instance.
@@ -15,7 +15,7 @@ final readonly class AssertSee implements Operation
         private string $text,
         private bool $ignoreCase = false,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertTitle.php
+++ b/src/Operations/AssertTitle.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 use Pest\Browser\Support\Str;
 
 /**
  * @internal
  */
-final readonly class AssertTitle implements Operation
+final readonly class AssertTitle extends Operation
 {
     /**
      * Creates an operation instance.
@@ -18,7 +18,7 @@ final readonly class AssertTitle implements Operation
     public function __construct(
         private string $title,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertTitleContains.php
+++ b/src/Operations/AssertTitleContains.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertTitleContains implements Operation
+final readonly class AssertTitleContains extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertTitleContains implements Operation
     public function __construct(
         private string $title,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertUrlIs.php
+++ b/src/Operations/AssertUrlIs.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 use Pest\Browser\Support\Str;
 
 /**
  * @internal
  */
-final readonly class AssertUrlIs implements Operation
+final readonly class AssertUrlIs extends Operation
 {
     /**
      * Creates an operation instance.
@@ -18,7 +18,7 @@ final readonly class AssertUrlIs implements Operation
     public function __construct(
         private string $url,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/AssertVisible.php
+++ b/src/Operations/AssertVisible.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
-final readonly class AssertVisible implements Operation
+final readonly class AssertVisible extends Operation
 {
     /**
      * Creates an operation instance.
@@ -14,7 +14,7 @@ final readonly class AssertVisible implements Operation
     public function __construct(
         private string $selector,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/Back.php
+++ b/src/Operations/Back.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class Back implements Operation
+final readonly class Back extends Operation
 {
     /**
      * Compile the operation.

--- a/src/Operations/Check.php
+++ b/src/Operations/Check.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class Check implements Operation
+final readonly class Check extends Operation
 {
     /**
      * Creates an operation instance.
      */
     public function __construct(
         private string $element,
-    ) {}
+    ) {
+        parent::__construct();
+    }
 
     /**
      * Compile the operation.

--- a/src/Operations/Click.php
+++ b/src/Operations/Click.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class Click implements Operation
+final readonly class Click extends Operation
 {
     /**
      * Creates an operation instance.
@@ -17,7 +17,7 @@ final readonly class Click implements Operation
     public function __construct(
         private string $selector,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/ClickAndHold.php
+++ b/src/Operations/ClickAndHold.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class ClickAndHold implements Operation
+final readonly class ClickAndHold extends Operation
 {
     /**
      * Creates an operation instance.
@@ -18,7 +18,7 @@ final readonly class ClickAndHold implements Operation
         private string $selector,
         private int $duration = 1000,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/ClickAtPoint.php
+++ b/src/Operations/ClickAtPoint.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class ClickAtPoint implements Operation
+final readonly class ClickAtPoint extends Operation
 {
     /**
      * Creates an operation instance.
@@ -18,7 +18,7 @@ final readonly class ClickAtPoint implements Operation
         private int $x = 0,
         private int $y = 0,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/ClickAtXPath.php
+++ b/src/Operations/ClickAtXPath.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class ClickAtXPath implements Operation
+final readonly class ClickAtXPath extends Operation
 {
     /**
      * Creates an operation instance.
@@ -17,7 +17,7 @@ final readonly class ClickAtXPath implements Operation
     public function __construct(
         private string $expression,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/ClickLink.php
+++ b/src/Operations/ClickLink.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class ClickLink implements Operation
+final readonly class ClickLink extends Operation
 {
     /**
      * Creates an operation instance.
@@ -18,7 +18,7 @@ final readonly class ClickLink implements Operation
         private string $text,
         private string $element = 'a',
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/ControlClick.php
+++ b/src/Operations/ControlClick.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class ControlClick implements Operation
+final readonly class ControlClick extends Operation
 {
     /**
      * Creates an operation instance.
@@ -17,7 +17,7 @@ final readonly class ControlClick implements Operation
     public function __construct(
         private string $selector,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/DoubleClick.php
+++ b/src/Operations/DoubleClick.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class DoubleClick implements Operation
+final readonly class DoubleClick extends Operation
 {
     /**
      * Creates an operation instance.
@@ -17,7 +17,7 @@ final readonly class DoubleClick implements Operation
     public function __construct(
         private string $selector,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/Forward.php
+++ b/src/Operations/Forward.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class Forward implements Operation
+final readonly class Forward extends Operation
 {
     /**
      * Compile the operation.

--- a/src/Operations/Pause.php
+++ b/src/Operations/Pause.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class Pause implements Operation
+final readonly class Pause extends Operation
 {
     /**
      * Creates an operation instance.
@@ -17,7 +17,7 @@ final readonly class Pause implements Operation
     public function __construct(
         private int $milliseconds
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/Refresh.php
+++ b/src/Operations/Refresh.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class Refresh implements Operation
+final readonly class Refresh extends Operation
 {
     /**
      * Compile the operation.

--- a/src/Operations/RightClick.php
+++ b/src/Operations/RightClick.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class RightClick implements Operation
+final readonly class RightClick extends Operation
 {
     /**
      * Creates an operation instance.
@@ -17,7 +17,7 @@ final readonly class RightClick implements Operation
     public function __construct(
         private string $selector,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/Operations/Screenshot.php
+++ b/src/Operations/Screenshot.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 use Pest\TestSuite;
 
 /**
  * @internal
  */
-final readonly class Screenshot implements Operation
+final readonly class Screenshot extends Operation
 {
     /**
      * The path to save the screenshot.
@@ -23,6 +23,8 @@ final readonly class Screenshot implements Operation
     public function __construct(
         ?string $path = null,
     ) {
+        parent::__construct();
+
         $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
 
         $path ??= $this->generateFilename();

--- a/src/Operations/UnCheck.php
+++ b/src/Operations/UnCheck.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class UnCheck implements Operation
+final readonly class UnCheck extends Operation
 {
     /**
      * Creates an operation instance.
      */
     public function __construct(
         private string $element,
-    ) {}
+    ) {
+        parent::__construct();
+    }
 
     /**
      * Compile the operation.

--- a/src/Operations/Visit.php
+++ b/src/Operations/Visit.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Operations;
 
-use Pest\Browser\Contracts\Operation;
+use Pest\Browser\Operation;
 
 /**
  * @internal
  */
-final readonly class Visit implements Operation
+final readonly class Visit extends Operation
 {
     /**
      * Creates an operation instance.
@@ -17,7 +17,7 @@ final readonly class Visit implements Operation
     public function __construct(
         private string $url,
     ) {
-        //
+        parent::__construct();
     }
 
     /**

--- a/src/ValueObjects/OperationTrace.php
+++ b/src/ValueObjects/OperationTrace.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\ValueObjects;
+
+use Pest\Support\Arr;
+
+/**
+ * @internal
+ */
+final readonly class OperationTrace
+{
+    public const TRACE_DEPTH = 4;
+
+    /**
+     * Construct a new instance
+     *
+     * @param  array<int, mixed>|null  $args
+     */
+    public function __construct(
+        public string $file,
+        public int $line,
+        public string $method,
+        public ?array $args = null,
+    ) {
+        //
+    }
+
+    /**
+     * Create a new instance
+     */
+    public static function create(): self
+    {
+        $trace = debug_backtrace(0, self::TRACE_DEPTH)[self::TRACE_DEPTH - 1];
+
+        return new self(
+            Arr::get($trace, 'file', ''), // @phpstan-ignore-line
+            Arr::get($trace, 'line', 0), // @phpstan-ignore-line
+            Arr::get($trace, 'function', ''), // @phpstan-ignore-line
+            Arr::get($trace, 'args'), // @phpstan-ignore-line
+        );
+    }
+}

--- a/src/ValueObjects/TestResult.php
+++ b/src/ValueObjects/TestResult.php
@@ -4,25 +4,93 @@ declare(strict_types=1);
 
 namespace Pest\Browser\ValueObjects;
 
+use Pest\Support\Arr;
+use RuntimeException;
+use SplFileObject;
+
 /**
  * @internal
  */
 final readonly class TestResult
 {
     /**
-     * The test result.
+     * Constructs a new instance.
      */
     public function __construct(
-        private bool $ok,
+        public bool $isPassed,
+        public string $browser,
+        public ?string $errorLine = null,
+        public mixed $actualValue = null,
+        public mixed $expectedValue = null,
     ) {
         //
     }
 
     /**
-     * Get the test result.
+     * Creates a new instance from an array.
+     *
+     * @param  array<string, mixed>  $data
      */
-    public function ok(): bool
+    public static function fromArray(array $data): self
     {
-        return $this->ok;
+        $isPassed = (bool) Arr::get($data, 'suites.0.specs.0.ok', false);
+        $browser = (string) Arr::get($data, 'suites.0.specs.0.tests.0.projectName', ''); // @phpstan-ignore-line
+        $errorLine = null;
+        $actualValue = null;
+        $expectedValue = null;
+
+        if (! $isPassed) {
+            $errorLocation = (array) Arr::get($data, 'suites.0.specs.0.tests.0.results.0.errorLocation', []);
+
+            $errorLine = self::getErrorLine(
+                (string) Arr::get($errorLocation, 'file'), // @phpstan-ignore-line
+                (int) Arr::get($errorLocation, 'line') // @phpstan-ignore-line
+            );
+
+            if (Arr::has($data, 'suites.0.specs.0.tests.0.results.0.error.matcherResult.actual')) {
+                $actualValue = Arr::get($data, 'suites.0.specs.0.tests.0.results.0.error.matcherResult.actual');
+            }
+
+            if (Arr::has($data, 'suites.0.specs.0.tests.0.results.0.error.matcherResult.expected')) {
+                $expectedValue = Arr::get($data, 'suites.0.specs.0.tests.0.results.0.error.matcherResult.expected');
+            }
+        }
+
+        return new self(
+            $isPassed,
+            $browser,
+            $errorLine,
+            $actualValue,
+            $expectedValue,
+        );
+    }
+
+    /**
+     * Creates a new instance from JSON.
+     */
+    public static function fromJson(string $json): self
+    {
+        return self::fromArray(json_decode($json, true)); // @phpstan-ignore-line
+    }
+
+    /**
+     * Get the error line for a given file and line number.
+     */
+    private static function getErrorLine(string $filePath, int $lineNumber): string
+    {
+        if (! file_exists($filePath)) {
+            throw new RuntimeException("Test file not found: {$filePath}");
+        }
+
+        $file = new SplFileObject($filePath);
+        $file->seek($lineNumber - 1);
+
+        $content = $file->current();
+
+        if (! is_string($content)) {
+            throw new RuntimeException("Failed to read file at {$filePath}:{$lineNumber}");
+        }
+
+        return trim($content);
     }
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pest\Browser;
 
 use Pest\Browser\ValueObjects\TestResult;
-use Pest\Support\Arr;
 use Symfony\Component\Process\Process;
 
 /**
@@ -20,15 +19,10 @@ final class Worker
     {
         $process = new Process(['npx', 'playwright', 'test', '--reporter=json']);
 
-        $process->mustRun();
+        $process->run();
 
         $output = $process->getOutput();
 
-        /** @var array<int, mixed> $outputAsArray */
-        $outputAsArray = json_decode($output, true);
-
-        $ok = (bool) Arr::get($outputAsArray, 'suites.0.specs.0.ok');
-
-        return new TestResult($ok);
+        return TestResult::fromJson($output);
     }
 }

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -2,13 +2,28 @@
 
 declare(strict_types=1);
 
-arch('src')
-    ->expect('Pest\Browser')
-    ->toHaveMethodsDocumented()
-    ->toHavePropertiesDocumented();
+describe('arch', function () {
+    arch()
+        ->expect('Pest\Browser')
+        ->toHaveMethodsDocumented()
+        ->toHavePropertiesDocumented();
 
-arch()->preset()->php();
-arch()->preset()->strict();
-arch()->preset()->security()->ignoring([
-    'assert',
-]);
+    arch()
+        ->expect('Pest\Browser\Contracts')
+        ->toBeInterfaces();
+
+    arch()
+        ->expect('Pest\Browser\Exceptions')
+        ->toExtend('Throwable');
+
+    arch('')
+        ->expect('Pest\Browser\Operation\*')
+        ->toBeClasses()
+        ->toExtend('Pest\Browser\Operation')
+        ->toImplement('Pest\Browser\Contracts\Operation')
+        ->toOnlyBeUsedIn('Pest\Browser\PendingTest');
+
+    arch()->preset()->php()->ignoring(['debug_backtrace']);
+    arch()->preset()->strict()->ignoring(['Pest\Browser\Operation']);
+    arch()->preset()->security()->ignoring(['assert']);
+});

--- a/tests/Browser/Operations/AssertDontSeeTest.php
+++ b/tests/Browser/Operations/AssertDontSeeTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Pest\Browser\Exceptions\BrowserOperationException;
+
 it('does not see', function () {
     $this->visit(playgroundUrl('/'))
         ->assertSee('Pest Plugin Browser')
@@ -23,4 +25,4 @@ it('does not see with special characters', function () {
 it('does not see while supporting regex', function () {
     $this->visit(playgroundUrl('/test/interactive-elements'))
         ->assertSee('text(.*)formatted');
-})->throws(Exception::class);
+})->throws(BrowserOperationException::class);

--- a/tests/Browser/Operations/AssertMissingTest.php
+++ b/tests/Browser/Operations/AssertMissingTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\Process\Exception\ProcessFailedException;
+use Pest\Browser\Exceptions\BrowserOperationException;
 
 describe('assert missing', function () {
     it('passes when the given element is not visible', function () {
@@ -13,5 +13,5 @@ describe('assert missing', function () {
     it('fails when the given element is visible', function () {
         $this->visit('/test/interactive-elements')
             ->assertMissing('#i-have-data-testid');
-    })->throws(ProcessFailedException::class);
+    })->throws(BrowserOperationException::class);
 });

--- a/tests/Browser/Operations/AssertNotPresentTest.php
+++ b/tests/Browser/Operations/AssertNotPresentTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\Process\Exception\ProcessFailedException;
+use Pest\Browser\Exceptions\BrowserOperationException;
 
 describe('assert not present', function () {
     it('passes when the given element is not present', function () {
@@ -13,10 +13,10 @@ describe('assert not present', function () {
     it('fails when the given element is present', function () {
         $this->visit('/test/interactive-elements')
             ->assertNotPresent('#i-have-data-testid');
-    })->throws(ProcessFailedException::class);
+    })->throws(BrowserOperationException::class);
 
     it('fails when the given element is present, even when invisible', function () {
         $this->visit('/test/interactive-elements')
             ->assertNotPresent('#invisible-element'); // invisible, but present!
-    })->throws(ProcessFailedException::class);
+    })->throws(BrowserOperationException::class);
 });

--- a/tests/Browser/Operations/AssertPresentTest.php
+++ b/tests/Browser/Operations/AssertPresentTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\Process\Exception\ProcessFailedException;
+use Pest\Browser\Exceptions\BrowserOperationException;
 
 describe('assert present', function () {
     it('passes when the given element is present', function () {
@@ -18,5 +18,5 @@ describe('assert present', function () {
     it('fails when the given element is not present', function () {
         $this->visit('/test/interactive-elements')
             ->assertPresent('#unexistent-element-for-sure-not-to-be-present');
-    })->throws(ProcessFailedException::class);
+    })->throws(BrowserOperationException::class);
 });

--- a/tests/Browser/Operations/AssertSeeTest.php
+++ b/tests/Browser/Operations/AssertSeeTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Pest\Browser\Exceptions\BrowserOperationException;
+
 it('sees', function () {
     $this->visit(playgroundUrl('/'))
         ->assertSee('Pest Plugin Browser');
@@ -20,4 +22,4 @@ it('sees with special characters', function () {
 it('sees without supporting regex', function () {
     $this->visit(playgroundUrl('/test/interactive-elements'))
         ->assertSee('text(.*)formatted');
-})->throws(Exception::class);
+})->throws(BrowserOperationException::class);

--- a/tests/Browser/Operations/AssertVisibleTest.php
+++ b/tests/Browser/Operations/AssertVisibleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\Process\Exception\ProcessFailedException;
+use Pest\Browser\Exceptions\BrowserOperationException;
 
 describe('assert visible', function () {
     it('passes when the given element is visible', function () {
@@ -13,5 +13,5 @@ describe('assert visible', function () {
     it('fails when the given element is not visible', function () {
         $this->visit('/test/interactive-elements')
             ->assertVisible('#invisible-element');
-    })->throws(ProcessFailedException::class);
+    })->throws(BrowserOperationException::class);
 });

--- a/tests/Unit/TestResultTest.php
+++ b/tests/Unit/TestResultTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\TestResult;
+
+describe('TestResult class', function () {
+    test('ok method returns if test suite passes', function ($json, $expected) {
+        $testResult = new TestResult(json_decode($json, true));
+        expect($testResult->ok())->toBe($expected);
+    })->with([
+        ['{"suites":[{"specs":[{"ok":true}]}]}', true],
+        ['{"suites":[{"specs":[{"ok":false}]}]}', false],
+    ]);
+
+    test('method getFirstFailedTest throws exception when no failed tests found', function () {
+        $testResult = new TestResult([]);
+        $testResult->getFailedLine();
+    })->throws(RuntimeException::class, 'No failed tests found in the test result');
+
+    test('method getFirstFailedTest returns the first failed test', function () {
+        $testResult = new TestResult(json_decode(
+            '{"suites":[{"specs":[{"ok":false,"tests":[{"status":"unexpected"}]}]}]}',
+            true
+        ));
+
+        $failedTest = $testResult->getFirstFailedTest();
+
+        expect($failedTest)->toBe(['status' => 'unexpected']);
+    });
+
+    test('method getFailedLine returns the line number of the first failed test', function () {
+        $compiledOperation = 'testoperation';
+        file_put_contents('/tmp/testtmp', $compiledOperation);
+
+        $testResult = new TestResult(json_decode(
+            '{"suites":[{"specs":[{"ok":false,"tests":[{"status":"unexpected","results":[{"errorLocation":{"file":"/tmp/testtmp","line":1}}]}]}]}]}',
+            true
+        ));
+
+        $failedLine = $testResult->getFailedLine();
+
+        unlink('/tmp/testtmp');
+
+        expect($failedLine)->toBe($compiledOperation);
+    });
+
+    test('method getFailedLine throws exception when cannot read file line', function () {
+        $testResult = new TestResult(json_decode(
+            '{"suites":[{"specs":[{"ok":false,"tests":[{"status":"unexpected","results":[{"errorLocation":{"file":"/tmp/testtmp","line":1}}]}]}]}]}',
+            true
+        ));
+
+        $testResult->getFailedLine();
+    })->throws(RuntimeException::class);
+});


### PR DESCRIPTION
Added processing of failed assertion.
Now CLI shows related exception message and shows where failed assertion was called.

For now I left auto-generated exception message in the following format:
`Failed <assertion> assertion with <args>`
But we can pass more detailed message as a second argument of `Assertion` constuctor.

Used `debug_backtrace` function to find a file and line of called assertion. Didn't find a better way.

![image](https://github.com/user-attachments/assets/de38c8b6-d987-4b6a-b1b3-6b6358cc3ee5)
