### PR TITLE
chore: pin livewire to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "ext-pcntl": "*",
         "ext-posix": "*",
-        "livewire/livewire": "dev-main",
+        "livewire/livewire": "^v3.0",
         "nunomaduro/collision": "^8.8.2",
         "orchestra/testbench": "^10.6.0",
         "pestphp/pest-dev-tools": "^4.0.0",


### PR DESCRIPTION
This PR pins Livewire to ^v3.0 to make sure tests don't fail unexpectedly. Especially since Caleb is actively working on v4.

E.g. [here](https://github.com/pestphp/pest-plugin-browser/actions/runs/17191957362/job/48768761501):

```bash
FAILED  Tests\Browser\Visit\Livewire > it may visit a component      Error   
  Class "Facades\Livewire\Features\SupportFileUploads\GenerateSignedUploadUrl" not found

  at vendor/livewire/livewire/src/Features/SupportFileUploads/SupportFileUploads.php:16
     12▕     static function provide()
     13▕     {
     14▕         if (app()->runningUnitTests()) {
     15▕             // Don't actually generate S3 signedUrls during testing.
  ➜  16▕             GenerateSignedUploadUrlFacade::swap(new class extends GenerateSignedUploadUrl {
     17▕                 public function forS3($file, $visibility = '') { return []; }
     18▕             });
     19▕         }
     20▕
```
