### PR TITLE
feat: add support for typing slowly

### DIFF
--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -68,6 +68,17 @@ trait InteractsWithElements
     }
 
     /**
+     * Type the given value slowly in the given field.
+     */
+    public function typeSlowly(string $field, string $value, int $delay = 100): Webpage
+    {
+        $options = ['delay' => $delay];
+        $this->guessLocator($field)->type($value, $options);
+
+        return $this;
+    }
+
+    /**
      * Fills the given value in the given field.
      */
     public function fill(string $field, string $value): Webpage

--- a/tests/Browser/Webpage/TypeTest.php
+++ b/tests/Browser/Webpage/TypeTest.php
@@ -31,3 +31,13 @@ it('may clear the field before typing', function (): void {
 
     expect($page->value('#name'))->toBe('John Doe');
 });
+
+it('may type text slowly in an input field', function (): void {
+    Route::get('/', fn (): string => '<input id="name" name="name" type="text">');
+
+    $page = visit('/');
+
+    $page->typeSlowly('#name', 'John Doe');
+
+    expect($page->value('#name'))->toBe('John Doe');
+});

--- a/tests/Browser/Webpage/TypeTest.php
+++ b/tests/Browser/Webpage/TypeTest.php
@@ -41,3 +41,13 @@ it('may type text slowly in an input field', function (): void {
 
     expect($page->value('#name'))->toBe('John Doe');
 });
+
+it('may type text slowly in an input field with a custom delay', function (): void {
+    Route::get('/', fn (): string => '<input id="name" name="name" type="text">');
+
+    $page = visit('/');
+
+    $page->typeSlowly('#name', 'John Doe', 100);
+
+    expect($page->value('#name'))->toBe('John Doe');
+});


### PR DESCRIPTION
This pull request add an additional method that allows to type slowly like a human.

Example:

```php
$page = visit('/');

$page
    ->typeSlowly('name', 'Mansoor')
    ->typeSlowly(field: 'email', value: 'mansoor@example.com', delay: 100);
```