### PR TITLE
refactor: Better `from()->{$city}` autocomplete

### DIFF
--- a/src/Api/From.php
+++ b/src/Api/From.php
@@ -6,7 +6,7 @@ namespace Pest\Browser\Api;
 
 use InvalidArgumentException;
 use Pest\Browser\Enums\BrowserType;
-use Pest\Browser\Enums\Cities;
+use Pest\Browser\Enums\City;
 use Pest\Browser\Enums\Device;
 
 /**
@@ -33,14 +33,126 @@ final readonly class From
      *
      * @param  array<int, mixed>  $arguments
      */
-    public function __call(string $name, array $arguments): mixed
+    public function __call(string $name, array $arguments): PendingAwaitablePage
     {
-        $city = Cities::tryFrom($name);
-
-        if (is_null($city)) {
-            throw new InvalidArgumentException("City '{$name}' is not supported.");
+        foreach (City::cases() as $case) {
+            if ($case->value === $name) {
+                return $this->city($case);
+            }
         }
 
+        throw new InvalidArgumentException("City '{$name}' is not supported.");
+    }
+
+    /**
+     * Sets the city to Amsterdam.
+     */
+    public function amsterdam(): PendingAwaitablePage
+    {
+        return $this->city(City::AMSTERDAM);
+    }
+
+    /**
+     * Sets the city to Berlin.
+     */
+    public function berlin(): PendingAwaitablePage
+    {
+        return $this->city(City::BERLIN);
+    }
+
+    /**
+     * Sets the city to Chicago.
+     */
+    public function chicago(): PendingAwaitablePage
+    {
+        return $this->city(City::CHICAGO);
+    }
+
+    /**
+     * Sets the city to Houston.
+     */
+    public function houston(): PendingAwaitablePage
+    {
+        return $this->city(City::HOUSTON);
+    }
+
+    /**
+     * Sets the city to London.
+     */
+    public function london(): PendingAwaitablePage
+    {
+        return $this->city(City::LONDON);
+    }
+
+    /**
+     * Sets the city to Los Angeles.
+     */
+    public function losAngeles(): PendingAwaitablePage
+    {
+        return $this->city(City::LOS_ANGELES);
+    }
+
+    /**
+     * Sets the city to Miami.
+     */
+    public function miami(): PendingAwaitablePage
+    {
+        return $this->city(City::MIAMI);
+    }
+
+    /**
+     * Sets the city to New York.
+     */
+    public function newYork(): PendingAwaitablePage
+    {
+        return $this->city(City::NEW_YORK);
+    }
+
+    /**
+     * Sets the city to Paris.
+     */
+    public function paris(): PendingAwaitablePage
+    {
+        return $this->city(City::PARIS);
+    }
+
+    /**
+     * Sets the city to Tokyo.
+     */
+    public function tokyo(): PendingAwaitablePage
+    {
+        return $this->city(City::TOKYO);
+    }
+
+    /**
+     * Sets the city to Toronto.
+     */
+    public function toronto(): PendingAwaitablePage
+    {
+        return $this->city(City::TORONTO);
+    }
+
+    /**
+     * Sets the city to San Francisco.
+     */
+    public function sanFrancisco(): PendingAwaitablePage
+    {
+        return $this->city(City::SAN_FRANCISCO);
+    }
+
+    /**
+     * Sets the city to Sydney.
+     */
+    public function sydney(): PendingAwaitablePage
+    {
+        return $this->city(City::SYDNEY);
+    }
+
+    /**
+     * Creates the actual visit page instance using the provided city.
+     */
+    private function city(City $city): PendingAwaitablePage
+    {
         return (new PendingAwaitablePage(
             $this->browserType,
             $this->device,

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -6,7 +6,6 @@ namespace Pest\Browser\Api;
 
 use InvalidArgumentException;
 use Pest\Browser\Enums\BrowserType;
-use Pest\Browser\Enums\Cities;
 use Pest\Browser\Enums\City;
 use Pest\Browser\Enums\ColorScheme;
 use Pest\Browser\Enums\Device;

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -7,6 +7,7 @@ namespace Pest\Browser\Api;
 use InvalidArgumentException;
 use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Enums\Cities;
+use Pest\Browser\Enums\City;
 use Pest\Browser\Enums\ColorScheme;
 use Pest\Browser\Enums\Device;
 use Pest\Browser\Playwright\InitScript;
@@ -134,15 +135,15 @@ final class PendingAwaitablePage
     /**
      * Sets the geolocation for the page.
      *
-     * @param  float|Cities  $location  The latitude or a Cities enum value
+     * @param  float|City  $location  The latitude or a Cities enum value
      * @param  float|null  $longitude  The longitude (required with latitude, ignored when using Cities enum)
      *
      * @example geolocation(Cities::NEW_YORK)
      * @example geolocation(40.7128, -74.0060)
      */
-    public function geolocation(float|Cities $location, ?float $longitude = null): self
+    public function geolocation(float|City $location, ?float $longitude = null): self
     {
-        if ($location instanceof Cities) {
+        if ($location instanceof City) {
             $geolocation = $location->geolocation();
         } elseif ($longitude === null) {
             throw new InvalidArgumentException('Longitude must be provided when latitude is specified');

--- a/src/Enums/City.php
+++ b/src/Enums/City.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Enums;
 
-enum Cities: string
+enum City: string
 {
     case AMSTERDAM = 'amsterdam';
     case BERLIN = 'berlin';

--- a/tests/Browser/Visit/FromTest.php
+++ b/tests/Browser/Visit/FromTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
-use Pest\Browser\Enums\Cities;
+use Pest\Browser\Enums\City;
 
 it('can emulate being from another location', function (): void {
     Route::get('/', fn (): string => '
@@ -29,7 +29,7 @@ it('can emulate being from another location', function (): void {
         </html>
     ');
 
-    $cities = Cities::cases();
+    $cities = City::cases();
 
     foreach ($cities as $city) {
         visit('/')

--- a/tests/Browser/Visit/GeolocationTest.php
+++ b/tests/Browser/Visit/GeolocationTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
-use Pest\Browser\Enums\Cities;
+use Pest\Browser\Enums\City;
 
 test('can set geolocation', function (): void {
     Route::get('/', fn (): string => '
@@ -55,7 +55,7 @@ test('can set geolocation using Cities enum', function (): void {
             </html>
         ');
 
-    $city = Cities::LONDON;
+    $city = City::LONDON;
     $expectedLatitude = $city->geolocation()['latitude'];
     $expectedLongitude = $city->geolocation()['longitude'];
 


### PR DESCRIPTION
Had a private conversation with @jasonmccreary and he mentioned that Nuno wanted better autocomplete support for specifying cities in the Enum, since the dynamic approach doesn't offer that.  I'm definitely on board with better autocomplete so here's my first take on it.

I'm putting this out there as a v1 but if anyone has any better suggestions on how to accomplish autocomplete without hardcoding a method for every enum'd `City`, I am very happy to refactor into it.