### PR TITLE
fix: failing test for external url

### DIFF
--- a/tests/Browser/Visit/SingleUrl.php
+++ b/tests/Browser/Visit/SingleUrl.php
@@ -96,8 +96,7 @@ it('may visit a page with custom locale and timezone', function (): void {
 });
 
 it('may visit external URLs', function (): void {
-    $page = visit('https://laravel.com');
+    $page = visit('https://example.com');
 
-    $page->assertSee('Laravel')
-        ->assertDontSee('Symfony');
+    $page->assertSee('Example Domain');
 });


### PR DESCRIPTION
This pull request fixes the failing test for external url. For some reason testing https://laravel.com URL always fails, but https://example.com passes all the time. 