### PR TITLE
feat: add cookie assertions

### DIFF
--- a/src/Api/Concerns/MakesCookieAssertions.php
+++ b/src/Api/Concerns/MakesCookieAssertions.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Pest\Browser\Api\Webpage;
+use Pest\Browser\Support\AccessibilityFormatter;
+use Pest\Matchers\Any;
+
+/**
+ * @mixin Webpage
+ *
+ * @phpstan-import-type Violations from AccessibilityFormatter
+ */
+trait MakesCookieAssertions
+{
+    /**
+     * Asserts the page has a cookie.
+     *
+     * @param  string  $key  The name of the cookie.
+     * @param  mixed  $value  The value of the cookie.
+     */
+    public function assertHasCookie(string $key, mixed $value = new Any()): Webpage
+    {
+        $cookies = $this->page->cookies();
+
+        expect($cookies)
+            ->toHaveKey($key, $value, sprintf(
+                'Expected cookie [%s] to be present on the page initially with the url [%s], but it was not found',
+                $key,
+                $this->initialUrl,
+            ));
+
+        return $this;
+    }
+
+    /**
+     * Asserts the page does not have a specific cookie.
+     *
+     * @param  string  $key  The name of the cookie.
+     * @param  mixed  $value  The value of the cookie.
+     */
+    public function assertCookieMissing(string $key, mixed $value = new Any()): Webpage
+    {
+        $cookies = $this->page->cookies();
+
+        expect($cookies)
+            ->not()->toHaveKey($key, $value, sprintf(
+                'Expected cookie [%s] to not be present on the page initially with the url [%s], but it was found',
+                $key,
+                $this->initialUrl,
+            ));
+
+        return $this;
+    }
+
+    /**
+     * Asserts there are no cookies on the page.
+     */
+    public function assertNoCookies(): Webpage
+    {
+        $cookies = $this->page->cookies();
+
+        expect($cookies)->toBeEmpty(sprintf(
+            'Expected no cookies on the page initially with the url [%s], but found %s: %s',
+            $this->initialUrl,
+            count($cookies),
+            implode(', ', array_keys($cookies)),
+        ));
+
+        return $this;
+    }
+}

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -19,6 +19,7 @@ final class Webpage
         Concerns\InteractsWithToolbar,
         Concerns\InteractsWithViewPort,
         Concerns\MakesConsoleAssertions,
+        Concerns\MakesCookieAssertions,
         Concerns\MakesElementAssertions,
         Concerns\MakesScreenshotAssertions,
         Concerns\MakesUrlAssertions;

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pest\Browser\Playwright;
 
 use Generator;
-use Illuminate\Support\Str;
 use Pest\Browser\Execution;
 use Pest\Browser\Support\ImageDiffView;
 use Pest\Browser\Support\JavaScriptSerializer;
@@ -67,21 +66,6 @@ final class Page
     }
 
     /**
-     * Evaluates a JavaScript expression in the page context.
-     */
-    public function evaluate(string $pageFunction, mixed $arg = null): mixed
-    {
-        $params = [
-            'expression' => $pageFunction,
-            'arg' => JavaScriptSerializer::serializeArgument($arg),
-        ];
-
-        $response = $this->sendMessage('evaluateExpression', $params);
-
-        return $this->processResultResponse($response);
-    }
-
-    /**
      * Performs the given callback in unstrict mode.
      *
      * @template TReturn
@@ -138,14 +122,6 @@ final class Page
     }
 
     /**
-     * Create a locator for the specified selector.
-     */
-    public function locator(string $selector): Locator
-    {
-        return new Locator($this->frameGuid, $selector, $this->strictLocators);
-    }
-
-    /**
      * Finds all elements matching the specified selector.
      *
      * @return Element[]
@@ -167,6 +143,14 @@ final class Page
         }
 
         return $elements;
+    }
+
+    /**
+     * Create a locator for the specified selector.
+     */
+    public function locator(string $selector): Locator
+    {
+        return new Locator($this->frameGuid, $selector, $this->strictLocators);
     }
 
     /**
@@ -359,6 +343,21 @@ final class Page
     }
 
     /**
+     * Evaluates a JavaScript expression in the page context.
+     */
+    public function evaluate(string $pageFunction, mixed $arg = null): mixed
+    {
+        $params = [
+            'expression' => $pageFunction,
+            'arg' => JavaScriptSerializer::serializeArgument($arg),
+        ];
+
+        $response = $this->sendMessage('evaluateExpression', $params);
+
+        return $this->processResultResponse($response);
+    }
+
+    /**
      * Evaluates a JavaScript expression and returns a JSHandle.
      */
     public function evaluateHandle(string $pageFunction, mixed $arg = null): JSHandle
@@ -426,17 +425,6 @@ final class Page
     }
 
     /**
-     * Make screenshot of a specific element.
-     */
-    public function screenshotElement(string $selector, ?string $filename = null): string
-    {
-        $locator = $this->locator($selector);
-        $binary = $locator->screenshot();
-
-        return Screenshot::save($binary, $filename);
-    }
-
-    /**
      * Make screenshot of the page.
      */
     public function screenshot(bool $fullPage = true, ?string $filename = null): ?string
@@ -446,6 +434,17 @@ final class Page
         if ($binary === null) {
             return null;
         }
+
+        return Screenshot::save($binary, $filename);
+    }
+
+    /**
+     * Make screenshot of a specific element.
+     */
+    public function screenshotElement(string $selector, ?string $filename = null): string
+    {
+        $locator = $this->locator($selector);
+        $binary = $locator->screenshot();
 
         return Screenshot::save($binary, $filename);
     }
@@ -473,18 +472,20 @@ final class Page
     {
         $cookieString = $this->evaluate('document.cookie || []');
 
-        if (blank($cookieString)) {
+        if (empty($cookieString)) {
             return [];
         }
 
         /** @var array<string, string> $cookies */
-        $cookies = Str::of(is_string($cookieString) ? $cookieString : '')
-            ->explode(';')
-            ->mapWithKeys(function (string $cookie): array {
-                $value = explode('=', $cookie);
+        $cookies = [];
+        $cookiePairs = explode(';', is_string($cookieString) ? $cookieString : '');
 
-                return [Str::trim($value[0]) => Str::trim($value[1])];
-            })->toArray();
+        foreach ($cookiePairs as $cookie) {
+            $value = explode('=', $cookie, 2);
+            if (count($value) >= 2) {
+                $cookies[mb_trim($value[0])] = mb_trim($value[1]);
+            }
+        }
 
         return $cookies;
     }
@@ -502,8 +503,7 @@ final class Page
                     .filter(img => img.complete && img.naturalWidth === 0)
                     .map(img => img.src);
             }
-            JS
-        );
+            JS);
 
         /** @var array<int, string> $brokenImages */
         return $brokenImages;
@@ -619,6 +619,27 @@ final class Page
     }
 
     /**
+     * Screenshots the page and returns the binary data.
+     */
+    private function screenshotBinary(bool $fullPage = true): ?string
+    {
+        $response = Client::instance()->execute(
+            $this->guid,
+            'screenshot',
+            $this->screenshotOptions($fullPage)
+        );
+
+        /** @var array{result: array{binary: string|null}} $message */
+        foreach ($response as $message) {
+            if (isset($message['result']['binary'])) {
+                return $message['result']['binary'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Send a message to the frame (for frame-related operations)
      *
      * @param  array<string, mixed>  $params
@@ -652,27 +673,6 @@ final class Page
         ];
 
         return in_array($method, $pageLevelOperations, true);
-    }
-
-    /**
-     * Screenshots the page and returns the binary data.
-     */
-    private function screenshotBinary(bool $fullPage = true): ?string
-    {
-        $response = Client::instance()->execute(
-            $this->guid,
-            'screenshot',
-            $this->screenshotOptions($fullPage)
-        );
-
-        /** @var array{result: array{binary: string|null}} $message */
-        foreach ($response as $message) {
-            if (isset($message['result']['binary'])) {
-                return $message['result']['binary'];
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -472,10 +472,6 @@ final class Page
     {
         $cookieString = $this->evaluate('document.cookie || []');
 
-        if (empty($cookieString)) {
-            return [];
-        }
-
         /** @var array<string, string> $cookies */
         $cookies = [];
         $cookiePairs = explode(';', is_string($cookieString) ? $cookieString : '');

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Browser\Playwright;
 
 use Generator;
+use Illuminate\Support\Str;
 use Pest\Browser\Execution;
 use Pest\Browser\Support\ImageDiffView;
 use Pest\Browser\Support\JavaScriptSerializer;
@@ -66,6 +67,21 @@ final class Page
     }
 
     /**
+     * Evaluates a JavaScript expression in the page context.
+     */
+    public function evaluate(string $pageFunction, mixed $arg = null): mixed
+    {
+        $params = [
+            'expression' => $pageFunction,
+            'arg' => JavaScriptSerializer::serializeArgument($arg),
+        ];
+
+        $response = $this->sendMessage('evaluateExpression', $params);
+
+        return $this->processResultResponse($response);
+    }
+
+    /**
      * Performs the given callback in unstrict mode.
      *
      * @template TReturn
@@ -122,6 +138,14 @@ final class Page
     }
 
     /**
+     * Create a locator for the specified selector.
+     */
+    public function locator(string $selector): Locator
+    {
+        return new Locator($this->frameGuid, $selector, $this->strictLocators);
+    }
+
+    /**
      * Finds all elements matching the specified selector.
      *
      * @return Element[]
@@ -143,14 +167,6 @@ final class Page
         }
 
         return $elements;
-    }
-
-    /**
-     * Create a locator for the specified selector.
-     */
-    public function locator(string $selector): Locator
-    {
-        return new Locator($this->frameGuid, $selector, $this->strictLocators);
     }
 
     /**
@@ -343,21 +359,6 @@ final class Page
     }
 
     /**
-     * Evaluates a JavaScript expression in the page context.
-     */
-    public function evaluate(string $pageFunction, mixed $arg = null): mixed
-    {
-        $params = [
-            'expression' => $pageFunction,
-            'arg' => JavaScriptSerializer::serializeArgument($arg),
-        ];
-
-        $response = $this->sendMessage('evaluateExpression', $params);
-
-        return $this->processResultResponse($response);
-    }
-
-    /**
      * Evaluates a JavaScript expression and returns a JSHandle.
      */
     public function evaluateHandle(string $pageFunction, mixed $arg = null): JSHandle
@@ -425,6 +426,17 @@ final class Page
     }
 
     /**
+     * Make screenshot of a specific element.
+     */
+    public function screenshotElement(string $selector, ?string $filename = null): string
+    {
+        $locator = $this->locator($selector);
+        $binary = $locator->screenshot();
+
+        return Screenshot::save($binary, $filename);
+    }
+
+    /**
      * Make screenshot of the page.
      */
     public function screenshot(bool $fullPage = true, ?string $filename = null): ?string
@@ -434,17 +446,6 @@ final class Page
         if ($binary === null) {
             return null;
         }
-
-        return Screenshot::save($binary, $filename);
-    }
-
-    /**
-     * Make screenshot of a specific element.
-     */
-    public function screenshotElement(string $selector, ?string $filename = null): string
-    {
-        $locator = $this->locator($selector);
-        $binary = $locator->screenshot();
 
         return Screenshot::save($binary, $filename);
     }
@@ -464,6 +465,31 @@ final class Page
     }
 
     /**
+     * Get the cookies from the page, if any.
+     *
+     * @return array<string, string>
+     */
+    public function cookies(): array
+    {
+        $cookieString = $this->evaluate('document.cookie || []');
+
+        if (blank($cookieString)) {
+            return [];
+        }
+
+        /** @var array<string, string> $cookies */
+        $cookies = Str::of(is_string($cookieString) ? $cookieString : '')
+            ->explode(';')
+            ->mapWithKeys(function (string $cookie): array {
+                $value = explode('=', $cookie);
+
+                return [Str::trim($value[0]) => Str::trim($value[1])];
+            })->toArray();
+
+        return $cookies;
+    }
+
+    /**
      * Get the broken images from the page, if any.
      *
      * @return array<int, string>
@@ -476,7 +502,8 @@ final class Page
                     .filter(img => img.complete && img.naturalWidth === 0)
                     .map(img => img.src);
             }
-            JS);
+            JS
+        );
 
         /** @var array<int, string> $brokenImages */
         return $brokenImages;
@@ -592,27 +619,6 @@ final class Page
     }
 
     /**
-     * Screenshots the page and returns the binary data.
-     */
-    private function screenshotBinary(bool $fullPage = true): ?string
-    {
-        $response = Client::instance()->execute(
-            $this->guid,
-            'screenshot',
-            $this->screenshotOptions($fullPage)
-        );
-
-        /** @var array{result: array{binary: string|null}} $message */
-        foreach ($response as $message) {
-            if (isset($message['result']['binary'])) {
-                return $message['result']['binary'];
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Send a message to the frame (for frame-related operations)
      *
      * @param  array<string, mixed>  $params
@@ -646,6 +652,27 @@ final class Page
         ];
 
         return in_array($method, $pageLevelOperations, true);
+    }
+
+    /**
+     * Screenshots the page and returns the binary data.
+     */
+    private function screenshotBinary(bool $fullPage = true): ?string
+    {
+        $response = Client::instance()->execute(
+            $this->guid,
+            'screenshot',
+            $this->screenshotOptions($fullPage)
+        );
+
+        /** @var array{result: array{binary: string|null}} $message */
+        foreach ($response as $message) {
+            if (isset($message['result']['binary'])) {
+                return $message['result']['binary'];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Browser/Webpage/AssertCookieMissingTest.php
+++ b/tests/Browser/Webpage/AssertCookieMissingTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('may assert cookie is missing', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertCookieMissing('nonexistent');
+});
+
+it('may assert cookie is missing with value', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertCookieMissing('test', 5);
+});
+
+it('may fail when asserting cookie is missing but it exists', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertCookieMissing('test');
+})->throws(ExpectationFailedException::class, 'Expected cookie');
+
+it('may fail when asserting cookie is missing with value but it exists with that value', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertCookieMissing('test', 1);
+})->throws(ExpectationFailedException::class, 'Expected cookie');

--- a/tests/Browser/Webpage/AssertHasCookieTest.php
+++ b/tests/Browser/Webpage/AssertHasCookieTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('may assert cookie exists', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertHasCookie('test');
+});
+
+it('may assert cookie exists with value', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertHasCookie('test', 1);
+});
+
+it('may fail when asserting cookie exists but it does not', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertHasCookie('foobar');
+})->throws(ExpectationFailedException::class, 'but it was not found');
+
+it('may fail when asserting cookie exists with value but value does not match', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertHasCookie('test', 2);
+})->throws(ExpectationFailedException::class, 'but it was not found');

--- a/tests/Browser/Webpage/AssertNoCookiesTest.php
+++ b/tests/Browser/Webpage/AssertNoCookiesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('may assert there are no cookies', function (): void {
+    Route::get('/', fn (): string => '<h1>Page with no cookies</h1>');
+
+    $page = visit('/');
+
+    $page->assertNoCookies();
+});
+
+it('may fail when asserting no cookies but there are cookies', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            document.cookie = "test=1";
+            document.cookie = "test2=2";
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoCookies();
+})->throws(ExpectationFailedException::class, 'but found 2');


### PR DESCRIPTION
Hi PestPHP team,

thank you for the awesome Pest v4 release and the new browser testing plugin.

This PR introduces functionalities to do assertions on cookies when visiting pages.

This is especially useful when you want to test applications that have some custom cookie logic. E.g. testing cookie security mechanisms, impersonation or login functionalities.


## New Assertions added in this PR
```PHP
$page = visit('https://laravel.com');

$page->assertHasCookie('laravel');
$page->assertCookieMissing('django');
$page->assertNoCookies();
```