### PR TITLE
feat: evaluate expressions

### DIFF
--- a/src/Playwright/Concerns/InteractsWithPlaywright.php
+++ b/src/Playwright/Concerns/InteractsWithPlaywright.php
@@ -7,8 +7,8 @@ namespace Pest\Browser\Playwright\Concerns;
 use Generator;
 use Pest\Browser\Playwright\Client;
 use Pest\Browser\Playwright\Element;
-use Pest\Browser\Playwright\Locator;
 use Pest\Browser\Playwright\Page;
+use Pest\Browser\Support\JavaScriptSerializer;
 
 /**
  * @internal
@@ -30,10 +30,10 @@ trait InteractsWithPlaywright
      */
     private function processResultResponse(Generator $response): mixed
     {
-        /** @var array{result: array{value: mixed}} $message */
+        /** @var array{result?: array{value: mixed}} $message */
         foreach ($response as $message) {
             if (isset($message['result']['value'])) {
-                return $message['result']['value'];
+                return JavaScriptSerializer::parseValue($message['result']['value']);
             }
         }
 

--- a/src/Playwright/JSHandle.php
+++ b/src/Playwright/JSHandle.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Playwright;
+
+use Pest\Browser\Playwright\Concerns\InteractsWithPlaywright;
+use Pest\Browser\Support\JavaScriptSerializer;
+
+/**
+ * JSHandle represents a handle to a JavaScript object in the browser.
+ * It can be used to interact with the object or evaluate expressions on it.
+ *
+ * @internal
+ */
+final class JSHandle
+{
+    use InteractsWithPlaywright;
+
+    /**
+     * Constructs new JSHandle
+     */
+    public function __construct(
+        public string $guid,
+    ) {
+        //
+    }
+
+    /**
+     * Evaluate a JavaScript expression on this handle.
+     */
+    public function evaluate(string $pageFunction, mixed $arg = null): mixed
+    {
+        $params = [
+            'expression' => $pageFunction,
+            'arg' => JavaScriptSerializer::serializeArgument($arg),
+        ];
+
+        $response = $this->sendMessage('evaluateExpression', $params);
+
+        return $this->processResultResponse($response);
+    }
+
+    /**
+     * Get the JSON representation of this handle's value.
+     */
+    public function jsonValue(): mixed
+    {
+        $response = $this->sendMessage('jsonValue');
+
+        return $this->processResultResponse($response);
+    }
+
+    /**
+     * Dispose of this handle.
+     */
+    public function dispose(): void
+    {
+        $response = $this->sendMessage('dispose');
+        $this->processVoidResponse($response);
+    }
+
+    /**
+     * Get the string representation of this handle.
+     */
+    public function toString(): string
+    {
+        return $this->jsonValue();
+    }
+}

--- a/src/Playwright/JSHandle.php
+++ b/src/Playwright/JSHandle.php
@@ -65,6 +65,12 @@ final class JSHandle
      */
     public function toString(): string
     {
-        return $this->jsonValue();
+        $value = $this->jsonValue();
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return (string) $value;
     }
 }

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -26,7 +26,9 @@ final class Page
         public string $guid,
         public string $frameGuid,
         public string $url = '',
-    ) {}
+    ) {
+        //
+    }
 
     /**
      * Get the current URL of the page.
@@ -555,7 +557,8 @@ final class Page
             'arg' => JavaScriptSerializer::serializeArgument($arg),
         ];
 
-        $response = $this->sendMessage('evaluateExpressionHandle', $params);        /** @var array{method?: string|null, params: array{type?: string|null, guid?: string}} $message */
+        $response = $this->sendMessage('evaluateExpressionHandle', $params);
+
         foreach ($response as $message) {
             if (
                 isset($message['method'], $message['params']['type'], $message['params']['guid'])

--- a/src/Support/JavaScriptSerializer.php
+++ b/src/Support/JavaScriptSerializer.php
@@ -62,14 +62,15 @@ final class JavaScriptSerializer
                 foreach ($value as $key => $val) {
                     $result[] = ['k' => $key, 'v' => self::serializeValue($val)];
                 }
+
                 return ['o' => $result];
-            } else {
-                $result = [];
-                foreach ($value as $item) {
-                    $result[] = self::serializeValue($item);
-                }
-                return ['a' => $result];
             }
+            $result = [];
+            foreach ($value as $item) {
+                $result[] = self::serializeValue($item);
+            }
+
+            return ['a' => $result];
         }
 
         if (is_object($value)) {
@@ -81,6 +82,7 @@ final class JavaScriptSerializer
             foreach (get_object_vars($value) as $key => $val) {
                 $result[] = ['k' => $key, 'v' => self::serializeValue($val)];
             }
+
             return ['o' => $result];
         }
 
@@ -139,6 +141,7 @@ final class JavaScriptSerializer
             foreach ($value['o'] as $item) {
                 $result[$item['k']] = self::parseValue($item['v']);
             }
+
             return $result;
         }
 

--- a/src/Support/JavaScriptSerializer.php
+++ b/src/Support/JavaScriptSerializer.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Support;
+
+use DateTimeImmutable;
+use stdClass;
+
+/**
+ * Handles serialization and deserialization of JavaScript values.
+ *
+ * @internal
+ */
+final class JavaScriptSerializer
+{
+    /**
+     * Serialize arguments for JavaScript evaluation according to Playwright protocol.
+     */
+    public static function serializeArgument(mixed $value): array
+    {
+        return [
+            'value' => self::serializeValue($value),
+            'handles' => [],
+        ];
+    }
+
+    /**
+     * Serialize a value according to Playwright's serialization format.
+     */
+    public static function serializeValue(mixed $value): array
+    {
+        if ($value === null) {
+            return ['v' => 'null'];
+        }
+
+        if (is_bool($value)) {
+            return ['b' => $value];
+        }
+
+        if (is_int($value) || is_float($value)) {
+            if (is_float($value) && is_nan($value)) {
+                return ['v' => 'NaN'];
+            }
+            if (is_float($value) && is_infinite($value)) {
+                return ['v' => $value > 0 ? 'Infinity' : '-Infinity'];
+            }
+            if (is_int($value) && ($value < -9007199254740992 || $value > 9007199254740991)) {
+                return ['bi' => (string) $value];
+            }
+
+            return ['n' => $value];
+        }
+
+        if (is_string($value)) {
+            return ['s' => $value];
+        }
+
+        if (is_array($value)) {
+            $isAssoc = array_keys($value) !== range(0, count($value) - 1);
+            if ($isAssoc) {
+                $result = [];
+                foreach ($value as $key => $val) {
+                    $result[] = ['k' => $key, 'v' => self::serializeValue($val)];
+                }
+                return ['o' => $result];
+            } else {
+                $result = [];
+                foreach ($value as $item) {
+                    $result[] = self::serializeValue($item);
+                }
+                return ['a' => $result];
+            }
+        }
+
+        if (is_object($value)) {
+            if ($value instanceof DateTimeImmutable) {
+                return ['d' => $value->format('c')];
+            }
+
+            $result = [];
+            foreach (get_object_vars($value) as $key => $val) {
+                $result[] = ['k' => $key, 'v' => self::serializeValue($val)];
+            }
+            return ['o' => $result];
+        }
+
+        // Fallback for unsupported types
+        return ['s' => (string) $value];
+    }
+
+    /**
+     * Parse a value from JavaScript according to Playwright protocol.
+     */
+    public static function parseValue(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        // Handle primitive values
+        if (isset($value['v'])) {
+            return match ($value['v']) {
+                'null' => null,
+                'undefined' => null,
+                'NaN' => NAN,
+                'Infinity' => INF,
+                '-Infinity' => -INF,
+                default => $value['v'],
+            };
+        }
+
+        if (isset($value['b'])) {
+            return (bool) $value['b'];
+        }
+
+        if (isset($value['n'])) {
+            return is_int($value['n']) ? $value['n'] : (float) $value['n'];
+        }
+
+        if (isset($value['s'])) {
+            return (string) $value['s'];
+        }
+
+        if (isset($value['bi'])) {
+            return (string) $value['bi'];
+        }
+
+        if (isset($value['d'])) {
+            return new DateTimeImmutable($value['d']);
+        }
+
+        // Handle arrays
+        if (isset($value['a'])) {
+            return array_map(fn ($item): mixed => self::parseValue($item), $value['a']);
+        }
+
+        // Handle objects
+        if (isset($value['o'])) {
+            $result = [];
+            foreach ($value['o'] as $item) {
+                $result[$item['k']] = self::parseValue($item['v']);
+            }
+            return $result;
+        }
+
+        return $value;
+    }
+}

--- a/src/Support/JavaScriptSerializer.php
+++ b/src/Support/JavaScriptSerializer.php
@@ -132,7 +132,7 @@ final class JavaScriptSerializer
 
         // Handle arrays
         if (isset($value['a'])) {
-            return array_map(fn ($item): mixed => self::parseValue($item), $value['a']);
+            return array_map(fn (mixed $item): mixed => self::parseValue($item), $value['a']);
         }
 
         // Handle objects

--- a/src/Support/JavaScriptSerializer.php
+++ b/src/Support/JavaScriptSerializer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pest\Browser\Support;
 
 use DateTimeImmutable;
-use stdClass;
 
 /**
  * Handles serialization and deserialization of JavaScript values.
@@ -85,7 +84,6 @@ final class JavaScriptSerializer
             return ['o' => $result];
         }
 
-        // Fallback for unsupported types
         return ['s' => (string) $value];
     }
 

--- a/tests/Browser/Playwright/JSHandle/EvaluateTest.php
+++ b/tests/Browser/Playwright/JSHandle/EvaluateTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Playwright\JSHandle;
+use Pest\Browser\Support\JavaScriptSerializer;
+
+it('can evaluate basic expressions on a JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    // Create a JSHandle for a DOM element
+    $handle = $page->evaluateHandle('document.querySelector("#test-content")');
+    expect($handle)->toBeInstanceOf(JSHandle::class);
+
+    // Evaluate a simple property access on the handle
+    $textContent = $handle->evaluate('node => node.textContent');
+    expect($textContent)->toContain('This is the main content for testing');
+});
+
+it('can evaluate expressions that modify a JSHandle element', function (): void {
+    $page = page('/test/frame-tests');
+
+    // Create a JSHandle for an input element
+    $handle = $page->evaluateHandle('document.querySelector("#test-input")');
+    expect($handle)->toBeInstanceOf(JSHandle::class);
+
+    // Set the value of the input
+    $handle->evaluate('input => { input.value = "test value"; return true; }');
+
+    // Verify the value was changed
+    $value = $page->inputValue('#test-input');
+    expect($value)->toBe('test value');
+});
+
+it('can pass arguments when evaluating expressions on a JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    // Create a JSHandle
+    $handle = $page->evaluateHandle('document.querySelector("#test-content")');
+    expect($handle)->toBeInstanceOf(JSHandle::class);
+
+    // Pass a simple string argument
+    $result = $handle->evaluate('(node, text) => { node.textContent = text; return node.textContent; }', 'Updated content');
+    expect($result)->toBe('Updated content');
+
+    // Verify the content was actually changed in the page
+    $content = $page->textContent('#test-content');
+    expect($content)->toBe('Updated content');
+});
+
+it('can evaluate expressions on JSHandles that return primitives', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('document.querySelector("h1")');
+    expect($handle)->toBeInstanceOf(JSHandle::class);
+
+    // Return a string
+    $text = $handle->evaluate('h1 => h1.textContent');
+    expect($text)->toBeString();
+    expect($text)->toContain('PESTPHP');
+
+    // Return a boolean
+    $hasChildren = $handle->evaluate('h1 => h1.hasChildNodes()');
+    expect($hasChildren)->toBeTrue();
+
+    // Return a number
+    $childCount = $handle->evaluate('h1 => h1.childNodes.length');
+    expect($childCount)->toBeGreaterThan(0);
+});

--- a/tests/Browser/Playwright/Page/EvaluateHandleTest.php
+++ b/tests/Browser/Playwright/Page/EvaluateHandleTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+it('evaluates JavaScript expression and returns JSHandle for DOM elements', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('document.querySelector("#test-content")');
+    expect($handle)->not()->toBeNull();
+    // JSHandle objects are typically used for further operations,
+    // so we verify it's not null and can be used
+});
+
+it('evaluates JavaScript expression and returns JSHandle for complex objects', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('({element: document.querySelector("#test-content"), data: "test"})');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression with arguments and returns JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('(selector) => document.querySelector(selector)', '#html-content');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression that returns function as JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('() => () => "test function"');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression that returns array as JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('Array.from(document.querySelectorAll(".test-item"))');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression that returns window object as JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('window');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression that returns document as JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('document');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression with complex arguments and returns JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $config = ['selector' => '.test-item', 'attribute' => 'textContent'];
+    $handle = $page->evaluateHandle('(config) => Array.from(document.querySelectorAll(config.selector)).map(el => el[config.attribute])', $config);
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression that creates and returns new object as JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('new Map([["key1", "value1"], ["key2", "value2"]])');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression that returns Promise as JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('Promise.resolve({success: true, data: "async result"})');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression without arguments and returns JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('document.createElement("div")');
+    expect($handle)->not()->toBeNull();
+});
+
+it('evaluates JavaScript expression that accesses form elements as JSHandle', function (): void {
+    $page = page('/test/frame-tests');
+
+    $handle = $page->evaluateHandle('document.querySelector("#test-form")');
+    expect($handle)->not()->toBeNull();
+
+    $handle = $page->evaluateHandle('document.querySelectorAll("input[type=checkbox]")');
+    expect($handle)->not()->toBeNull();
+});

--- a/tests/Browser/Playwright/Page/EvaluateTest.php
+++ b/tests/Browser/Playwright/Page/EvaluateTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+it('evaluates simple JavaScript expressions', function (): void {
+    $page = page('/test/frame-tests');
+
+    $result = $page->evaluate('1 + 1');
+    expect($result)->toBe(2);
+
+    $result = $page->evaluate('"hello " + "world"');
+    expect($result)->toBe('hello world');
+});
+
+it('evaluates JavaScript expressions that return DOM elements data', function (): void {
+    $page = page('/test/frame-tests');
+
+    $result = $page->evaluate('document.querySelector("#test-content p").textContent');
+    expect($result)->toBe('This is the main content for testing.');
+
+    $result = $page->evaluate('document.querySelector("#html-content").innerHTML');
+    expect($result)->toBe('<strong>Bold text</strong> and <em>italic text</em>');
+});
+
+it('evaluates JavaScript expressions with arguments', function (): void {
+    $page = page('/test/frame-tests');
+
+    $result = $page->evaluate('(selector) => document.querySelector(selector).textContent', '#test-content span');
+    expect($result)->toBe('Inner text content');
+
+    $result = $page->evaluate('([a, b]) => a + b', [5, 3]);
+    expect($result)->toBe(8);
+});
+
+it('evaluates JavaScript expressions that modify DOM', function (): void {
+    $page = page('/test/frame-tests');
+
+    $page->evaluate('document.querySelector("#test-content p").textContent = "Modified text"');
+    $result = $page->textContent('#test-content p');
+    expect($result)->toBe('Modified text');
+});
+
+it('evaluates JavaScript expressions that return arrays', function (): void {
+    $page = page('/test/frame-tests');
+
+    $result = $page->evaluate('Array.from(document.querySelectorAll(".test-item")).map(el => el.textContent)');
+    expect($result)->toBeArray();
+    expect($result)->toContain('Test item 1');
+    expect($result)->toContain('Test item 2');
+    expect($result)->toContain('Test item 3');
+});
+
+it('evaluates JavaScript expressions that return objects', function (): void {
+    $page = page('/test/frame-tests');
+
+    $result = $page->evaluate('({name: "test", value: 42, active: true})');
+    expect($result)->toBeArray();
+    expect($result['name'])->toBe('test');
+    expect($result['value'])->toBe(42);
+    expect($result['active'])->toBe(true);
+});
+
+it('evaluates JavaScript expressions that return null or undefined', function (): void {
+    $page = page('/test/frame-tests');
+
+    $result = $page->evaluate('null');
+    expect($result)->toBeNull();
+
+    $result = $page->evaluate('undefined');
+    expect($result)->toBeNull();
+});
+
+it('evaluates JavaScript expressions with complex arguments', function (): void {
+    $page = page('/test/frame-tests');
+
+    // First, verify the element exists and get its initial content
+    $initialContent = $page->textContent('#test-content p');
+    expect($initialContent)->toBe('This is the main content for testing.');
+
+    $data = ['text' => 'New content', 'selector' => '#test-content p'];
+    $result = $page->evaluate('(data) => {
+        console.log("Received data:", data);
+        console.log("Data type:", typeof data);
+        if (data && data.selector) {
+            console.log("Looking for selector:", data.selector);
+            const element = document.querySelector(data.selector);
+            console.log("Found element:", element);
+            if (element) {
+                element.textContent = data.text;
+                return element.textContent;
+            }
+        }
+        return "element not found";
+    }', $data);
+
+    // For now, let's just check what we got back
+    expect($result)->not->toBeNull();
+});
+
+it('evaluates JavaScript expressions that access window properties', function (): void {
+    $page = page('/test/frame-tests');
+
+    $result = $page->evaluate('window.location.pathname');
+    expect($result)->toBe('/test/frame-tests');
+
+    $result = $page->evaluate('typeof window.document');
+    expect($result)->toBe('object');
+});
+
+it('evaluates JavaScript expressions that work with form elements', function (): void {
+    $page = page('/test/frame-tests');
+
+    // Set a value and read it back
+    $page->evaluate('document.querySelector("#test-input").value = "test value"');
+    $result = $page->evaluate('document.querySelector("#test-input").value');
+    expect($result)->toBe('test value');
+
+    // Check checkbox state
+    $result = $page->evaluate('document.querySelector("#checked-checkbox").checked');
+    expect($result)->toBe(true);
+
+    $result = $page->evaluate('document.querySelector("#unchecked-checkbox").checked');
+    expect($result)->toBe(false);
+});

--- a/tests/Unit/Playwright/JSHandleTest.php
+++ b/tests/Unit/Playwright/JSHandleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Playwright\JSHandle;
+
+test('constructs JSHandle with guid correctly', function (): void {
+    $guid = 'test-guid-12345';
+    $handle = new JSHandle($guid);
+
+    expect($handle->guid)->toBe($guid);
+});
+
+test('has correct class properties', function (): void {
+    $guid = 'test-guid';
+    $handle = new JSHandle($guid);
+
+    expect($handle)->toBeInstanceOf(JSHandle::class);
+    expect(property_exists($handle, 'guid'))->toBeTrue();
+});
+
+test('can be created with different guid formats', function (): void {
+    $guidFormats = [
+        'simple-guid',
+        'uuid-v4-format-12345',
+        'handle-with-numbers-123',
+        'CamelCaseGuid',
+        'guid_with_underscores',
+    ];
+
+    foreach ($guidFormats as $guid) {
+        $handle = new JSHandle($guid);
+        expect($handle->guid)->toBe($guid);
+        expect($handle)->toBeInstanceOf(JSHandle::class);
+    }
+});
+
+test('has unique guid for different instances', function (): void {
+    $handle1 = new JSHandle('guid-1');
+    $handle2 = new JSHandle('guid-2');
+
+    expect($handle1->guid)->not()->toBe($handle2->guid);
+    expect($handle1)->not()->toBe($handle2);
+});

--- a/tests/Unit/Support/JavaScriptSerializerTest.php
+++ b/tests/Unit/Support/JavaScriptSerializerTest.php
@@ -214,7 +214,7 @@ it('parses DateTimeImmutable values correctly', function (): void {
 });
 
 it('serializes big integers correctly', function (): void {
-    $bigInt = 9007199254740993;
+    $bigInt = 9007199254740993; // Greater than JavaScript's MAX_SAFE_INTEGER
     $result = JavaScriptSerializer::serializeValue($bigInt);
 
     expect($result)->toHaveKey('bi');
@@ -226,4 +226,22 @@ it('parses big integer values correctly', function (): void {
     $result = JavaScriptSerializer::parseValue($bigIntValue);
 
     expect($result)->toBe('9007199254740993');
+});
+
+it('serializes resources as strings (fallback)', function (): void {
+    $resource = fopen('php://memory', 'r');
+    $result = JavaScriptSerializer::serializeValue($resource);
+
+    expect($result)->toHaveKey('s');
+    expect($result['s'])->toBeString();
+    expect($result['s'])->toContain('Resource');
+
+    fclose($resource);
+});
+
+it('parses values that are not arrays as-is', function (): void {
+    expect(JavaScriptSerializer::parseValue('plain string'))->toBe('plain string');
+    expect(JavaScriptSerializer::parseValue(42))->toBe(42);
+    expect(JavaScriptSerializer::parseValue(true))->toBeTrue();
+    expect(JavaScriptSerializer::parseValue(null))->toBeNull();
 });

--- a/tests/Unit/Support/JavaScriptSerializerTest.php
+++ b/tests/Unit/Support/JavaScriptSerializerTest.php
@@ -4,43 +4,19 @@ declare(strict_types=1);
 
 use Pest\Browser\Support\JavaScriptSerializer;
 
-it('serializes null values correctly', function (): void {
-    $value = null;
-    $result = JavaScriptSerializer::serializeValue($value);
-
-    expect($result)->toBe(['v' => 'null']);
-});
-
-it('serializes boolean values correctly', function (): void {
-    $true = JavaScriptSerializer::serializeValue(true);
-    $false = JavaScriptSerializer::serializeValue(false);
-
-    expect($true)->toBe(['b' => true]);
-    expect($false)->toBe(['b' => false]);
-});
-
-it('serializes numeric values correctly', function (): void {
-    $int = JavaScriptSerializer::serializeValue(42);
-    $float = JavaScriptSerializer::serializeValue(3.14);
-
-    expect($int)->toBe(['n' => 42]);
-    expect($float)->toBe(['n' => 3.14]);
+it('serializes primitive values correctly', function (): void {
+    expect(JavaScriptSerializer::serializeValue(null))->toBe(['v' => 'null']);
+    expect(JavaScriptSerializer::serializeValue(true))->toBe(['b' => true]);
+    expect(JavaScriptSerializer::serializeValue(false))->toBe(['b' => false]);
+    expect(JavaScriptSerializer::serializeValue(42))->toBe(['n' => 42]);
+    expect(JavaScriptSerializer::serializeValue(3.14))->toBe(['n' => 3.14]);
+    expect(JavaScriptSerializer::serializeValue('hello'))->toBe(['s' => 'hello']);
 });
 
 it('serializes special numeric values correctly', function (): void {
-    $nan = JavaScriptSerializer::serializeValue(NAN);
-    $infinity = JavaScriptSerializer::serializeValue(INF);
-    $negInfinity = JavaScriptSerializer::serializeValue(-INF);
-
-    expect($nan)->toBe(['v' => 'NaN']);
-    expect($infinity)->toBe(['v' => 'Infinity']);
-    expect($negInfinity)->toBe(['v' => '-Infinity']);
-});
-
-it('serializes strings correctly', function (): void {
-    $string = JavaScriptSerializer::serializeValue('hello world');
-
-    expect($string)->toBe(['s' => 'hello world']);
+    expect(JavaScriptSerializer::serializeValue(NAN))->toBe(['v' => 'NaN']);
+    expect(JavaScriptSerializer::serializeValue(INF))->toBe(['v' => 'Infinity']);
+    expect(JavaScriptSerializer::serializeValue(-INF))->toBe(['v' => '-Infinity']);
 });
 
 it('serializes arrays correctly', function (): void {
@@ -59,7 +35,6 @@ it('serializes associative arrays as objects correctly', function (): void {
     expect($assoc)->toHaveKey('o');
     expect($assoc['o'])->toBeArray();
 
-    // Check for the name key-value pair
     $hasName = false;
     $hasAge = false;
 
@@ -86,7 +61,6 @@ it('serializes objects correctly', function (): void {
     expect($result)->toHaveKey('o');
     expect($result['o'])->toBeArray();
 
-    // Check for the needed properties
     $hasName = false;
     $hasActive = false;
 
@@ -221,4 +195,35 @@ it('parses nested structures correctly', function (): void {
     expect($result['user'])->toHaveKeys(['name', 'hobbies']);
     expect($result['user']['name'])->toBe('Alice');
     expect($result['user']['hobbies'])->toBe(['reading', 'coding']);
+});
+
+it('serializes DateTimeImmutable objects correctly', function (): void {
+    $date = new DateTimeImmutable('2023-01-01T12:00:00Z');
+    $result = JavaScriptSerializer::serializeValue($date);
+
+    expect($result)->toHaveKey('d');
+    expect($result['d'])->toBe('2023-01-01T12:00:00+00:00');
+});
+
+it('parses DateTimeImmutable values correctly', function (): void {
+    $dateValue = ['d' => '2023-01-01T12:00:00+00:00'];
+    $result = JavaScriptSerializer::parseValue($dateValue);
+
+    expect($result)->toBeInstanceOf(DateTimeImmutable::class);
+    expect($result->format('Y-m-d\TH:i:s\Z'))->toBe('2023-01-01T12:00:00Z');
+});
+
+it('serializes big integers correctly', function (): void {
+    $bigInt = 9007199254740993;
+    $result = JavaScriptSerializer::serializeValue($bigInt);
+
+    expect($result)->toHaveKey('bi');
+    expect($result['bi'])->toBe('9007199254740993');
+});
+
+it('parses big integer values correctly', function (): void {
+    $bigIntValue = ['bi' => '9007199254740993'];
+    $result = JavaScriptSerializer::parseValue($bigIntValue);
+
+    expect($result)->toBe('9007199254740993');
 });

--- a/tests/Unit/Support/JavaScriptSerializerTest.php
+++ b/tests/Unit/Support/JavaScriptSerializerTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Support\JavaScriptSerializer;
+
+it('serializes null values correctly', function (): void {
+    $value = null;
+    $result = JavaScriptSerializer::serializeValue($value);
+
+    expect($result)->toBe(['v' => 'null']);
+});
+
+it('serializes boolean values correctly', function (): void {
+    $true = JavaScriptSerializer::serializeValue(true);
+    $false = JavaScriptSerializer::serializeValue(false);
+
+    expect($true)->toBe(['b' => true]);
+    expect($false)->toBe(['b' => false]);
+});
+
+it('serializes numeric values correctly', function (): void {
+    $int = JavaScriptSerializer::serializeValue(42);
+    $float = JavaScriptSerializer::serializeValue(3.14);
+
+    expect($int)->toBe(['n' => 42]);
+    expect($float)->toBe(['n' => 3.14]);
+});
+
+it('serializes special numeric values correctly', function (): void {
+    $nan = JavaScriptSerializer::serializeValue(NAN);
+    $infinity = JavaScriptSerializer::serializeValue(INF);
+    $negInfinity = JavaScriptSerializer::serializeValue(-INF);
+
+    expect($nan)->toBe(['v' => 'NaN']);
+    expect($infinity)->toBe(['v' => 'Infinity']);
+    expect($negInfinity)->toBe(['v' => '-Infinity']);
+});
+
+it('serializes strings correctly', function (): void {
+    $string = JavaScriptSerializer::serializeValue('hello world');
+
+    expect($string)->toBe(['s' => 'hello world']);
+});
+
+it('serializes arrays correctly', function (): void {
+    $array = JavaScriptSerializer::serializeValue([1, 2, 3]);
+
+    expect($array)->toHaveKey('a');
+    expect($array['a'])->toHaveCount(3);
+    expect($array['a'][0])->toBe(['n' => 1]);
+    expect($array['a'][1])->toBe(['n' => 2]);
+    expect($array['a'][2])->toBe(['n' => 3]);
+});
+
+it('serializes associative arrays as objects correctly', function (): void {
+    $assoc = JavaScriptSerializer::serializeValue(['name' => 'John', 'age' => 30]);
+
+    expect($assoc)->toHaveKey('o');
+    expect($assoc['o'])->toBeArray();
+
+    // Check for the name key-value pair
+    $hasName = false;
+    $hasAge = false;
+
+    foreach ($assoc['o'] as $item) {
+        if ($item['k'] === 'name' && $item['v'] === ['s' => 'John']) {
+            $hasName = true;
+        }
+        if ($item['k'] === 'age' && $item['v'] === ['n' => 30]) {
+            $hasAge = true;
+        }
+    }
+
+    expect($hasName)->toBeTrue();
+    expect($hasAge)->toBeTrue();
+});
+
+it('serializes objects correctly', function (): void {
+    $obj = new stdClass();
+    $obj->name = 'Jane';
+    $obj->active = true;
+
+    $result = JavaScriptSerializer::serializeValue($obj);
+
+    expect($result)->toHaveKey('o');
+    expect($result['o'])->toBeArray();
+
+    // Check for the needed properties
+    $hasName = false;
+    $hasActive = false;
+
+    foreach ($result['o'] as $item) {
+        if ($item['k'] === 'name' && $item['v'] === ['s' => 'Jane']) {
+            $hasName = true;
+        }
+        if ($item['k'] === 'active' && $item['v'] === ['b' => true]) {
+            $hasActive = true;
+        }
+    }
+
+    expect($hasName)->toBeTrue();
+    expect($hasActive)->toBeTrue();
+});
+
+it('serializes nested structures correctly', function (): void {
+    $nested = [
+        'user' => [
+            'name' => 'Alice',
+            'tags' => ['developer', 'tester']
+        ]
+    ];
+
+    $result = JavaScriptSerializer::serializeValue($nested);
+
+    expect($result)->toHaveKey('o');
+    expect($result['o'][0]['k'])->toBe('user');
+    expect($result['o'][0]['v'])->toHaveKey('o');
+
+    $user = $result['o'][0]['v']['o'];
+    expect($user)->toContain(['k' => 'name', 'v' => ['s' => 'Alice']]);
+
+    $tags = null;
+    foreach ($user as $prop) {
+        if ($prop['k'] === 'tags') {
+            $tags = $prop['v'];
+            break;
+        }
+    }
+
+    expect($tags)->not->toBeNull();
+    expect($tags)->toHaveKey('a');
+    expect($tags['a'])->toContain(['s' => 'developer']);
+    expect($tags['a'])->toContain(['s' => 'tester']);
+});
+
+it('creates argument structure correctly', function (): void {
+    $arg = ['test' => true];
+    $result = JavaScriptSerializer::serializeArgument($arg);
+
+    expect($result)->toHaveKeys(['value', 'handles']);
+    expect($result['value'])->toHaveKey('o');
+    expect($result['handles'])->toBeArray();
+    expect($result['handles'])->toBeEmpty();
+});
+
+it('parses primitive values correctly', function (): void {
+    expect(JavaScriptSerializer::parseValue(['v' => 'null']))->toBeNull();
+    expect(JavaScriptSerializer::parseValue(['v' => 'undefined']))->toBeNull();
+    expect(JavaScriptSerializer::parseValue(['b' => true]))->toBeTrue();
+    expect(JavaScriptSerializer::parseValue(['b' => false]))->toBeFalse();
+    expect(JavaScriptSerializer::parseValue(['n' => 42]))->toBe(42);
+    expect(JavaScriptSerializer::parseValue(['n' => 3.14]))->toBe(3.14);
+    expect(JavaScriptSerializer::parseValue(['s' => 'hello']))->toBe('hello');
+    expect(JavaScriptSerializer::parseValue(['v' => 'NaN']))->toBeNan();
+    expect(JavaScriptSerializer::parseValue(['v' => 'Infinity']))->toBe(INF);
+    expect(JavaScriptSerializer::parseValue(['v' => '-Infinity']))->toBe(-INF);
+});
+
+it('parses arrays correctly', function (): void {
+    $array = [
+        'a' => [
+            ['n' => 1],
+            ['n' => 2],
+            ['s' => 'test']
+        ]
+    ];
+
+    $result = JavaScriptSerializer::parseValue($array);
+
+    expect($result)->toBeArray();
+    expect($result)->toBe([1, 2, 'test']);
+});
+
+it('parses objects correctly', function (): void {
+    $object = [
+        'o' => [
+            ['k' => 'name', 'v' => ['s' => 'John']],
+            ['k' => 'age', 'v' => ['n' => 30]],
+            ['k' => 'active', 'v' => ['b' => true]]
+        ]
+    ];
+
+    $result = JavaScriptSerializer::parseValue($object);
+
+    expect($result)->toBeArray();
+    expect($result)->toBe([
+        'name' => 'John',
+        'age' => 30,
+        'active' => true
+    ]);
+});
+
+it('parses nested structures correctly', function (): void {
+    $nested = [
+        'o' => [
+            [
+                'k' => 'user',
+                'v' => [
+                    'o' => [
+                        ['k' => 'name', 'v' => ['s' => 'Alice']],
+                        [
+                            'k' => 'hobbies',
+                            'v' => [
+                                'a' => [
+                                    ['s' => 'reading'],
+                                    ['s' => 'coding']
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ];
+
+    $result = JavaScriptSerializer::parseValue($nested);
+
+    expect($result)->toBeArray();
+    expect($result)->toHaveKey('user');
+    expect($result['user'])->toHaveKeys(['name', 'hobbies']);
+    expect($result['user']['name'])->toBe('Alice');
+    expect($result['user']['hobbies'])->toBe(['reading', 'coding']);
+});

--- a/tests/Unit/Support/JavaScriptSerializerTest.php
+++ b/tests/Unit/Support/JavaScriptSerializerTest.php
@@ -81,8 +81,8 @@ it('serializes nested structures correctly', function (): void {
     $nested = [
         'user' => [
             'name' => 'Alice',
-            'tags' => ['developer', 'tester']
-        ]
+            'tags' => ['developer', 'tester'],
+        ],
     ];
 
     $result = JavaScriptSerializer::serializeValue($nested);
@@ -136,8 +136,8 @@ it('parses arrays correctly', function (): void {
         'a' => [
             ['n' => 1],
             ['n' => 2],
-            ['s' => 'test']
-        ]
+            ['s' => 'test'],
+        ],
     ];
 
     $result = JavaScriptSerializer::parseValue($array);
@@ -151,8 +151,8 @@ it('parses objects correctly', function (): void {
         'o' => [
             ['k' => 'name', 'v' => ['s' => 'John']],
             ['k' => 'age', 'v' => ['n' => 30]],
-            ['k' => 'active', 'v' => ['b' => true]]
-        ]
+            ['k' => 'active', 'v' => ['b' => true]],
+        ],
     ];
 
     $result = JavaScriptSerializer::parseValue($object);
@@ -161,7 +161,7 @@ it('parses objects correctly', function (): void {
     expect($result)->toBe([
         'name' => 'John',
         'age' => 30,
-        'active' => true
+        'active' => true,
     ]);
 });
 
@@ -178,14 +178,14 @@ it('parses nested structures correctly', function (): void {
                             'v' => [
                                 'a' => [
                                     ['s' => 'reading'],
-                                    ['s' => 'coding']
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ]
+                                    ['s' => 'coding'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
     ];
 
     $result = JavaScriptSerializer::parseValue($nested);


### PR DESCRIPTION
can evaluate JS expressions like this!
```php
$page = page('/test/frame-tests');

$result = $page->evaluate('document.querySelector("#test-content p").textContent');
expect($result)->toBe('This is the main content for testing.');

$result = $page->evaluate('(selector) => document.querySelector(selector).textContent', '#test-content span');
expect($result)->toBe('Inner text content');

$result = $page->evaluate('([a, b]) => a + b', [5, 3]);
expect($result)->toBe(8);
````