### PR TITLE
feat: add ability to resize browser

### DIFF
--- a/src/Api/Concerns/InteractsWithViewPort.php
+++ b/src/Api/Concerns/InteractsWithViewPort.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+trait InteractsWithViewPort
+{
+    /**
+     * Resizes the page.
+     */
+    public function resize(int $width, int $height): self
+    {
+        $this->page->setViewportSize($width, $height);
+
+        return $this;
+    }
+
+    /**
+     * Returns the viewport size.
+     *
+     * @return array{width: int, height: int}
+     */
+    public function getViewportSize(): array
+    {
+        return $this->page->viewportSize();
+    }
+}

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -15,6 +15,7 @@ final readonly class Webpage
         Concerns\InteractsWithFrames,
         Concerns\InteractsWithTab,
         Concerns\InteractsWithToolbar,
+        Concerns\InteractsWithViewPort,
         Concerns\MakesConsoleAssertions,
         Concerns\MakesElementAssertions,
         Concerns\MakesScreenshotAssertions,

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -305,6 +305,33 @@ final class Page
     }
 
     /**
+     * Sets the viewport size and resizes the page.
+     */
+    public function setViewportSize(int $width, int $height): self
+    {
+        $viewportSize = ['viewportSize' => ['width' => $width, 'height' => $height]];
+
+        $response = $this->sendMessage('setViewportSize', $viewportSize);
+
+        $this->processVoidResponse($response);
+
+        return $this;
+    }
+
+    /**
+     * Returns the viewport size.
+     *
+     * @return array{width: int, height: int}
+     */
+    public function viewportSize(): array
+    {
+        /** @var array{width: int, height: int} $result */
+        $result = $this->evaluate('() => ({ width: window.innerWidth, height: window.innerHeight })');
+
+        return $result;
+    }
+
+    /**
      * Sets the content of the page.
      */
     public function setContent(string $html): self
@@ -581,6 +608,8 @@ final class Page
             'screenshot',
             'waitForLoadState',
             'waitForURL',
+            'setViewportSize',
+            'viewportSize',
         ];
 
         return in_array($method, $pageLevelOperations, true);

--- a/tests/Browser/Webpage/ViewportSizeTest.php
+++ b/tests/Browser/Webpage/ViewportSizeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('may set viewport size', function (): void {
+    Route::get('/', fn (): string => '
+        <style>
+            .mobile-only-element {
+                display: none;
+            }
+            @media screen and (max-width: 600px) {
+                .mobile-only-element {
+                    display: block;
+                }
+            }
+        </style>
+
+        <div class="mobile-only-element">
+            Only visible on mobile
+        </div>
+    ');
+
+    $page = visit('/');
+
+    $page
+        ->assertDontSee('Only visible on mobile')
+        ->resize(600, 600)
+        ->assertSee('Only visible on mobile');
+});
+
+it('may get viewport size', function (): void {
+    Route::get('/', fn (): string => '<h1>Test Page</h1>');
+
+    $page = visit('/');
+
+    $page->resize(800, 1200);
+
+    $viewportSize = $page->getViewportSize();
+
+    expect($viewportSize)->toHaveKey('width', 800);
+    expect($viewportSize)->toHaveKey('height', 1200);
+});


### PR DESCRIPTION
This pull request solves https://github.com/pestphp/pest/issues/1482 by adding the ability to resize the page.

Example:

```php
$page = visit('/');

$page->assertDontSee('Only visible on mobile')
$page->resize(600, 600)
$page->assertSee('Only visible on mobile');

$viewportSize = $page->getViewportSize();

expect($viewportSize)->toHaveKey('width', 600);
expect($viewportSize)->toHaveKey('height', 600);
```