### PR TITLE
Fix bold formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 This repository contains the Pest Plugin Browser.
 
-> If you want to start testing your application with Pest, visit the main *
-*[Pest Repository](https://github.com/pestphp/pest)**.
+> If you want to start testing your application with Pest, visit the main **[Pest Repository](https://github.com/pestphp/pest)**.
 
 ## Community & Resources
 
 - Explore our docs at **[pestphp.com »](https://pestphp.com)**
 - Follow us on Twitter at **[@pestphp »](https://twitter.com/pestphp)**
-- Join us at **[discord.gg/kaHY6p54JH »](https://discord.gg/kaHY6p54JH)** or *
-  *[t.me/+kYH5G4d5MV83ODk0 »](https://t.me/+kYH5G4d5MV83ODk0)**
+- Join us at **[discord.gg/kaHY6p54JH »](https://discord.gg/kaHY6p54JH)** or **[t.me/+kYH5G4d5MV83ODk0 »](https://t.me/+kYH5G4d5MV83ODk0)**
 
 ## Installation (for development purposes)
 


### PR DESCRIPTION
Bold formatting syntax (**) had spaces causing it to render incorrectly.

### Before
![image](https://github.com/user-attachments/assets/a22be140-3722-432c-b04a-4291290d66c1)
![image](https://github.com/user-attachments/assets/10fbafc0-9e3b-46f3-be36-06b51607ee56)

---

### After
![image](https://github.com/user-attachments/assets/49e20622-ee8e-446a-a2ef-0703420337b7)
![image](https://github.com/user-attachments/assets/c5261aa1-d8ea-4c4b-b251-8700a6209c42)
