### PR TITLE
userAgent configuration setting

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -86,7 +86,7 @@ final readonly class Configuration
     }
 
     /**
-     * Defaults the browsers userAgent.
+     * Sets the browsers userAgent.
      */
     public function userAgent(string $userAgent): self
     {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -85,6 +85,9 @@ final readonly class Configuration
         return $this;
     }
 
+    /**
+     * Defaults the browsers userAgent.
+     */
     public function userAgent(string $userAgent): self
     {
         Playwright::setUserAgent($userAgent);

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -85,6 +85,13 @@ final readonly class Configuration
         return $this;
     }
 
+    public function userAgent(string $userAgent): self
+    {
+        Playwright::setUserAgent($userAgent);
+
+        return $this;
+    }
+
     /**
      * Enables debug mode for assertions.
      */

--- a/src/Playwright/BrowserFactory.php
+++ b/src/Playwright/BrowserFactory.php
@@ -50,7 +50,7 @@ final class BrowserFactory
             'bypassCSP' => true,
         ];
 
-        if($this->userAgent !== null) {
+        if ($this->userAgent !== null) {
             $defaultOptions['userAgent'] = $this->userAgent;
         }
 

--- a/src/Playwright/BrowserFactory.php
+++ b/src/Playwright/BrowserFactory.php
@@ -43,16 +43,21 @@ final class BrowserFactory
             return $this->browser;
         }
 
+        $defaultOptions = [
+            'browserType' => $this->name,
+            'headless' => $this->headless,
+            'ignoreHttpsErrors' => true,
+            'bypassCSP' => true,
+        ];
+
+        if($this->userAgent !== null) {
+            $defaultOptions['userAgent'] = $this->userAgent;
+        }
+
         $response = Client::instance()->execute(
             $this->guid,
             'launch',
-            [
-                'browserType' => $this->name,
-                'headless' => $this->headless,
-                'ignoreHttpsErrors' => true,
-                'bypassCSP' => true,
-                ...($this->userAgent !== null ? ['userAgent' => $this->userAgent] : []),
-            ],
+            $defaultOptions,
         );
 
         /** @var array{result: array{browser: array{guid: string|null}}} $message */

--- a/src/Playwright/BrowserFactory.php
+++ b/src/Playwright/BrowserFactory.php
@@ -21,6 +21,7 @@ final class BrowserFactory
         private readonly string $guid,
         private readonly string $name,
         private readonly bool $headless,
+        private readonly ?string $userAgent = null,
     ) {
         //
     }
@@ -50,6 +51,7 @@ final class BrowserFactory
                 'headless' => $this->headless,
                 'ignoreHttpsErrors' => true,
                 'bypassCSP' => true,
+                ...($this->userAgent !== null ? ['userAgent' => $this->userAgent] : []),
             ],
         );
 

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -49,6 +49,9 @@ final class Playwright
      */
     private static int $timeout = 5_000;
 
+    /**
+     * The default userAgent.
+     */
     private static ?string $userAgent = null;
 
     /**
@@ -123,6 +126,9 @@ final class Playwright
         return self::$timeout;
     }
 
+    /**
+     * Set the default userAgent.
+     */
     public static function setUserAgent(string $userAgent): void
     {
         self::$userAgent = $userAgent;

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -49,6 +49,8 @@ final class Playwright
      */
     private static int $timeout = 5_000;
 
+    private static ?string $userAgent = null;
+
     /**
      * Get a browser factory for the given browser type.
      */
@@ -119,6 +121,11 @@ final class Playwright
     public static function timeout(): int
     {
         return self::$timeout;
+    }
+
+    public static function setUserAgent(string $userAgent): void
+    {
+        self::$userAgent = $userAgent;
     }
 
     /**
@@ -238,6 +245,7 @@ final class Playwright
                     $message['params']['guid'],
                     $name,
                     self::$headless,
+                    self::$userAgent
                 );
             }
         }


### PR DESCRIPTION
Adds the ability to use `pest()->browser()->userAgent('...');` which then sets the userAgent for all tests.  Same as headless etc.

Thought it would be cool to have the ability to set it overall.