### PR TITLE
Feature/configurable browser launch args

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -124,4 +124,40 @@ final readonly class Configuration
 
         return $this;
     }
+
+    /**
+     * Set custom browser launch arguments for all modes.
+     *
+     * @param  array<string>  $args
+     */
+    public function withArgs(array $args): self
+    {
+        Playwright::setLaunchArgs($args);
+
+        return $this;
+    }
+
+    /**
+     * Set custom browser launch arguments for headed mode only.
+     *
+     * @param  array<string>  $args
+     */
+    public function withHeadedArgs(array $args): self
+    {
+        Playwright::setHeadedLaunchArgs($args);
+
+        return $this;
+    }
+
+    /**
+     * Set custom browser launch arguments for headless mode only.
+     *
+     * @param  array<string>  $args
+     */
+    public function withHeadlessArgs(array $args): self
+    {
+        Playwright::setHeadlessLaunchArgs($args);
+
+        return $this;
+    }
 }

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -59,7 +59,7 @@ final class Client
 
             // Add custom launch arguments if configured
             $customArgs = Playwright::getEffectiveLaunchArgs();
-            if (! empty($customArgs)) {
+            if ($customArgs !== []) {
                 $launchOptions['args'] = $customArgs;
             }
 

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -51,11 +51,19 @@ final class Client
         if (! $this->websocketConnection instanceof WebsocketConnection) {
             $browser = Playwright::defaultBrowserType()->toPlaywrightName();
 
-            $launchOptions = json_encode([
+            $launchOptions = [
                 'headless' => Playwright::isHeadless(),
                 'ignoreHTTPSErrors' => true,
                 'bypassCSP' => true,
-            ]);
+            ];
+
+            // Add custom launch arguments if configured
+            $customArgs = Playwright::getEffectiveLaunchArgs();
+            if (! empty($customArgs)) {
+                $launchOptions['args'] = $customArgs;
+            }
+
+            $launchOptions = json_encode($launchOptions);
 
             $this->websocketConnection = connect(
                 "ws://$url?browser=$browser&launch-options=$launchOptions",

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -57,7 +57,6 @@ final class Client
                 'bypassCSP' => true,
             ];
 
-            // Add custom launch arguments if configured
             $customArgs = Playwright::getEffectiveLaunchArgs();
             if ($customArgs !== []) {
                 $launchOptions['args'] = $customArgs;

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -274,12 +274,10 @@ final class Playwright
         $args = self::$launchArgs;
 
         if (self::isHeadless()) {
-            $args = array_merge($args, self::$headlessLaunchArgs);
-        } else {
-            $args = array_merge($args, self::$headedLaunchArgs);
+            return array_merge($args, self::$headlessLaunchArgs);
         }
 
-        return $args;
+        return array_merge($args, self::$headedLaunchArgs);
     }
 
     /**

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -60,6 +60,27 @@ final class Playwright
     private static ?string $host = null;
 
     /**
+     * Custom launch arguments for all modes.
+     *
+     * @var array<string>
+     */
+    private static array $launchArgs = [];
+
+    /**
+     * Custom launch arguments for headed mode only.
+     *
+     * @var array<string>
+     */
+    private static array $headedLaunchArgs = [];
+
+    /**
+     * Custom launch arguments for headless mode only.
+     *
+     * @var array<string>
+     */
+    private static array $headlessLaunchArgs = [];
+
+    /**
      * Get a browser factory for the given browser type.
      */
     public static function browser(BrowserType $browserType): BrowserFactory
@@ -211,6 +232,54 @@ final class Playwright
     public static function defaultBrowserType(): BrowserType
     {
         return self::$defaultBrowserType;
+    }
+
+    /**
+     * Set custom launch arguments for all modes.
+     *
+     * @param  array<string>  $args
+     */
+    public static function setLaunchArgs(array $args): void
+    {
+        self::$launchArgs = $args;
+    }
+
+    /**
+     * Set custom launch arguments for headed mode only.
+     *
+     * @param  array<string>  $args
+     */
+    public static function setHeadedLaunchArgs(array $args): void
+    {
+        self::$headedLaunchArgs = $args;
+    }
+
+    /**
+     * Set custom launch arguments for headless mode only.
+     *
+     * @param  array<string>  $args
+     */
+    public static function setHeadlessLaunchArgs(array $args): void
+    {
+        self::$headlessLaunchArgs = $args;
+    }
+
+    /**
+     * Get effective launch arguments based on current mode.
+     *
+     * @return array<string>
+     */
+    public static function getEffectiveLaunchArgs(): array
+    {
+        $args = self::$launchArgs;
+
+        if (self::isHeadless()) {
+            $args = array_merge($args, self::$headlessLaunchArgs);
+        } else {
+            $args = array_merge($args, self::$headedLaunchArgs);
+        }
+
+        return $args;
     }
 
     /**

--- a/tests/Unit/Playwright/LaunchArgsTest.php
+++ b/tests/Unit/Playwright/LaunchArgsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Configuration;
+use Pest\Browser\Playwright\Playwright;
+
+beforeEach(function () {
+    // Reset Playwright state before each test
+    Playwright::setLaunchArgs([]);
+    Playwright::setHeadedLaunchArgs([]);
+    Playwright::setHeadlessLaunchArgs([]);
+});
+
+test('can set custom launch arguments for all modes', function () {
+    $args = ['--custom-flag', '--another-flag'];
+
+    Playwright::setLaunchArgs($args);
+
+    expect(Playwright::getEffectiveLaunchArgs())
+        ->toBe($args);
+});
+
+test('can set custom launch arguments for headed mode only', function () {
+    $headedArgs = ['--headed-flag'];
+
+    Playwright::setHeadedLaunchArgs($headedArgs);
+
+    // In headless mode, should not include headed args
+    expect(Playwright::getEffectiveLaunchArgs())
+        ->toBe([]);
+
+    // Switch to headed mode
+    Playwright::headed();
+
+    expect(Playwright::getEffectiveLaunchArgs())
+        ->toBe($headedArgs);
+});
+
+test('can set custom launch arguments for headless mode only', function () {
+    $headlessArgs = ['--headless-flag'];
+
+    Playwright::setHeadlessLaunchArgs($headlessArgs);
+
+    // In headless mode (default), should include headless args
+    expect(Playwright::getEffectiveLaunchArgs())
+        ->toBe($headlessArgs);
+
+    // Switch to headed mode
+    Playwright::headed();
+
+    expect(Playwright::getEffectiveLaunchArgs())
+        ->toBe([]);
+});
+
+test('merges global and mode-specific arguments correctly', function () {
+    $globalArgs = ['--global-flag'];
+    $headedArgs = ['--headed-flag'];
+    $headlessArgs = ['--headless-flag'];
+
+    Playwright::setLaunchArgs($globalArgs);
+    Playwright::setHeadedLaunchArgs($headedArgs);
+    Playwright::setHeadlessLaunchArgs($headlessArgs);
+
+    // In headless mode (default)
+    expect(Playwright::getEffectiveLaunchArgs())
+        ->toBe(['--global-flag', '--headless-flag']);
+
+    // Switch to headed mode
+    Playwright::headed();
+
+    expect(Playwright::getEffectiveLaunchArgs())
+        ->toBe(['--global-flag', '--headed-flag']);
+});
+
+test('configuration withArgs method sets launch arguments', function () {
+    $args = ['--config-flag'];
+
+    $config = new Configuration();
+    $result = $config->withArgs($args);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::getEffectiveLaunchArgs())->toBe($args);
+});
+
+test('configuration withHeadedArgs method sets headed launch arguments', function () {
+    $args = ['--headed-config-flag'];
+
+    $config = new Configuration();
+    $result = $config->withHeadedArgs($args);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+
+    // Should not be active in headless mode
+    expect(Playwright::getEffectiveLaunchArgs())->toBe([]);
+
+    // Should be active in headed mode
+    Playwright::headed();
+    expect(Playwright::getEffectiveLaunchArgs())->toBe($args);
+});
+
+test('configuration withHeadlessArgs method sets headless launch arguments', function () {
+    $args = ['--headless-config-flag'];
+
+    $config = new Configuration();
+    $result = $config->withHeadlessArgs($args);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+
+    // Should be active in headless mode (default)
+    expect(Playwright::getEffectiveLaunchArgs())->toBe($args);
+
+    // Should not be active in headed mode
+    Playwright::headed();
+    expect(Playwright::getEffectiveLaunchArgs())->toBe([]);
+});
+
+test('configuration methods can be chained', function () {
+    $config = new Configuration();
+
+    $result = $config
+        ->withArgs(['--global'])
+        ->withHeadedArgs(['--headed'])
+        ->withHeadlessArgs(['--headless'])
+        ->headed();
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+
+    $args = Playwright::getEffectiveLaunchArgs();
+
+    expect($args)->toContain('--global')
+        ->and($args)->toContain('--headed');
+});

--- a/tests/Unit/Playwright/LaunchArgsTest.php
+++ b/tests/Unit/Playwright/LaunchArgsTest.php
@@ -12,7 +12,6 @@ beforeEach(function (): void {
 
     $reflection = new ReflectionClass(Playwright::class);
     $headlessProperty = $reflection->getProperty('headless');
-    $headlessProperty->setAccessible(true);
     $headlessProperty->setValue(null, true);
 });
 

--- a/tests/Unit/Playwright/LaunchArgsTest.php
+++ b/tests/Unit/Playwright/LaunchArgsTest.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 use Pest\Browser\Configuration;
 use Pest\Browser\Playwright\Playwright;
 
-beforeEach(function () {
-    // Reset Playwright state before each test
+beforeEach(function (): void {
     Playwright::setLaunchArgs([]);
     Playwright::setHeadedLaunchArgs([]);
     Playwright::setHeadlessLaunchArgs([]);
+
+    $reflection = new ReflectionClass(Playwright::class);
+    $headlessProperty = $reflection->getProperty('headless');
+    $headlessProperty->setAccessible(true);
+    $headlessProperty->setValue(null, true);
 });
 
-test('can set custom launch arguments for all modes', function () {
+it('can set custom launch arguments for all modes', function (): void {
     $args = ['--custom-flag', '--another-flag'];
 
     Playwright::setLaunchArgs($args);
@@ -21,39 +25,31 @@ test('can set custom launch arguments for all modes', function () {
         ->toBe($args);
 });
 
-test('can set custom launch arguments for headed mode only', function () {
+it('can set custom launch arguments for headed mode only', function (): void {
     $headedArgs = ['--headed-flag'];
 
     Playwright::setHeadedLaunchArgs($headedArgs);
 
-    // In headless mode, should not include headed args
-    expect(Playwright::getEffectiveLaunchArgs())
-        ->toBe([]);
+    expect(Playwright::getEffectiveLaunchArgs())->toBe([]);
 
-    // Switch to headed mode
     Playwright::headed();
 
-    expect(Playwright::getEffectiveLaunchArgs())
-        ->toBe($headedArgs);
+    expect(Playwright::getEffectiveLaunchArgs())->toBe($headedArgs);
 });
 
-test('can set custom launch arguments for headless mode only', function () {
+it('can set custom launch arguments for headless mode only', function (): void {
     $headlessArgs = ['--headless-flag'];
 
     Playwright::setHeadlessLaunchArgs($headlessArgs);
 
-    // In headless mode (default), should include headless args
-    expect(Playwright::getEffectiveLaunchArgs())
-        ->toBe($headlessArgs);
+    expect(Playwright::getEffectiveLaunchArgs())->toBe($headlessArgs);
 
-    // Switch to headed mode
     Playwright::headed();
 
-    expect(Playwright::getEffectiveLaunchArgs())
-        ->toBe([]);
+    expect(Playwright::getEffectiveLaunchArgs())->toBe([]);
 });
 
-test('merges global and mode-specific arguments correctly', function () {
+it('merges global and mode-specific arguments correctly', function (): void {
     $globalArgs = ['--global-flag'];
     $headedArgs = ['--headed-flag'];
     $headlessArgs = ['--headless-flag'];
@@ -62,18 +58,14 @@ test('merges global and mode-specific arguments correctly', function () {
     Playwright::setHeadedLaunchArgs($headedArgs);
     Playwright::setHeadlessLaunchArgs($headlessArgs);
 
-    // In headless mode (default)
-    expect(Playwright::getEffectiveLaunchArgs())
-        ->toBe(['--global-flag', '--headless-flag']);
+    expect(Playwright::getEffectiveLaunchArgs())->toBe(['--global-flag', '--headless-flag']);
 
-    // Switch to headed mode
     Playwright::headed();
 
-    expect(Playwright::getEffectiveLaunchArgs())
-        ->toBe(['--global-flag', '--headed-flag']);
+    expect(Playwright::getEffectiveLaunchArgs())->toBe(['--global-flag', '--headed-flag']);
 });
 
-test('configuration withArgs method sets launch arguments', function () {
+it('configuration withArgs method sets launch arguments', function (): void {
     $args = ['--config-flag'];
 
     $config = new Configuration();
@@ -83,39 +75,33 @@ test('configuration withArgs method sets launch arguments', function () {
     expect(Playwright::getEffectiveLaunchArgs())->toBe($args);
 });
 
-test('configuration withHeadedArgs method sets headed launch arguments', function () {
+it('configuration withHeadedArgs method sets headed launch arguments', function (): void {
     $args = ['--headed-config-flag'];
 
     $config = new Configuration();
     $result = $config->withHeadedArgs($args);
 
     expect($result)->toBeInstanceOf(Configuration::class);
-
-    // Should not be active in headless mode
     expect(Playwright::getEffectiveLaunchArgs())->toBe([]);
 
-    // Should be active in headed mode
     Playwright::headed();
     expect(Playwright::getEffectiveLaunchArgs())->toBe($args);
 });
 
-test('configuration withHeadlessArgs method sets headless launch arguments', function () {
+it('configuration withHeadlessArgs method sets headless launch arguments', function (): void {
     $args = ['--headless-config-flag'];
 
     $config = new Configuration();
     $result = $config->withHeadlessArgs($args);
 
     expect($result)->toBeInstanceOf(Configuration::class);
-
-    // Should be active in headless mode (default)
     expect(Playwright::getEffectiveLaunchArgs())->toBe($args);
 
-    // Should not be active in headed mode
     Playwright::headed();
     expect(Playwright::getEffectiveLaunchArgs())->toBe([]);
 });
 
-test('configuration methods can be chained', function () {
+it('configuration methods can be chained', function (): void {
     $config = new Configuration();
 
     $result = $config


### PR DESCRIPTION
# Add configurable browser launch arguments

## Problem

Currently, there's no way to pass custom launch arguments to the browser when running Pest browser tests. This creates issues in several scenarios:

- **Docker/DDEV environments** need stability flags like `--no-sandbox` and `--disable-dev-shm-usage`
- **HiDPI displays** require scaling arguments for proper rendering in headed mode
- **CI environments** could benefit from performance optimizations in headless mode

In our case, we needed to configure HiDPI scaling for browser tests running in DDEV with Omarchy (Arch Linux desktop environment) to match the 2x scaling of our regular desktop environment.

## Solution

This PR adds three new methods to the `Configuration` class:

- `withArgs(array $args)` - Sets arguments for all modes (headless and headed)
- `withHeadedArgs(array $args)` - Sets arguments only for headed mode
- `withHeadlessArgs(array $args)` - Sets arguments only for headless mode

Arguments are merged intelligently: global args are always included, plus mode-specific args based on whether `--headed` flag is used.

## Usage

Configure globally in `tests/Pest.php`:

```php
use Pest\Browser\Playwright\Playwright;

pest()->extend(Tests\TestCase::class)
    ->beforeEach(function () {
        // Stability args for all modes
        Playwright::setLaunchArgs(['--no-sandbox', '--disable-dev-shm-usage']);
        
        // HiDPI scaling for headed mode only
        Playwright::setHeadedLaunchArgs([
            '--force-device-scale-factor=2',
            '--high-dpi-support=1',
            '--device-scale-factor=2',
            '--force-color-profile=srgb',
        ]);
    })
    ->in('Browser');
```

Or using the fluent configuration API:

```php
browser()->configure()
    ->withArgs(['--no-sandbox', '--disable-dev-shm-usage'])
    ->withHeadedArgs(['--force-device-scale-factor=2'])
    ->headed();
```

## Implementation

- Added static properties to `Playwright` class to store launch arguments
- Modified `Client::connectTo()` to include custom arguments in launch options
- Arguments are passed to Playwright server via WebSocket connection
- Comprehensive test coverage with proper state management

## Backward Compatibility

This change is fully backward compatible. Existing tests continue to work unchanged, and the new functionality is opt-in.
