### PR TITLE
assertRoute($name, $parameters = [])

### DIFF
--- a/src/Api/Concerns/MakesUrlAssertions.php
+++ b/src/Api/Concerns/MakesUrlAssertions.php
@@ -147,6 +147,14 @@ trait MakesUrlAssertions
     }
 
     /**
+     * Assert that the current URL path matches the given route.
+     */
+    public function assertRoute(string $route, array $parameters = []): Webpage
+    {
+        return $this->assertPathIs(route($route, $parameters, false));
+    }
+
+    /**
      * Assert that the current URL path ends with the given path.
      */
     public function assertPathEndsWith(string $path): Webpage

--- a/tests/Browser/Webpage/AssertUrlTest.php
+++ b/tests/Browser/Webpage/AssertUrlTest.php
@@ -98,6 +98,39 @@ it('may assert URL path matches expected path', function (): void {
     $page->assertPathIs('/test-path');
 });
 
+it('may assert URL path matches a route', function (): void {
+    Route::name('test.path')->get('/test-path', fn (): string => 'Test Path Page');
+
+    $page = visit('/test-path');
+
+    $page->assertRoute('test.path');
+});
+
+it('may fail when asserting URL path matches a route but it does not', function (): void {
+    Route::name('test.path')->get('/test-path', fn (): string => 'Test Path Page');
+
+    $page = visit('/wrong-path');
+
+    $page->assertRoute('test.path');
+})->throws(ExpectationFailedException::class);;
+
+it('may assert URL path matches a route with paramters', function (): void {
+    Route::name('test.path')->get('/test-path/{slug}', fn ($slug): string => 'Test Path Page');
+
+    $page = visit('/test-path/example');
+
+    $page->assertRoute('test.path', ['slug' => 'example']);
+});
+
+it('may fail when asserting URL path matches a route but it has wrong parameters', function (): void {
+    Route::name('test.path')->get('/test-path/{slug}', fn ($slug): string => 'Test Path Page');
+
+    $page = visit('/test-path/wrong-slug');
+
+    $page->assertRoute('test.path', ['slug' => 'example']);
+})->throws(ExpectationFailedException::class);;
+
+
 it('may fail when asserting URL path matches but it does not', function (): void {
     Route::get('/test-path', fn (): string => 'Test Path Page');
 


### PR DESCRIPTION
Introduces a new convenience method for asserting against route names.

## Why?
I generally like to write tests against route names instead of exact paths. Since `route('home')` will include the host name, you need to put `route('home', [], false)`. This is not a big deal, but this little helper makes it a bit easier.