### PR TITLE
feat: adds ability to test iframes

### DIFF
--- a/src/Api/Concerns/InteractsWithFrames.php
+++ b/src/Api/Concerns/InteractsWithFrames.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Pest\Browser\Api\Webpage;
+use Pest\Browser\Playwright\Page;
+use RuntimeException;
+
+/**
+ * @mixin Webpage
+ */
+trait InteractsWithFrames
+{
+    public function withinFrame(string $selector, callable $callback): Webpage
+    {
+        $this->page->waitForLoadState('networkidle');
+
+        $iframeLocator = $this->guessLocator($selector)->frameLocator($selector);
+
+        $iframeLocator->waitFor(['state' => 'attached']);
+
+        $contentFrameObj = $iframeLocator->contentFrame();
+
+        if ($contentFrameObj !== null) {
+            assert(
+                property_exists($contentFrameObj, 'guid') && is_string($contentFrameObj->guid),
+                'Expected contentFrame to have string guid property',
+            );
+
+            $iframePage = new Page(
+                $this->page->context(),
+                $contentFrameObj->guid,
+                $contentFrameObj->guid,
+            );
+
+            $iframeWebpage = new Webpage($iframePage, $this->url());
+
+            $callback($iframeWebpage);
+
+            return $this;
+        }
+
+        throw new RuntimeException("Unable to access iframe content with selector: {$selector}. The Playwright server may not support iframe operations for this setup.");
+    }
+}

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -12,6 +12,7 @@ use Pest\Browser\Support\GuessLocator;
 final readonly class Webpage
 {
     use Concerns\InteractsWithElements,
+        Concerns\InteractsWithFrames,
         Concerns\InteractsWithTab,
         Concerns\InteractsWithToolbar,
         Concerns\MakesConsoleAssertions,

--- a/src/Playwright/Concerns/InteractsWithPlaywright.php
+++ b/src/Playwright/Concerns/InteractsWithPlaywright.php
@@ -178,4 +178,20 @@ trait InteractsWithPlaywright
 
         return '';
     }
+
+    /**
+     * Process response to handle Frame result messages.
+     * Returns frame GUID if a Frame object was returned.
+     */
+    private function processFrameCreationResponse(Generator $response): ?string
+    {
+        /** @var array{result?: array{frame?: array{guid?: string}}} $message */
+        foreach ($response as $message) {
+            if (isset($message['result']['frame']['guid'])) {
+                return $message['result']['frame']['guid'];
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Playwright/Element.php
+++ b/src/Playwright/Element.php
@@ -119,9 +119,9 @@ final readonly class Element
      */
     public function contentFrame(): ?object
     {
-        $result = $this->processResultResponse($this->sendMessage('contentFrame'));
+        $frameGuid = $this->processFrameCreationResponse($this->sendMessage('contentFrame'));
 
-        return $result !== null ? (object) ['guid' => $result] : null;
+        return $frameGuid !== null ? (object) ['guid' => $frameGuid] : null;
     }
 
     /**
@@ -129,8 +129,8 @@ final readonly class Element
      */
     public function ownerFrame(): ?object
     {
-        $result = $this->processResultResponse($this->sendMessage('ownerFrame'));
+        $frameGuid = $this->processFrameCreationResponse($this->sendMessage('ownerFrame'));
 
-        return $result !== null ? (object) ['guid' => $result] : null;
+        return $frameGuid !== null ? (object) ['guid' => $frameGuid] : null;
     }
 }

--- a/src/Playwright/Locator.php
+++ b/src/Playwright/Locator.php
@@ -709,9 +709,25 @@ final readonly class Locator
      */
     public function frameLocator(string $selector): self
     {
-        // This would typically return a FrameLocator, but for simplicity
-        // we'll return a regular locator pointing to the frame content
-        return $this->locator($selector);
+        $directLocator = new self($this->frameGuid, $selector, $this->strictMode);
+        $contentFrame = null;
+
+        try {
+            $contentFrame = $directLocator->contentFrame();
+        } catch (RuntimeException) {
+            // Not a direct iframe, continue to search within the container
+        }
+
+        if ($contentFrame !== null) {
+            return $directLocator;
+        }
+
+        $containerLocator = new self($this->frameGuid, $selector, $this->strictMode);
+        $frameLocator = $containerLocator->locator('iframe');
+
+        $frameLocator->waitFor();
+
+        return $frameLocator;
     }
 
     /**

--- a/tests/Browser/Webpage/IframeTest.php
+++ b/tests/Browser/Webpage/IframeTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Pest\Browser\Api\Webpage;
+
+it('can interact with iframe content using withinFrame', function (): void {
+    $iframeContent = <<<'HTML'
+        <!DOCTYPE html>
+        <html>
+        <head><title>Frame Content</title></head>
+        <body>
+            <h2>Inside Iframe</h2>
+            <input type="text" id="frame-input" placeholder="Type here" />
+            <button id="frame-button">Click me</button>
+            <div id="result"></div>
+        </body>
+        </html>
+        HTML;
+
+    $mainContent = <<<'HTML'
+        <!DOCTYPE html>
+        <html>
+        <head><title>Main Page</title></head>
+        <body>
+            <h1>Main Page</h1>
+            <div class="iframe-container">
+                <iframe id="test-iframe" src="/iframe" width="400" height="300"></iframe>
+            </div>
+        </body>
+        </html>
+        HTML;
+
+    Route::get('/', fn (): string => $mainContent);
+    Route::get('/iframe', fn (): string => $iframeContent);
+
+    $page = visit('/');
+    $page->assertSee('Main Page');
+
+    $page->withinFrame('.iframe-container', function (Webpage $frame): void {
+        $frame->assertSee('Inside Iframe')
+            ->type('frame-input', 'Hello iframe')
+            ->click('frame-button');
+    });
+});
+
+it('can interact with iframe that uses JavaScript', function (): void {
+    $iframeContent = <<<'HTML'
+        <!DOCTYPE html>
+        <html>
+        <head><title>Frame Content</title></head>
+        <body>
+            <h2>Inside Iframe</h2>
+            <input type="text" id="frame-input" placeholder="Type here" />
+            <button id="frame-button" onclick="handleClick()">Click me</button>
+            <div id="result"></div>
+            <script>
+                function handleClick() {
+                    var input = document.getElementById('frame-input');
+                    var result = document.getElementById('result');
+                    result.textContent = 'Clicked with: ' + input.value;
+                }
+            </script>
+        </body>
+        </html>
+        HTML;
+
+    $mainContent = <<<'HTML'
+        <!DOCTYPE html>
+        <html>
+        <head><title>Main Page</title></head>
+        <body>
+            <h1>Main Page</h1>
+            <div class="iframe-wrapper">
+                <iframe id="test-iframe" src="/iframe" width="500" height="400"></iframe>
+            </div>
+        </body>
+        </html>
+        HTML;
+
+    Route::get('/', fn (): string => $mainContent);
+    Route::get('/iframe', fn (): string => $iframeContent);
+
+    $page = visit('/');
+    $page->assertSee('Main Page');
+
+    $page->withinFrame('.iframe-wrapper', function (Webpage $frame): void {
+        $frame->assertSee('Inside Iframe')
+            ->type('frame-input', 'Hello from JavaScript')
+            ->click('frame-button')
+            ->assertSee('Clicked with: Hello from JavaScript');
+    });
+});
+
+it('can interact with iframe from external URL content', function (): void {
+    $mainContent = <<<'HTML'
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Cross-Origin Iframe Test</title>
+        </head>
+        <body>
+            <h1>Cross-Origin Iframe Behavior Test</h1>
+
+            <div class="iframe-container">
+                <iframe id="external-iframe" src="https://example.com"></iframe>
+            </div>
+        </body>
+        </html>
+        HTML;
+
+    Route::get('/', fn (): string => $mainContent);
+
+    visit('/')
+        ->assertSee('Cross-Origin Iframe Behavior Test')
+        ->wait(1)
+        ->withinFrame('.iframe-container', function (Webpage $frame): void {
+            $frame->assertSee('Example Domain');
+        });
+});
+
+it('can interact with two iframes from external URL content', function (): void {
+    $mainContent = <<<'HTML'
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Cross-Origin Iframe Test</title>
+        </head>
+        <body>
+            <h1>Cross-Origin Iframe Behavior Test</h1>
+
+            <div class="iframe-container">
+                <iframe id="external-iframe" src="https://example.com"></iframe>
+            </div>
+
+            <div class="another-iframe-container">
+                <iframe id="external-iframe" src="https://example.com"></iframe>
+            </div>
+        </body>
+        </html>
+        HTML;
+
+    Route::get('/', fn (): string => $mainContent);
+
+    $page = visit('/')
+        ->assertSee('Cross-Origin Iframe Behavior Test');
+
+    $page->withinFrame('.iframe-container', function (Webpage $frame): void {
+        $frame->assertSee('Example Domain');
+    });
+
+    $page->withinFrame('.another-iframe-container', function (Webpage $frame): void {
+        $frame->assertSee('Example Domain');
+    });
+});


### PR DESCRIPTION
This Pull request tries to solve issue https://github.com/pestphp/pest/issues/1471 by adding the ability to test iframes in browser. 

API Example:

```php
$page = visit('/');
$page->assertSee('Main Page');

$page->withinFrame('.iframe-container', function ($frame): void {
    $frame->assertSee('Inside Iframe')
        ->type('#frame-input', 'Hello iframe')
        ->click('#frame-button');
});
```