### PR TITLE
tests: add an additional test waitForSelector

### DIFF
--- a/tests/Browser/Webpage/WaitTest.php
+++ b/tests/Browser/Webpage/WaitTest.php
@@ -56,3 +56,26 @@ it('may wait for selector', function (): void {
 
     $page->assertSeeIn('#child', 'Child Element Added');
 });
+
+it('may wait for selector with options', function (): void {
+    Route::get('/', fn (): string => '
+        <div id="container">
+            <div id="child">Child Element</div>
+        </div>
+        <script>
+            setTimeout(() => {
+                const container = document.getElementById("container");
+                const childElement = document.getElementById("child");
+                container.removeChild(childElement);
+            }, 100);
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->waitForSelector('#child', [
+        'state' => 'detached',
+    ]);
+
+    $page->assertSourceMissing('<div id="child">Child Element</div>');
+});

--- a/tests/Browser/Webpage/WaitTest.php
+++ b/tests/Browser/Webpage/WaitTest.php
@@ -57,7 +57,7 @@ it('may wait for selector', function (): void {
     $page->assertSeeIn('#child', 'Child Element Added');
 });
 
-it('may wait for selector with options', function (): void {
+it('may wait for selector with options', function (string $state): void {
     Route::get('/', fn (): string => '
         <div id="container">
             <div id="child">Child Element</div>
@@ -74,8 +74,13 @@ it('may wait for selector with options', function (): void {
     $page = visit('/');
 
     $page->waitForSelector('#child', [
-        'state' => 'detached',
+        'state' => $state,
     ]);
 
     $page->assertSourceMissing('<div id="child">Child Element</div>');
-});
+})->with([
+    'attached' => 'attached',
+    'detached' => 'detached',
+    'visible' => 'visible',
+    'hidden' => 'hidden',
+]);


### PR DESCRIPTION
This PR adds an additional test for `waitForSelector` to make sure it can accept options.