### PR TITLE
Fix string formatting in console assertion messages

### DIFF
--- a/src/Api/Concerns/MakesConsoleAssertions.php
+++ b/src/Api/Concerns/MakesConsoleAssertions.php
@@ -38,7 +38,8 @@ trait MakesConsoleAssertions
         $brokenImages = $this->page->brokenImages();
 
         expect($brokenImages)->toBeEmpty(sprintf(
-            "Expected no broken images on the page initially with the url [{$this->initialUrl}], but found %s: %s",
+            'Expected no broken images on the page initially with the url [%s], but found %s: %s',
+            $this->initialUrl,
             count($brokenImages),
             implode(', ', $brokenImages),
         ));
@@ -62,7 +63,8 @@ trait MakesConsoleAssertions
         $consoleLogs = $this->page->consoleLogs();
 
         expect($consoleLogs)->toBeEmpty(sprintf(
-            "Expected no console logs on the page initially with the url [{$this->initialUrl}], but found %s: %s",
+            'Expected no console logs on the page initially with the url [%s], but found %s: %s',
+            $this->initialUrl,
             count($consoleLogs),
             implode(', ', array_map(fn (array $log) => $log['message'], $consoleLogs)),
         ));
@@ -78,7 +80,8 @@ trait MakesConsoleAssertions
         $javaScriptErrors = $this->page->javaScriptErrors();
 
         expect($javaScriptErrors)->toBeEmpty(sprintf(
-            "Expected no JavaScript errors on the page initially with the url [{$this->initialUrl}], but found %s: %s",
+            'Expected no JavaScript errors on the page initially with the url [%s], but found %s: %s',
+            $this->initialUrl,
             count($javaScriptErrors),
             implode(', ', array_map(fn (array $log) => $log['message'], $javaScriptErrors)),
         ));


### PR DESCRIPTION
When a url contains reserved characters it gets percent-encoded which breaks the expected number of arguments for sprintf and causes an ArgumentCountError. This PR fixes this issue by moving the url into a separate argument instead of including it directly in the format string.