### PR TITLE
feat: add support for taking screenshot of an element

### DIFF
--- a/src/Api/Concerns/CanTakeScreenshots.php
+++ b/src/Api/Concerns/CanTakeScreenshots.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+trait CanTakeScreenshots
+{
+    /**
+     * Performs a screenshot of the current page and saves it to the given path.
+     */
+    public function screenshot(bool $fullPage = true, ?string $filename = null): self
+    {
+        $filename = $this->getFilename($filename);
+
+        $this->page->screenshot($fullPage, $filename);
+
+        return $this;
+    }
+
+    /**
+     * Performs a screenshot of an element and saves it to the given path.
+     */
+    public function screenshotElement(string $selector, ?string $filename = null): self
+    {
+        $filename = $this->getFilename($filename);
+
+        $this->page->screenshotElement($selector, $filename);
+
+        return $this;
+    }
+
+    private function getFilename(?string $filename = null): string
+    {
+        return is_string($filename) ? $filename : 'screenshot-'.date('Y_m_d_H_i_s_u').'.png';
+    }
+}

--- a/src/Api/Concerns/InteractsWithScreen.php
+++ b/src/Api/Concerns/InteractsWithScreen.php
@@ -32,6 +32,11 @@ trait InteractsWithScreen
 
     private function getFilename(?string $filename = null): string
     {
-        return is_string($filename) ? $filename : 'screenshot-'.date('Y_m_d_H_i_s_u').'.png';
+        if ($filename === null) {
+            // @phpstan-ignore-next-line
+            return str_replace('__pest_evaluable_', '', test()->name());
+        }
+
+        return $filename;
     }
 }

--- a/src/Api/Concerns/InteractsWithScreen.php
+++ b/src/Api/Concerns/InteractsWithScreen.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Api\Concerns;
 
-trait CanTakeScreenshots
+trait InteractsWithScreen
 {
     /**
      * Performs a screenshot of the current page and saves it to the given path.

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -11,7 +11,8 @@ use Pest\Browser\Support\GuessLocator;
 
 final readonly class Webpage
 {
-    use Concerns\HasWaitCapabilities,
+    use Concerns\CanTakeScreenshots,
+        Concerns\HasWaitCapabilities,
         Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
         Concerns\InteractsWithTab,
@@ -66,18 +67,6 @@ final readonly class Webpage
     public function url(): string
     {
         return $this->page->url();
-    }
-
-    /**
-     * Performs a screenshot of the current page and saves it to the given path.
-     */
-    public function screenshot(bool $fullPage = true, ?string $filename = null): self
-    {
-        $filename = is_string($filename) ? $filename : date('Y_m_d_H_i_s_u');
-
-        $this->page->screenshot($fullPage, $filename);
-
-        return $this;
     }
 
     /**

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -11,10 +11,10 @@ use Pest\Browser\Support\GuessLocator;
 
 final readonly class Webpage
 {
-    use Concerns\CanTakeScreenshots,
-        Concerns\HasWaitCapabilities,
+    use Concerns\HasWaitCapabilities,
         Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
+        Concerns\InteractsWithScreen,
         Concerns\InteractsWithTab,
         Concerns\InteractsWithToolbar,
         Concerns\InteractsWithViewPort,

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -439,6 +439,17 @@ final class Page
     }
 
     /**
+     * Make screenshot of a specific element.
+     */
+    public function screenshotElement(string $selector, ?string $filename = null): string
+    {
+        $locator = $this->locator($selector);
+        $binary = $locator->screenshot();
+
+        return Screenshot::save($binary, $filename);
+    }
+
+    /**
      * Get the console logs from the page, if any.
      *
      * @return array<int, array{message: string}>

--- a/tests/Browser/Webpage/ScreenshotTest.php
+++ b/tests/Browser/Webpage/ScreenshotTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Pest\Browser\Support\Screenshot;
+
+it('captures a full-page screenshot', function (): void {
+    Route::get('/', fn (): string => 'Hello World');
+
+    $page = visit('/');
+
+    $page->screenshot(filename: 'full-page-screenshot.png');
+
+    expect(file_exists(Screenshot::path('full-page-screenshot.png')))
+        ->toBeTrue();
+});
+
+it('captures a full-page screenshot with default filename', function (): void {
+    Route::get('/', fn (): string => 'Hello World');
+
+    $page = visit('/');
+
+    $page->screenshot();
+
+    expect(file_exists(Screenshot::path('screenshot-'.date('Y_m_d_H_i_s_u').'.png')))
+        ->toBeTrue();
+});
+
+it('captures a screenshot of an specific element', function (): void {
+    Route::get('/', fn (): string => '<div>
+        <h1>Text outside of screenshot element</h1>
+        <div id="screenshot-element">Text inside of screenshot element</div>
+    </div>');
+
+    $page = visit('/');
+
+    $page->screenshotElement('#screenshot-element', 'element-screenshot.png');
+
+    expect(file_exists(Screenshot::path('element-screenshot.png')))
+        ->toBeTrue();
+});

--- a/tests/Browser/Webpage/ScreenshotTest.php
+++ b/tests/Browser/Webpage/ScreenshotTest.php
@@ -23,7 +23,9 @@ it('captures a full-page screenshot with default filename', function (): void {
 
     $page->screenshot();
 
-    expect(file_exists(Screenshot::path('screenshot-'.date('Y_m_d_H_i_s_u').'.png')))
+    $defaultFilename = str_replace('__pest_evaluable_', '', test()->name());
+
+    expect(file_exists(Screenshot::path($defaultFilename)))
         ->toBeTrue();
 });
 


### PR DESCRIPTION
This pull requests solves https://github.com/pestphp/pest/issues/1481 by adding the support to take screenshot of an element.

Example:

```php
$page = visit('/');

$page->screenshotElement('#screenshot-element', 'element-screenshot.png');
```