### PR TITLE
feat: expose wait capabilities to WebPage

### DIFF
--- a/src/Api/Concerns/HasWaitCapabilities.php
+++ b/src/Api/Concerns/HasWaitCapabilities.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Pest\Browser\Api\Webpage;
+
+/**
+ * @mixin Webpage
+ */
+trait HasWaitCapabilities
+{
+    /**
+     * Waits for the specified load state.
+     */
+    public function waitForLoadState(string $state = 'load'): self
+    {
+        $this->page->waitForLoadState($state);
+
+        return $this;
+    }
+
+    /**
+     * Waits for a JavaScript function to return true.
+     *
+     * @param  mixed  $arg  Optional argument to pass to the function
+     */
+    public function waitForFunction(string $content, mixed $arg = null): self
+    {
+        $this->page->waitForFunction($content, $arg);
+
+        return $this;
+    }
+
+    /**
+     * Waits for navigation to the specified URL.
+     */
+    public function waitForURL(string $url): self
+    {
+        $this->page->waitForURL($url);
+
+        return $this;
+    }
+
+    /**
+     * Waits for the selector to satisfy state option.
+     *
+     * @param  array<string, mixed>|null  $options  Additional options like state, strict, timeout
+     */
+    public function waitForSelector(string $selector, ?array $options = null): self
+    {
+        $this->page->waitForSelector($selector, $options);
+
+        return $this;
+    }
+}

--- a/src/Api/Concerns/InteractsWithToolbar.php
+++ b/src/Api/Concerns/InteractsWithToolbar.php
@@ -35,4 +35,24 @@ trait InteractsWithToolbar
 
         return $this;
     }
+
+    /**
+     * Navigates to the next page in the history.
+     */
+    public function forward(): self
+    {
+        $this->page->forward();
+
+        return $this;
+    }
+
+    /**
+     * Navigates to the previous page in the history.
+     */
+    public function back(): self
+    {
+        $this->page->back();
+
+        return $this;
+    }
 }

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -11,7 +11,8 @@ use Pest\Browser\Support\GuessLocator;
 
 final readonly class Webpage
 {
-    use Concerns\InteractsWithElements,
+    use Concerns\HasWaitCapabilities,
+        Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
         Concerns\InteractsWithTab,
         Concerns\InteractsWithToolbar,

--- a/tests/Browser/Webpage/NavigateTest.php
+++ b/tests/Browser/Webpage/NavigateTest.php
@@ -12,3 +12,20 @@ it('may navigate to a page', function (): void {
     $page->navigate('/page-b');
     $page->assertSee('page 2');
 });
+
+it('may navigate forward and back', function (): void {
+    Route::get('/page-a', fn (): string => 'page 1');
+    Route::get('/page-b', fn (): string => 'page 2');
+
+    $page = visit('/page-a');
+    $page->assertSee('page 1');
+
+    $page->navigate('/page-b');
+    $page->assertSee('page 2');
+
+    $page->back();
+    $page->assertSee('page 1');
+
+    $page->forward();
+    $page->assertSee('page 2');
+});

--- a/tests/Browser/Webpage/WaitTest.php
+++ b/tests/Browser/Webpage/WaitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Route;
+
+it('may wait for function to return true', function (): void {
+    Route::get('/', fn (): string => '
+        <div id="content">Loading...</div>
+        <script>
+            setTimeout(() => {
+                document.getElementById("content").textContent = "Loaded!";
+            }, 100);
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->waitForFunction('() => document.getElementById("content").textContent === "Loaded!"');
+
+    $page->assertSeeIn('#content', 'Loaded!');
+});
+
+it('may wait for url', function (): void {
+    Route::get('/page-a', function (): RedirectResponse {
+        sleep(1);
+
+        return redirect('/page-b');
+    });
+
+    Route::get('/page-b', fn (): string => 'page 2');
+
+    $page = visit('/page-a');
+    $page->waitForURL('/page-b');
+    $page->assertSee('page 2');
+});
+
+it('may wait for selector', function (): void {
+    Route::get('/', fn (): string => '
+        <div id="container"></div>
+        <script>
+            setTimeout(() => {
+                const container = document.getElementById("container");
+                const childElement = document.createElement("div");
+                childElement.id = "child";
+                childElement.textContent = "Child Element Added";
+                container.appendChild(childElement);
+            }, 100);
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->waitForSelector('#child');
+
+    $page->assertSeeIn('#child', 'Child Element Added');
+});


### PR DESCRIPTION
This pull request exposes the `Page` wait methods to be available in `WebPage` in order to allow to wait for certain use cases. 

Example:

```php
$page = visit('/payment');

$page->withinFrame('.__PrivateStripeElement', function (Webpage $frame) {
    $frame
        ->type('Field-numberInput', '4242424242424242')
        ->type('Field-expiryInput', '12/' . date('y'))
        ->type('Field-cvcInput', '123')
        ->select('Field-countryInput', 'US')
        ->type('Field-postalCodeInput', '99950');
});

$page->click('@stripe-payment-button');

// Don't need
// $page->wait(3);
$page->waitForURL('/invoice');

$page->assertSee('You have upgraded to Pro Plan!');
```

Very useful when dealing with Stripe forms, where wait time is not always same.
