### PR TITLE
Correct value() docblock and add getPlaywrightPage() accessor

### DIFF
--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -96,7 +96,15 @@ final readonly class Webpage
     }
 
     /**
-     * Gets the page instance.
+     * Gets the Playwright page instance.
+     */
+    public function getPlaywrightPage(): Page
+    {
+        return $this->page;
+    }
+
+    /**
+     * Gets input value.
      */
     public function value(string $selector): string
     {


### PR DESCRIPTION
Corrected the value() docblock to reflect the method's purpose.

Added a getPlaywrightPage() method to expose the underlying Playwright Page instance, since the docblock on the value() method suggests it either used to be there or was supposed to be there.

The method is intentionally called getPlaywrightPage() instead of page() to avoid confusion with Pest’s own WebPage instance (avoids $page->page() in tests).