### PR TITLE
add ability to change userAgent per test

### DIFF
--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -96,6 +96,17 @@ final class PendingAwaitablePage
     }
 
     /**
+     * Sets the userAgent for the page.
+     */
+    public function withUserAgent(string $userAgent): self
+    {
+        return new self($this->browserType, $this->device, $this->url, [
+            'userAgent' => $userAgent,
+            ...$this->options,
+        ]);
+    }
+
+    /**
      * Sets the timezone for the page.
      */
     public function withTimezone(string $timezone): self

--- a/tests/Browser/Visit/SingleUrl.php
+++ b/tests/Browser/Visit/SingleUrl.php
@@ -95,6 +95,24 @@ it('may visit a page with custom locale and timezone', function (): void {
     expect($timezone)->toBe('Europe/Paris');
 });
 
+it('may visit a page with a custom userAgent', function (): void {
+    Route::get('/', fn (): string => '
+        <html>
+        <head></head>
+        <body>
+            <h1>User Agent Test</h1>
+        </body>
+        </html>
+    ');
+
+    $page = visit('/')
+        ->withUserAgent('Pest-Browser');
+
+    $userAgent = $page->script('navigator.userAgent');
+    expect($userAgent)->toBe('Pest-Browser');
+
+});
+
 it('may visit external URLs', function (): void {
     $page = visit('https://laravel.com');
 

--- a/tests/Browser/Visit/SingleUrl.php
+++ b/tests/Browser/Visit/SingleUrl.php
@@ -110,7 +110,6 @@ it('may visit a page with a custom userAgent', function (): void {
 
     $userAgent = $page->script('navigator.userAgent');
     expect($userAgent)->toBe('Pest-Browser');
-
 });
 
 it('may visit external URLs', function (): void {


### PR DESCRIPTION
Would be nice to change user agent per test if needed, since playwright gives us the ability.  Same as withLocale, withTimezone etc.

Will do another PR to set it as an overall option similar to headed maybe 🤔 as would be nice.

See playwright setting: https://playwright.dev/docs/api/class-testoptions#test-options-user-agent
