### PR TITLE
Rename `$name` to `$filename` to match docs

### DIFF
--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -68,11 +68,11 @@ final readonly class Webpage
     /**
      * Performs a screenshot of the current page and saves it to the given path.
      */
-    public function screenshot(bool $fullPage = true, ?string $name = null): self
+    public function screenshot(bool $fullPage = true, ?string $filename = null): self
     {
-        $name = is_string($name) ? $name : date('Y_m_d_H_i_s_u');
+        $filename = is_string($filename) ? $filename : date('Y_m_d_H_i_s_u');
 
-        $this->page->screenshot($fullPage, $name);
+        $this->page->screenshot($fullPage, $filename);
 
         return $this;
     }


### PR DESCRIPTION
The [documentation](https://v4.pestphp.com/docs/browser-testing) says that we can change the name of the screenshot by passing the `filename` parameter to the screenshot method:

<img width="699" height="232" alt="CleanShot 2025-08-21 at 11  26 54" src="https://github.com/user-attachments/assets/3d231e72-e479-40a2-bf45-0d3f3bed2508" />

However, when I add the `filename` parameter, I get the following error:

<img width="592" height="105" alt="CleanShot 2025-08-21 at 11  29 15 2" src="https://github.com/user-attachments/assets/b57c7aaa-d4f2-44d7-bb5b-14061380e7cd" />

This PR renames the parameter to match the docs.