### PR TITLE
feat: add support for passing params to click

### DIFF
--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -14,9 +14,9 @@ trait InteractsWithElements
     /**
      * Click the link with the given text.
      *
-     * @param  array<string, mixed>|null  $options
+     * @param  array<string, mixed>  $options
      */
-    public function click(string $text, ?array $options = null): Webpage
+    public function click(string $text, array $options = []): Webpage
     {
         $this->guessLocator($text)->click($options);
 

--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -13,10 +13,12 @@ trait InteractsWithElements
 {
     /**
      * Click the link with the given text.
+     *
+     * @param  array<string, mixed>|null  $options
      */
-    public function click(string $text): Webpage
+    public function click(string $text, ?array $options = null): Webpage
     {
-        $this->guessLocator($text)->click();
+        $this->guessLocator($text)->click($options);
 
         return $this;
     }

--- a/tests/Browser/Webpage/ClickTest.php
+++ b/tests/Browser/Webpage/ClickTest.php
@@ -73,3 +73,23 @@ it('can click elements via exact match css selectors', function (string $selecto
     '[name$="test"]',
     'button[name="test"]',
 ]);
+
+test('click may accept options', function (): void {
+    Route::get('/', fn (): string => '
+    <p id="result"></p>
+    <button
+        id="button"
+        ondblclick="document.getElementById(\'result\').textContent = \'Option-2 clicked\'"
+    >
+        Click Me
+    </button>');
+
+    $page = visit('/');
+
+    $page->click('#button');
+    $page->assertDontSeeIn('#result', 'Option-2 clicked');
+
+    // clickCount => 2 is considered as double click
+    $page->click('#button', options: ['clickCount' => 2]);
+    $page->assertSeeIn('#result', 'Option-2 clicked');
+});


### PR DESCRIPTION
This pull requests solves https://github.com/pestphp/pest/issues/1477 by adding support for passing params to `click`.

Example:

```php
$page = visit('/');

$page->click('#button');
$page->assertDontSeeIn('#result', 'Option-2 clicked');

// clickCount => 2 is considered as double click
$page->click('#button', options: ['clickCount' => 2]);
$page->assertSeeIn('#result', 'Option-2 clicked');
```