### PR TITLE
fix: update filename arg to match documentation

### DIFF
--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -68,9 +68,9 @@ final readonly class Webpage
     /**
      * Performs a screenshot of the current page and saves it to the given path.
      */
-    public function screenshot(bool $fullPage = true, ?string $name = null): self
+    public function screenshot(bool $fullPage = true, ?string $filename = null): self
     {
-        $name = is_string($name) ? $name : date('Y_m_d_H_i_s_u');
+        $name = is_string($filename) ? $filename : date('Y_m_d_H_i_s_u');
 
         $this->page->screenshot($fullPage, $name);
 


### PR DESCRIPTION
## Bug Fix

## Description
The named argument `name` for the ```screenshot()``` method does not align with the argument name described in the documentation (`filename`). Updated the named argument to match with the documentation.