### PR TITLE
Add hover interaction

### DIFF
--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -76,6 +76,16 @@ trait InteractsWithElements
     }
 
     /**
+     * Hovers over the element matching the given selector.
+     */
+    public function hover(string $selector): Webpage
+    {
+        $this->guessLocator($selector)->hover();
+
+        return $this;
+    }
+
+    /**
      * Select the given value in the given field.
      *
      * @param  array<int, string|int>|string|int  $option

--- a/tests/Browser/Webpage/HoverTest.php
+++ b/tests/Browser/Webpage/HoverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('may hover an element', function (): void {
+    Route::get('/', fn (): string => '
+        <style>
+            #after {
+            display: none;
+            }
+            #switch-text:hover #before {
+            display: none;
+            }
+            #switch-text:hover #after {
+            display: inline;
+            }
+        </style>
+        <div id="switch-text">
+            <span id="before">before</span>
+            <span id="after">after</span>
+        </div>
+    ');
+    $page = visit('/');
+    $page->assertUrlIs(url('/'));
+    $page->assertSee('before');
+    $page->assertDontSee('after');
+    $page->hover('#switch-text');
+    $page->assertSee('after');
+    $page->assertDontSee('before');
+});


### PR DESCRIPTION
## What's Changed
This PR adds hover interaction via $page->hover('').

### Problem
I have a navigation that expands on mouseover to display all available options, such as logout. Without mouseover/hover functionality, clicking these hidden elements is not effective.

```PHP
  $page->click('#logout') // Fails because element is hidden without hovering the navigation
      ->assertSee('Sign in');
```

### Solution

I've added the hover interaction that simply uses the existing ->hover functionality from playwright, which is already part of the package, but was not usable.

```PHP
    $page->hover('#navigation')
        ->click('#logout') // Works because element becomes visible after navigation is hovered
        ->assertSee('Sign in');
```