### PR TITLE
feat: start playground from php instead of playwright process

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,13 @@ To run the test suite, execute:
 
 For each Operation/Assertion, we add a corresponding Test.
 
-We can make use of the `playgroundUrl()` helper, to get its URL during the test.
+We can make use of the `playground()->url()` helper, to get its URL during the test.
 
-We can provide a URI that will be appended, e.g: `playgroundUrl('/test/interactive-elements')`.
-
-Attention: we can use `->visit('/foo')`, using the base URL, without the helper.
-
-The helper exists for assertion scenarios, like:
+We can provide a URI that will be appended, e.g: `playground()->url('/test/interactive-elements')`.
 
 ```php
-$this->visit('/test/interactive-elements')
-    ->assertUrlIs(playgroundUrl('/test/interactive-elements'))
+$this->visit(playground()->url('/test/interactive-elements'))
+    ->assertUrlIs(playground()->url('/test/interactive-elements'))
 ```
 
 ### Routes and views for testing
@@ -66,7 +62,7 @@ Check the `playground/resources/views/test-pages` folder for existing views.
 They are accessible by the playground route `/test/{page}`.
 
 E.g.: The view `resources/views/test-pages/interactive-elements.blade.php` is visited
-on `playgroundUrl('/test/interactive-elements')`.
+on `playground()->url('/test/interactive-elements')`.
 
 The playground is standard Laravel App, where you may add a page with a feature for your test.
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,9 @@
         "laravel/pint": "^1.20",
         "peckphp/peck": "^0.1.2",
         "pestphp/pest-dev-tools": "^3.4.0",
-        "pestphp/pest-plugin-type-coverage": "^3.3"
+        "pestphp/pest-plugin-type-coverage": "^3.3",
+        "ext-pcntl": "*",
+        "ext-posix": "*"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,10 +9,6 @@ import {defineConfig, devices} from '@playwright/test';
 // import path from 'path';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
 
-const port = process.env.PORT || 9357;
-const host = process.env.HOST || 'localhost';
-const baseURL = process.env.BASE_URL || `http://${host}:${port}`;
-
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
@@ -30,9 +26,6 @@ export default defineConfig({
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
-        /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL,
-
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
 
@@ -81,10 +74,10 @@ export default defineConfig({
     ],
 
     /* Run your local dev server before starting the tests */
-    webServer: {
+    /*webServer: {
         cwd: `${__dirname}/playground`,
         command: `php artisan serve --port=${port}`,
         url: baseURL,
         reuseExistingServer: !process.env.CI,
-    },
+    },*/
 });

--- a/src/Operations/AssertPathIs.php
+++ b/src/Operations/AssertPathIs.php
@@ -22,7 +22,9 @@ final readonly class AssertPathIs implements Operation
      */
     public function compile(): string
     {
-        $pattern = str_replace('\*', '.*', preg_quote($this->path, '/'));
+        $pattern = preg_quote($this->path, '/');
+        $pattern = str_replace('\*', '.*', $pattern);
+        $pattern = str_replace('\-', '-', $pattern);
 
         return "await expect(new URL(await page.url()).pathname).toMatch(/^$pattern$/u)";
     }

--- a/src/Playground.php
+++ b/src/Playground.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser;
+
+use Pest\Support\Arr;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ */
+final class Playground
+{
+    private const DEFAULT_SCHEME = 'http';
+
+    private const DEFAULT_HOST = 'localhost';
+
+    private const DEFAULT_PORT = 9357;
+
+    /**
+     * Playground instance.
+     */
+    private static ?Playground $instance = null;
+
+    /**
+     * Artisan serve process.
+     */
+    private Process $process;
+
+    /**
+     * Constructs new instance and starts Artisan serve process.
+     */
+    private function __construct(
+        private string $scheme,
+        private string $host,
+        private int $port
+    ) {
+        $this->shutdownIdleProcesses();
+
+        $this->process = new Process(['php', 'playground/artisan', 'serve', "--port={$this->port}"]);
+        $this->process->disableOutput();
+        $this->process->start();
+    }
+
+    /**
+     * Destructor to stop Artisan serve process.
+     */
+    public function __destruct()
+    {
+        $this->stop();
+    }
+
+    /**
+     * Creates new Playground instance or returns existing one.
+     */
+    public static function start(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self(
+                Arr::get($_ENV, 'PEST_BROWSER_PLUGIN_PLAYGROUND_SCHEME', self::DEFAULT_SCHEME), // @phpstan-ignore-line
+                Arr::get($_ENV, 'PEST_BROWSER_PLUGIN_PLAYGROUND_HOST', self::DEFAULT_HOST), // @phpstan-ignore-line
+                Arr::get($_ENV, 'PEST_BROWSER_PLUGIN_PLAYGROUND_PORT', self::DEFAULT_PORT), // @phpstan-ignore-line
+            );
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Get URL for given path.
+     */
+    public function url(string $path = '/'): string
+    {
+        return sprintf(
+            '%s://%s:%d/%s',
+            $this->scheme,
+            $this->host,
+            $this->port,
+            ltrim($path, '/')
+        );
+    }
+
+    /**
+     * Stops Artisan serve process.
+     */
+    private function stop(): void
+    {
+        if ($this->process->isRunning()) {
+            $this->process->stop(0, SIGKILL);
+        }
+    }
+
+    /**
+     * Shuts down idle processes listening on the given port.
+     */
+    private function shutdownIdleProcesses(): void
+    {
+        $process = new Process(['lsof', '-i', "tcp:$this->port"]);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return;
+        }
+
+        $output = $process->getOutput();
+        $lines = explode("\n", trim($output));
+
+        foreach (array_slice($lines, 1) as $line) {
+            $columns = preg_split('/\s+/', $line);
+            $pid = $columns[1] ?? null;
+            $command = $columns[0] ?? '';
+
+            if ($pid !== null && str_contains($command, 'php')) {
+                posix_kill((int) $pid, SIGKILL);
+            }
+        }
+    }
+}

--- a/tests/Browser/Operations/AssertAttributeContainsTest.php
+++ b/tests/Browser/Operations/AssertAttributeContainsTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert attribute contains', function () {
-    $this->visit('/test/interactive-elements')
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertAttributeContains('#i-have-data-testid', 'data-testid', 'to-be-seen');
 });

--- a/tests/Browser/Operations/AssertAttributeDoesntContainTest.php
+++ b/tests/Browser/Operations/AssertAttributeDoesntContainTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert attribute doesnt contain', function () {
-    $this->visit('/test/interactive-elements')
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertAttributeDoesntContain('#i-have-data-testid', 'data-testid', 'not-included');
 });

--- a/tests/Browser/Operations/AssertAttributeMissingTest.php
+++ b/tests/Browser/Operations/AssertAttributeMissingTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert attribute missing', function () {
-    $this->visit('/test/interactive-elements')
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertAttributeMissing('#i-have-data-testid', 'attr-that-does-not-exist-on-the-element');
 });

--- a/tests/Browser/Operations/AssertAttributeTest.php
+++ b/tests/Browser/Operations/AssertAttributeTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert attribute', function () {
-    $this->visit('/test/interactive-elements')
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertAttribute('#i-have-data-testid', 'data-testid', 'i-exist-to-be-seen');
 });

--- a/tests/Browser/Operations/AssertCheckedTest.php
+++ b/tests/Browser/Operations/AssertCheckedTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert checkbox is checked', function () {
-    $this->visit('/test/form-inputs')
+    $this->visit(playground()->url('/test/form-inputs'))
         ->assertChecked('input[name="checked-checkbox"]');
 });

--- a/tests/Browser/Operations/AssertDontSeeTest.php
+++ b/tests/Browser/Operations/AssertDontSeeTest.php
@@ -3,24 +3,24 @@
 declare(strict_types=1);
 
 it('does not see', function () {
-    $this->visit(playgroundUrl('/'))
+    $this->visit(playground()->url())
         ->assertSee('Pest Plugin Browser')
         ->assertDontSee('Fest Plugin Bowser');
 });
 
 it('does not see ignoring case', function () {
-    $this->visit(playgroundUrl('/'))
+    $this->visit(playground()->url())
         ->assertSee('Pest Plugin Browser')
         ->assertDontSee('fest plugin bowser', true);
 });
 
 it('does not see with special characters', function () {
-    $this->visit(playgroundUrl('/test/interactive-elements'))
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertSee('Some (text) wi/th [some] "formatted" ch@racters.')
         ->assertDontSee('Some (text) which "does" not exist.');
 });
 
 it('does not see while supporting regex', function () {
-    $this->visit(playgroundUrl('/test/interactive-elements'))
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertSee('text(.*)formatted');
 })->throws(Exception::class);

--- a/tests/Browser/Operations/AssertHostIs.php
+++ b/tests/Browser/Operations/AssertHostIs.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 test('assert host is', function () {
-    $this
-        ->visit('/')
-        ->assertHostIs(
-            str_replace('http://', '', playgroundUrl())
-        );
+    $url = parse_url(playground()->url());
+
+    $this->visit(playground()->url())
+        ->assertHostIs("{$url['host']}:{$url['port']}");
 });

--- a/tests/Browser/Operations/AssertHostIsNot.php
+++ b/tests/Browser/Operations/AssertHostIsNot.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert host is not', function () {
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->assertHostIsNot('example.com');
 });

--- a/tests/Browser/Operations/AssertMissingTest.php
+++ b/tests/Browser/Operations/AssertMissingTest.php
@@ -6,12 +6,12 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 describe('assert missing', function () {
     it('passes when the given element is not visible', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertMissing('#invisible-element');
     });
 
     it('fails when the given element is visible', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertMissing('#i-have-data-testid');
     })->throws(ProcessFailedException::class);
 });

--- a/tests/Browser/Operations/AssertNotCheckedTest.php
+++ b/tests/Browser/Operations/AssertNotCheckedTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert checkbox is not checked', function () {
-    $this->visit('/test/form-inputs')
+    $this->visit(playground()->url('/test/form-inputs'))
         ->assertNotChecked('input[name="default-checkbox"]');
 });

--- a/tests/Browser/Operations/AssertNotPresentTest.php
+++ b/tests/Browser/Operations/AssertNotPresentTest.php
@@ -6,17 +6,17 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 describe('assert not present', function () {
     it('passes when the given element is not present', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertNotPresent('#unexistent-element-for-sure-not-to-be-present');
     });
 
     it('fails when the given element is present', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertNotPresent('#i-have-data-testid');
     })->throws(ProcessFailedException::class);
 
     it('fails when the given element is present, even when invisible', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertNotPresent('#invisible-element'); // invisible, but present!
     })->throws(ProcessFailedException::class);
 });

--- a/tests/Browser/Operations/AssertPathBeginsWith.php
+++ b/tests/Browser/Operations/AssertPathBeginsWith.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 test('assert path starts with', function () {
-    $url = 'https://laravel.com/docs/11.x';
-
-    $this->visit($url)
-        ->assertPathBeginsWith('/docs');
+    $this->visit(playground()->url('/test/form-inputs'))
+        ->assertPathBeginsWith('/test');
 });

--- a/tests/Browser/Operations/AssertPathContains.php
+++ b/tests/Browser/Operations/AssertPathContains.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 test('assert path contains', function () {
-    $url = 'https://laravel.com/docs/11.x';
-
-    $this->visit($url)
-        ->assertPathContains('/11');
+    $this->visit(playground()->url('/test/form-inputs'))
+        ->assertPathContains('form');
 });

--- a/tests/Browser/Operations/AssertPathEndsWith.php
+++ b/tests/Browser/Operations/AssertPathEndsWith.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 test('assert path ends with', function () {
-    $url = 'https://laravel.com/docs/11.x';
-
-    $this->visit($url)
-        ->assertPathEndsWith('/11.x');
+    $this->visit(playground()->url('/test/form-inputs'))
+        ->assertPathEndsWith('/form-inputs');
 });

--- a/tests/Browser/Operations/AssertPathIs.php
+++ b/tests/Browser/Operations/AssertPathIs.php
@@ -3,15 +3,11 @@
 declare(strict_types=1);
 
 test('assert path is', function () {
-    $url = 'https://laravel.com/docs/11.x';
-
-    $this->visit($url)
-        ->assertPathIs('/docs/11.x');
+    $this->visit(playground()->url('/test/form-inputs'))
+        ->assertPathIs('/test/form-inputs');
 });
 
 test('assert path is with wildcard', function () {
-    $url = 'https://laravel.com/docs/11.x';
-
-    $this->visit($url)
-        ->assertPathIs('/docs/*.x');
+    $this->visit(playground()->url('/test/form-inputs'))
+        ->assertPathIs('/test/*inputs');
 });

--- a/tests/Browser/Operations/AssertPathIsNot.php
+++ b/tests/Browser/Operations/AssertPathIsNot.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 test('assert path is not', function () {
-    $url = 'https://laravel.com/docs/11.x';
-
-    $this->visit($url)
-        ->assertPathIsNot('/docs/12.x');
+    $this->visit(playground()->url('/test/form-inputs'))
+        ->assertPathIsNot('/test');
 });

--- a/tests/Browser/Operations/AssertPresentTest.php
+++ b/tests/Browser/Operations/AssertPresentTest.php
@@ -6,17 +6,17 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 describe('assert present', function () {
     it('passes when the given element is present', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertPresent('#i-have-data-testid');
     });
 
     it('passes when the given element is present - and invisible', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertPresent('#invisible-element'); // invisible, but present
     });
 
     it('fails when the given element is not present', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertPresent('#unexistent-element-for-sure-not-to-be-present');
     })->throws(ProcessFailedException::class);
 });

--- a/tests/Browser/Operations/AssertQueryStringHasTest.php
+++ b/tests/Browser/Operations/AssertQueryStringHasTest.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 test('assert query string has a giving query param with value', function () {
-    $this->visit('/?q=test')
+    $this->visit(playground()->url('/?q=test'))
         ->assertQueryStringHas('q', 'test');
 });
 
 test('assert query string has a giving only the query param', function () {
-    $this->visit('/?q')
+    $this->visit(playground()->url('/?q'))
         ->assertQueryStringHas('q');
 });

--- a/tests/Browser/Operations/AssertQueryStringMissingTest.php
+++ b/tests/Browser/Operations/AssertQueryStringMissingTest.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 test('assert query string does not have the given query param with value', function () {
-    $this->visit('/?q=test')
+    $this->visit(playground()->url('/?q=test'))
         ->assertQueryStringHas('q')
         ->assertQueryStringHas('q', 'test')
         ->assertQueryStringMissing('q', 'test-1');
 });
 
 test('assert query string does not have the only given the query param', function () {
-    $this->visit('/?q=test')
+    $this->visit(playground()->url('/?q=test'))
         ->assertQueryStringMissing('s');
 });

--- a/tests/Browser/Operations/AssertSchemeIs.php
+++ b/tests/Browser/Operations/AssertSchemeIs.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert scheme', function () {
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->assertSchemeIs('http');
 });

--- a/tests/Browser/Operations/AssertSchemeIsNot.php
+++ b/tests/Browser/Operations/AssertSchemeIsNot.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert scheme is not', function () {
-    $this->visit('')
+    $this->visit(playground()->url())
         ->assertSchemeIsNot('https');
 });

--- a/tests/Browser/Operations/AssertScript.php
+++ b/tests/Browser/Operations/AssertScript.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 describe('assert script', function () {
     it('passes', function ($expression, $expected) {
-        $this->visit('/')
+        $this->visit(playground()->url())
             ->assertScript($expression, $expected);
     })->with([
         ['document.querySelector("title").textContent.includes("Pest")', true],

--- a/tests/Browser/Operations/AssertSeeTest.php
+++ b/tests/Browser/Operations/AssertSeeTest.php
@@ -3,21 +3,21 @@
 declare(strict_types=1);
 
 it('sees', function () {
-    $this->visit(playgroundUrl('/'))
+    $this->visit(playground()->url())
         ->assertSee('Pest Plugin Browser');
 });
 
 it('sees ignoring case', function () {
-    $this->visit(playgroundUrl('/'))
+    $this->visit(playground()->url())
         ->assertSee('pest plugin browser', true);
 });
 
 it('sees with special characters', function () {
-    $this->visit(playgroundUrl('/test/interactive-elements'))
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertSee('Some (text) wi/th [some] "formatted" ch@racters.');
 });
 
 it('sees without supporting regex', function () {
-    $this->visit(playgroundUrl('/test/interactive-elements'))
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertSee('text(.*)formatted');
 })->throws(Exception::class);

--- a/tests/Browser/Operations/AssertTitleContainsTest.php
+++ b/tests/Browser/Operations/AssertTitleContainsTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert title contains', function () {
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->assertTitleContains('Plugin Browser');
 });

--- a/tests/Browser/Operations/AssertTitleTest.php
+++ b/tests/Browser/Operations/AssertTitleTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert title', function (): void {
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->assertTitle('Pest Plugin Browser - Playground');
 });

--- a/tests/Browser/Operations/AssertUrlIsTest.php
+++ b/tests/Browser/Operations/AssertUrlIsTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('assert url is', function (): void {
-    $this->visit('/')
-        ->assertUrlIs(playgroundUrl());
+    $this->visit(playground()->url())
+        ->assertUrlIs(playground()->url());
 });

--- a/tests/Browser/Operations/AssertVisibleTest.php
+++ b/tests/Browser/Operations/AssertVisibleTest.php
@@ -6,12 +6,12 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 describe('assert visible', function () {
     it('passes when the given element is visible', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertVisible('#i-have-data-testid');
     });
 
     it('fails when the given element is not visible', function () {
-        $this->visit('/test/interactive-elements')
+        $this->visit(playground()->url('/test/interactive-elements'))
             ->assertVisible('#invisible-element');
     })->throws(ProcessFailedException::class);
 });

--- a/tests/Browser/Operations/BackTest.php
+++ b/tests/Browser/Operations/BackTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 test('navigates back', function (): void {
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->clickLink('Interacting with Elements')
-        ->assertUrlIs(playgroundUrl('/test/interacting-with-elements'))
+        ->assertUrlIs(playground()->url('/test/interacting-with-elements'))
         ->back()
-        ->assertUrlIs(playgroundUrl());
+        ->assertUrlIs(playground()->url());
 });

--- a/tests/Browser/Operations/CheckTest.php
+++ b/tests/Browser/Operations/CheckTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 test('check the unchecked checkbox', function () {
-    $this->visit('/test/form-inputs')
+    $this->visit(playground()->url('/test/form-inputs'))
         ->check('input[name="default-checkbox"]')
         ->assertChecked('input[name="default-checkbox"]');
 });

--- a/tests/Browser/Operations/ClickAndHoldTest.php
+++ b/tests/Browser/Operations/ClickAndHoldTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('clicks and hold an element using css selectors', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->assertSee('Click and hold me')
         ->assertDontSee('Free hug!')
         ->clickAndHold("button[data-testId='hold-click']")
@@ -12,13 +12,13 @@ it('clicks and hold an element using css selectors', function (): void {
 });
 
 it('escapes double quotes properly', function () {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->clickAndHold('button[data-testId="hold-click"]')
         ->assertSee('Free hug!');
 });
 
 it('can click and hold multiple times', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->clickAndHold('button[data-testId="hold-click"]')
         ->assertSee('Free hug! (1)')
         ->clickAndHold('button[data-testId="hold-click"]')
@@ -27,7 +27,7 @@ it('can click and hold multiple times', function (): void {
 });
 
 it('can click and hold for a given duration', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->clickAndHold('button[data-testId="hold-click"]', 400)
         ->assertDontSee('Free hug!')
         ->clickAndHold('button[data-testId="hold-click"]', 1500)

--- a/tests/Browser/Operations/ClickAtPointTest.php
+++ b/tests/Browser/Operations/ClickAtPointTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('clicks an element using x and y coordinates', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->assertSee('Absolutely click me')
         ->clickAtPoint(1050, 70)
         ->assertSee('Absolutely clicked!');

--- a/tests/Browser/Operations/ClickAtXPathTest.php
+++ b/tests/Browser/Operations/ClickAtXPathTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('clicks an element using xpath', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->clickAtXPath('/html/body/main/nav[1]/ul/li[1]/a')
-        ->assertUrlIs(playgroundUrl());
+        ->assertUrlIs(playground()->url());
 });

--- a/tests/Browser/Operations/ClickLinkTest.php
+++ b/tests/Browser/Operations/ClickLinkTest.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 it('clicks a link', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->clickLink('Home')
-        ->assertUrlIs(playgroundUrl());
+        ->assertUrlIs(playground()->url());
 });
 
 it('is case insensitive', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->clickLink('home')
-        ->assertUrlIs(playgroundUrl());
+        ->assertUrlIs(playground()->url());
 });

--- a/tests/Browser/Operations/ClickTest.php
+++ b/tests/Browser/Operations/ClickTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('clicks an element using css selectors', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->assertSee('Click me')
         ->assertDontSee('Single clicked!')
         ->doubleClick("button[data-testId='default-click']")
@@ -12,13 +12,13 @@ it('clicks an element using css selectors', function (): void {
 });
 
 it('escapes double quotes properly', function () {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->click('nav a[title="Playground home"]:visible')
-        ->assertUrlIs(playgroundUrl());
+        ->assertUrlIs(playground()->url());
 });
 
 it('can click multiple times', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->click('button[data-testId="default-click"]')
         ->assertSee('Single clicked! (1)')
         ->click('button[data-testId="default-click"]')

--- a/tests/Browser/Operations/ControlClickTest.php
+++ b/tests/Browser/Operations/ControlClickTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('control clicks an element using css selectors', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->assertSee('ctrl|cmd + click me')
         ->assertDontSee('ctrl|cmd clicked!')
         ->controlClick("button[data-testId='control-click']")
@@ -12,13 +12,13 @@ it('control clicks an element using css selectors', function (): void {
 });
 
 it('escapes control quotes properly', function () {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->controlClick('button[data-testId="control-click"]')
         ->assertSee('ctrl|cmd clicked!');
 });
 
 it('can control click multiple times', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->controlClick('button[data-testId="control-click"]')
         ->assertSee('ctrl|cmd clicked! (1)')
         ->controlClick('button[data-testId="control-click"]')

--- a/tests/Browser/Operations/DoubleClickTest.php
+++ b/tests/Browser/Operations/DoubleClickTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('double clicks an element using css selectors', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->assertSee('Double click me')
         ->assertDontSee('Double clicked!')
         ->doubleClick("button[data-testId='double-click']")
@@ -12,13 +12,13 @@ it('double clicks an element using css selectors', function (): void {
 });
 
 it('escapes double quotes properly', function () {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->doubleClick('button[data-testId="double-click"]')
         ->assertSee('Double clicked!');
 });
 
 it('can double click multiple times', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->doubleClick('button[data-testId="double-click"]')
         ->assertSee('Double clicked! (1)')
         ->doubleClick('button[data-testId="double-click"]')

--- a/tests/Browser/Operations/ForwardTest.php
+++ b/tests/Browser/Operations/ForwardTest.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 test('navigates forward', function (): void {
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->clickLink('Interacting with Elements')
-        ->assertUrlIs(playgroundUrl('/test/interacting-with-elements'))
+        ->assertUrlIs(playground()->url('/test/interacting-with-elements'))
         ->back()
-        ->assertUrlIs(playgroundUrl())
+        ->assertUrlIs(playground()->url())
         ->forward()
-        ->assertUrlIs(playgroundUrl('/test/interacting-with-elements'));
+        ->assertUrlIs(playground()->url('/test/interacting-with-elements'));
 });

--- a/tests/Browser/Operations/PauseTest.php
+++ b/tests/Browser/Operations/PauseTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('pause', function (): void {
-    $this->visit('/test/interactive-elements')
+    $this->visit(playground()->url('/test/interactive-elements'))
         ->assertDontSee('I appear after 2 seconds')
         ->pause(2200)
         ->assertSee('I appear after 2 seconds');
@@ -11,10 +11,10 @@ it('pause', function (): void {
 
 test('throws an exception when pause is negative', function (): void {
     expect(function () {
-        $this->visit('/')
+        $this->visit(playground()->url())
             ->clickLink('Get Started')
             ->pause(-1000)
-            ->assertUrlIs(playgroundUrl());
+            ->assertUrlIs(playground()->url());
     })
         ->toThrow(
             InvalidArgumentException::class,

--- a/tests/Browser/Operations/RefreshTest.php
+++ b/tests/Browser/Operations/RefreshTest.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 test('refreshes', function (): void {
-    $this->visit('/test/interactive-elements')
-        ->assertUrlIs(playgroundUrl('/test/interactive-elements'))
+    $this->visit(playground()->url('/test/interactive-elements'))
+        ->assertUrlIs(playground()->url('/test/interactive-elements'))
         ->pause(3000)
         ->assertSee('I appear after 2 seconds')
         ->refresh()
-        ->assertUrlIs(playgroundUrl('/test/interactive-elements'))
+        ->assertUrlIs(playground()->url('/test/interactive-elements'))
         ->assertDontSee('I appear after 2 seconds');
 });

--- a/tests/Browser/Operations/RightClickTest.php
+++ b/tests/Browser/Operations/RightClickTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('right clicks an element using css selectors', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->assertSee('Right click me')
         ->assertDontSee('Right clicked!')
         ->rightClick("button[data-testId='right-click']")
@@ -12,13 +12,13 @@ it('right clicks an element using css selectors', function (): void {
 });
 
 it('escapes double quotes properly', function () {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->rightClick('button[data-testId="right-click"]')
         ->assertSee('Right clicked!');
 });
 
 it('can right click multiple times', function (): void {
-    $this->visit('/test/interacting-with-elements')
+    $this->visit(playground()->url('/test/interacting-with-elements'))
         ->rightClick('button[data-testId="right-click"]')
         ->assertSee('Right clicked! (1)')
         ->rightClick('button[data-testId="right-click"]')

--- a/tests/Browser/Operations/ScreenshotTest.php
+++ b/tests/Browser/Operations/ScreenshotTest.php
@@ -7,7 +7,7 @@ use Pest\TestSuite;
 it('takes a screenshot', function (): void {
     $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
 
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->screenshot('index.png');
 
     expect(file_exists($basePath.'/index.png'))->toBeTrue();
@@ -16,7 +16,7 @@ it('takes a screenshot', function (): void {
 it('takes a screenshot and generates a path', function (): void {
     $basePath = TestSuite::getInstance()->testPath.'/Browser/screenshots';
 
-    $this->visit('/')
+    $this->visit(playground()->url())
         ->screenshot();
 
     $testName = mb_ltrim(test()->name(), '__pest_evaluable_'); // @phpstan-ignore-line

--- a/tests/Browser/Operations/UnCheckTest.php
+++ b/tests/Browser/Operations/UnCheckTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 test('uncheck the checked checkbox', function () {
-    $this->visit('/test/form-inputs')
+    $this->visit(playground()->url('/test/form-inputs'))
         ->uncheck('input[name="checked-checkbox"]')
         ->assertNotChecked('input[name="checked-checkbox"]');
 });

--- a/tests/Browser/Operations/VisitTest.php
+++ b/tests/Browser/Operations/VisitTest.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 test('visit', function (): void {
-    $this->visit('/')
-        ->assertUrlIs(playgroundUrl());
+    $this->visit(playground()->url())
+        ->assertUrlIs(playground()->url());
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pest\Browser\Playground;
 use Pest\TestSuite;
 
 pest()
@@ -21,7 +22,7 @@ function cleanupScreenshots(): void
     file_exists($basePath) && rmdir($basePath);
 }
 
-function playgroundUrl($uri = null): string
+function playground(): Playground
 {
-    return 'http://localhost:9357'.$uri;
+    return Playground::start();
 }


### PR DESCRIPTION
Added the `Playground` class to run `php artisan serve` command from php instead of Playwright.