### PR TITLE
Adding support for Geolocation emulation

### DIFF
--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -107,6 +107,18 @@ final class PendingAwaitablePage
     }
 
     /**
+     * Sets the geolocation for the page.
+     */
+    public function geolocation(float $latitude, float $longitude): self
+    {
+        return new self($this->browserType, $this->device, $this->url, [
+            'geolocation' => ['latitude' => $latitude, 'longitude' => $longitude],
+            'permissions' => ['geolocation'],
+            ...$this->options,
+        ]);
+    }
+
+    /**
      * Creates the webpage instance.
      */
     private function createAwaitablePage(): AwaitableWebpage

--- a/tests/Browser/Visit/GeolocationTest.php
+++ b/tests/Browser/Visit/GeolocationTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 
-test('can set geolocation', function () {
+test('can set geolocation', function (): void {
     Route::get('/', fn (): string => '
         <html>
         <head></head>

--- a/tests/Browser/Visit/GeolocationTest.php
+++ b/tests/Browser/Visit/GeolocationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+test('can set geolocation', function () {
+    Route::get('/', fn (): string => '
+        <html>
+        <head></head>
+        <body>
+            <div>Location:</div>
+            <div id="coordinates">
+                <span id="latitude">Waiting...</span>
+                <span id="longitude">Waiting...</span>
+            </div>
+            <script>
+                navigator.geolocation.getCurrentPosition(function(position) {
+                    document.getElementById("latitude").textContent = position.coords.latitude;
+                    document.getElementById("longitude").textContent = position.coords.longitude;
+                });
+            </script>
+        </body>
+        </html>
+    ');
+
+    $latitude = 51.5074;
+    $longitude = -0.1278;
+
+    visit('/')
+        ->geolocation($latitude, $longitude)
+        ->assertSeeIn('#latitude', (string) $latitude)
+        ->assertSeeIn('#longitude', (string) $longitude);
+});

--- a/tests/Browser/Visit/GeolocationTest.php
+++ b/tests/Browser/Visit/GeolocationTest.php
@@ -30,5 +30,6 @@ test('can set geolocation', function () {
     visit('/')
         ->geolocation($latitude, $longitude)
         ->assertSeeIn('#latitude', (string) $latitude)
-        ->assertSeeIn('#longitude', (string) $longitude);
+        ->assertSeeIn('#longitude', (string) $longitude)
+        ->assertDontSee('Waiting...');
 });

--- a/tests/Browser/Webpage/HoverTest.php
+++ b/tests/Browser/Webpage/HoverTest.php
@@ -30,4 +30,3 @@ it('may hover an element', function (): void {
     $page->assertSee('after');
     $page->assertDontSee('before');
 });
-

--- a/tests/Browser/Webpage/HoverTest.php
+++ b/tests/Browser/Webpage/HoverTest.php
@@ -30,3 +30,4 @@ it('may hover an element', function (): void {
     $page->assertSee('after');
     $page->assertDontSee('before');
 });
+


### PR DESCRIPTION
## Problem

I have a form that requires GPS coordinates be fetched and included, using JavaScript's getCurrentPosition API.

## Proposed solution

As described in the [Playwright docs](https://playwright.dev/docs/emulation#geolocation), this PR allows you to chain a `->geolocation(1.2345, 6.78910)` call in your visit which will set the testing browser's location to those coordinates.

Example:
```php
visit('/')
    ->geolocation(51.5076, 1.1124)
    ->assertSee(...)
```

## Notes

If this PR is accepted, https://github.com/pestphp/docs/pull/322 will update the docs to reflect these proposed changes