### PR TITLE
Add support for extending browser testing

### DIFF
--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -21,6 +21,8 @@ final class PendingAwaitablePage
      */
     private ?AwaitableWebpage $waitablePage = null;
 
+    public static array $initScripts = [];
+
     /**
      * Creates a new pending awaitable page instance.
      *
@@ -121,6 +123,9 @@ final class PendingAwaitablePage
         ]);
 
         $context->addInitScript(InitScript::get());
+        foreach (static::$initScripts as $script) {
+            $context->addInitScript($script);
+        }
 
         $url = ComputeUrl::from($this->url);
 

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -16,12 +16,12 @@ use Pest\Browser\Support\ComputeUrl;
  */
 final class PendingAwaitablePage
 {
+    public static array $initScripts = [];
+
     /**
      * The webpage instance that will be returned when the page is visited.
      */
     private ?AwaitableWebpage $waitablePage = null;
-
-    public static array $initScripts = [];
 
     /**
      * Creates a new pending awaitable page instance.
@@ -123,7 +123,7 @@ final class PendingAwaitablePage
         ]);
 
         $context->addInitScript(InitScript::get());
-        foreach (static::$initScripts as $script) {
+        foreach (self::$initScripts as $script) {
             $context->addInitScript($script);
         }
 

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -33,6 +33,26 @@ final class Webpage
     }
 
     /**
+     * Dynamically handle calls to the class.
+     */
+    public function __call(string $name, array $arguments)
+    {
+        if (! self::hasExtend($name)) {
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.', self::class, $name
+            ));
+        }
+
+        $macro = self::$extends[$name];
+
+        if ($macro instanceof Closure) {
+            $macro = $macro->bindTo($this, self::class);
+        }
+
+        return $macro(...$arguments);
+    }
+
+    /**
      * Dumps the current page's content and stops the execution.
      */
     public function dd(): never
@@ -112,25 +132,5 @@ final class Webpage
     private function guessLocator(string $selector, ?string $value = null): Locator
     {
         return (new GuessLocator($this->page))->for($selector, $value);
-    }
-
-    /**
-     * Dynamically handle calls to the class.
-     */
-    public function __call(string $name, array $arguments)
-    {
-        if (! static::hasExtend($name)) {
-            throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $name
-            ));
-        }
-
-        $macro = static::$extends[$name];
-
-        if ($macro instanceof Closure) {
-            $macro = $macro->bindTo($this, static::class);
-        }
-
-        return $macro(...$arguments);
     }
 }

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Api;
 
-use Illuminate\Support\Traits\Macroable;
-use Pest\Browser\Execution;
+use BadMethodCallException;
+use Closure;
 use Pest\Browser\Playwright\Locator;
 use Pest\Browser\Playwright\Page;
 use Pest\Browser\Support\GuessLocator;
+use Pest\Concerns\Extendable;
 
 final class Webpage
 {
@@ -19,7 +20,7 @@ final class Webpage
         Concerns\MakesElementAssertions,
         Concerns\MakesScreenshotAssertions,
         Concerns\MakesUrlAssertions,
-        Macroable;
+        Extendable;
 
     /**
      * The page instance.
@@ -111,5 +112,25 @@ final class Webpage
     private function guessLocator(string $selector, ?string $value = null): Locator
     {
         return (new GuessLocator($this->page))->for($selector, $value);
+    }
+
+    /**
+     * Dynamically handle calls to the class.
+     */
+    public function __call(string $name, array $arguments)
+    {
+        if (! static::hasExtend($name)) {
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.', static::class, $name
+            ));
+        }
+
+        $macro = static::$extends[$name];
+
+        if ($macro instanceof Closure) {
+            $macro = $macro->bindTo($this, static::class);
+        }
+
+        return $macro(...$arguments);
     }
 }

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Api;
 
+use Illuminate\Support\Traits\Macroable;
 use Pest\Browser\Execution;
 use Pest\Browser\Playwright\Locator;
 use Pest\Browser\Playwright\Page;
 use Pest\Browser\Support\GuessLocator;
 
-final readonly class Webpage
+final class Webpage
 {
     use Concerns\InteractsWithElements,
         Concerns\InteractsWithTab,
@@ -17,7 +18,8 @@ final readonly class Webpage
         Concerns\MakesConsoleAssertions,
         Concerns\MakesElementAssertions,
         Concerns\MakesScreenshotAssertions,
-        Concerns\MakesUrlAssertions;
+        Concerns\MakesUrlAssertions,
+        Macroable;
 
     /**
      * The page instance.


### PR DESCRIPTION
This allows us to add custom assertions to the browser testing and custom scripts to monitor for. 

For example for a accessibility plugin I am working on, I need support for adding additional init scripts and of course I want a custom assertion on top of it 👀 