### PR TITLE
add option to run a browser with ui

### DIFF
--- a/src/Playwright/BrowserType.php
+++ b/src/Playwright/BrowserType.php
@@ -36,7 +36,7 @@ final class BrowserType
         $response = Client::instance()->execute(
             $this->guid,
             'launch',
-            ['browserType' => $this->name]
+            ['headless' => Playwright::isHeadless(), 'browserType' => $this->name]
         );
 
         /** @var array{result: array{browser: array{guid: string|null}}} $message */

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -16,6 +16,18 @@ final class Playwright
      */
     private static array $browserTypes = [];
 
+    private static bool $headless = true;
+
+    public static function withUi(): void
+    {
+        self::$headless = false;
+    }
+
+    public static function isHeadless(): bool
+    {
+        return self::$headless;
+    }
+
     /**
      * Get chromium browser type
      */


### PR DESCRIPTION
`Playwright::withUi()`

first api was `page(withUi: true)` but then it would be true for all instances because we launch 1 browser and inside multiple isolated contexts