### PR TITLE
ensure pages are closed

### DIFF
--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -661,6 +661,7 @@ final class Page
     private function isPageLevelOperation(string $method): bool
     {
         $pageLevelOperations = [
+            'close',
             'Network.setExtraHTTPHeaders',
             'goForward',
             'goBack',
@@ -671,5 +672,10 @@ final class Page
         ];
 
         return in_array($method, $pageLevelOperations, true);
+    }
+
+    public function __destruct()
+    {
+        $this->processVoidResponse($this->sendMessage('close'));
     }
 }


### PR DESCRIPTION
If you hardcode headless to false in src/Playwright/BrowserType.php
```php
        $response = Client::instance()->execute(
            $this->guid,
            'launch',
            ['browserType' => $this->name, 'headless' => false]
        );
```
and run `pest --parallel --processes=2`

you will see how each tests opens a new window but will not close it
this PR fixes it