### PR TITLE
feat: add ability to interact with dialogs

### DIFF
--- a/src/Api/Concerns/InteractsWithDialogs.php
+++ b/src/Api/Concerns/InteractsWithDialogs.php
@@ -40,7 +40,7 @@ trait InteractsWithDialogs
     /**
      * Set up automatic dialog acceptance for all future dialogs.
      */
-    public function acceptingDialogs(?string $promptText = null): self
+    public function acceptAllDialogs(?string $promptText = null): self
     {
         $this->page->onDialog(function (Dialog $dialog) use ($promptText) {
             $dialog->accept($promptText);
@@ -52,7 +52,7 @@ trait InteractsWithDialogs
     /**
      * Set up automatic dialog dismissal for all future dialogs.
      */
-    public function dismissingDialogs(): self
+    public function dismissAllDialogs(): self
     {
         $this->page->onDialog(function (Dialog $dialog) {
             $dialog->dismiss();

--- a/src/Api/Concerns/InteractsWithDialogs.php
+++ b/src/Api/Concerns/InteractsWithDialogs.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Closure;
+use Pest\Browser\Playwright\Dialog;
+
+trait InteractsWithDialogs
+{
+    /**
+     * Set up a dialog handler for this page.
+     */
+    public function onDialog(Closure $handler): self
+    {
+        $this->page->onDialog($handler);
+
+        return $this;
+    }
+
+    /**
+     * Remove any previously set dialog handler.
+     */
+    public function removeDialogHandler(): self
+    {
+        $this->page->removeDialogHandler();
+
+        return $this;
+    }
+
+    /**
+     * Check if a dialog handler is currently set.
+     */
+    public function hasDialogHandler(): bool
+    {
+        return $this->page->hasDialogHandler();
+    }
+
+    /**
+     * Set up automatic dialog acceptance for all future dialogs.
+     */
+    public function acceptingDialogs(?string $promptText = null): self
+    {
+        $this->page->onDialog(function (Dialog $dialog) use ($promptText) {
+            $dialog->accept($promptText);
+        });
+
+        return $this;
+    }
+
+    /**
+     * Set up automatic dialog dismissal for all future dialogs.
+     */
+    public function dismissingDialogs(): self
+    {
+        $this->page->onDialog(function (Dialog $dialog) {
+            $dialog->dismiss();
+        });
+
+        return $this;
+    }
+
+    /**
+     * Set up a dialog handler that accepts confirm dialogs and dismisses all others.
+     */
+    public function acceptingConfirms(): self
+    {
+        $this->page->onDialog(function (Dialog $dialog) {
+            if ($dialog->type() === 'confirm') {
+                $dialog->accept();
+            } else {
+                $dialog->dismiss();
+            }
+        });
+
+        return $this;
+    }
+
+    /**
+     * Set up a dialog handler that dismisses confirm dialogs and accepts all others.
+     */
+    public function dismissingConfirms(): self
+    {
+        $this->page->onDialog(function (Dialog $dialog) {
+            if ($dialog->type() === 'confirm') {
+                $dialog->dismiss();
+            } else {
+                $dialog->accept();
+            }
+        });
+
+        return $this;
+    }
+}

--- a/src/Api/Concerns/InteractsWithDialogs.php
+++ b/src/Api/Concerns/InteractsWithDialogs.php
@@ -42,7 +42,7 @@ trait InteractsWithDialogs
      */
     public function acceptAllDialogs(?string $promptText = null): self
     {
-        $this->page->onDialog(function (Dialog $dialog) use ($promptText) {
+        $this->page->onDialog(function (Dialog $dialog) use ($promptText): void {
             $dialog->accept($promptText);
         });
 
@@ -54,7 +54,7 @@ trait InteractsWithDialogs
      */
     public function dismissAllDialogs(): self
     {
-        $this->page->onDialog(function (Dialog $dialog) {
+        $this->page->onDialog(function (Dialog $dialog): void {
             $dialog->dismiss();
         });
 
@@ -66,7 +66,7 @@ trait InteractsWithDialogs
      */
     public function acceptingConfirms(): self
     {
-        $this->page->onDialog(function (Dialog $dialog) {
+        $this->page->onDialog(function (Dialog $dialog): void {
             if ($dialog->type() === 'confirm') {
                 $dialog->accept();
             } else {
@@ -82,7 +82,7 @@ trait InteractsWithDialogs
      */
     public function dismissingConfirms(): self
     {
-        $this->page->onDialog(function (Dialog $dialog) {
+        $this->page->onDialog(function (Dialog $dialog): void {
             if ($dialog->type() === 'confirm') {
                 $dialog->dismiss();
             } else {

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -12,6 +12,7 @@ use Pest\Browser\Support\GuessLocator;
 final readonly class Webpage
 {
     use Concerns\HasWaitCapabilities,
+        Concerns\InteractsWithDialogs,
         Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
         Concerns\InteractsWithScreen,

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -156,7 +156,16 @@ final class Client
      */
     private function handleDialogCreation(string $dialogGuid, array $initializer): void
     {
-        // TODO: Implement dialog handling
+        if ($this->currentPage !== null && $this->currentPage->hasDialogHandler()) {
+            $dialog = new Dialog(
+                $dialogGuid,
+                $initializer['type'],
+                $initializer['message'],
+                $initializer['defaultValue']
+            );
+
+            $this->currentPage->handleDialogEvent($dialog);
+        }
     }
 
     /**

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -92,6 +92,7 @@ final class Client
         $this->websocketConnection->sendText($requestJson);
 
         while (true) {
+            // @phpstan-ignore-next-line
             $responseJson = $this->fetch($this->websocketConnection);
 
             /** @var array{id: string|null, method?: string, params: array{add: string|null, type: string|null, guid: string|null, initializer: array{type: string, message: string, defaultValue: string}|null }, error: array{error: array{message: string|null}}} $response */

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -108,7 +108,6 @@ final class Client
                 throw new ExpectationFailedException($message);
             }
 
-            // Handle dialog creation
             if (isset($response['method']) && $response['method'] === '__create__'
                 && isset($response['params']['type']) && $response['params']['type'] === 'Dialog'
                 && isset($response['params']['guid'], $response['params']['initializer'])) {

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -156,7 +156,7 @@ final class Client
      */
     private function handleDialogCreation(string $dialogGuid, array $initializer): void
     {
-        if ($this->currentPage !== null && $this->currentPage->hasDialogHandler()) {
+        if ($this->currentPage instanceof Page && $this->currentPage->hasDialogHandler()) {
             $dialog = new Dialog(
                 $dialogGuid,
                 $initializer['type'],

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -27,6 +27,11 @@ final class Client
     private ?WebsocketConnection $websocketConnection = null;
 
     /**
+     * Current page instance for handling events.
+     */
+    private ?Page $currentPage = null;
+
+    /**
      * Default timeout for requests in milliseconds.
      */
     private int $timeout = 5_000;
@@ -88,7 +93,8 @@ final class Client
 
         while (true) {
             $responseJson = $this->fetch($this->websocketConnection);
-            /** @var array{id: string|null, params: array{add: string|null}, error: array{error: array{message: string|null}}} $response */
+
+            /** @var array{id: string|null, method?: string, params: array{add: string|null, type: string|null, guid: string|null, initializer: array{type: string, message: string, defaultValue: string}|null }, error: array{error: array{message: string|null}}} $response */
             $response = json_decode($responseJson, true);
 
             if (isset($response['error']['error']['message'])) {
@@ -99,6 +105,13 @@ final class Client
                 }
 
                 throw new ExpectationFailedException($message);
+            }
+
+            // Handle dialog creation
+            if (isset($response['method']) && $response['method'] === '__create__'
+                && isset($response['params']['type']) && $response['params']['type'] === 'Dialog'
+                && isset($response['params']['guid'], $response['params']['initializer'])) {
+                $this->handleDialogCreation($response['params']['guid'], $response['params']['initializer']);
             }
 
             yield $response;
@@ -126,6 +139,24 @@ final class Client
     public function timeout(): int
     {
         return $this->timeout;
+    }
+
+    /**
+     * Sets the current page for event handling.
+     */
+    public function setCurrentPage(Page $page): void
+    {
+        $this->currentPage = $page;
+    }
+
+    /**
+     * Handles dialog creation events.
+     *
+     * @param  array{type: string, message: string, defaultValue: string}  $initializer
+     */
+    private function handleDialogCreation(string $dialogGuid, array $initializer): void
+    {
+        // TODO: Implement dialog handling
     }
 
     /**

--- a/src/Playwright/Dialog.php
+++ b/src/Playwright/Dialog.php
@@ -43,7 +43,7 @@ final readonly class Dialog
     }
 
     /**
-     * Returns the dialog's type (alert, confirm, prompt, beforeunload).
+     * Returns the dialog's type (alert, confirm, prompt).
      */
     public function type(): string
     {
@@ -51,7 +51,7 @@ final readonly class Dialog
     }
 
     /**
-     * Returns the dialog's default value (for prompt dialogs).
+     * Returns the dialog's default value for prompt dialogs.
      */
     public function defaultValue(): string
     {
@@ -60,7 +60,6 @@ final readonly class Dialog
 
     /**
      * Accepts the dialog.
-     * For prompt dialogs, you can provide text input.
      */
     public function accept(?string $promptText = null): void
     {

--- a/src/Playwright/Dialog.php
+++ b/src/Playwright/Dialog.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Playwright;
+
+use Pest\Browser\Playwright\Concerns\InteractsWithPlaywright;
+
+/**
+ * @internal
+ */
+final class Dialog
+{
+    use InteractsWithPlaywright;
+
+    /**
+     * Creates a new dialog instance.
+     */
+    public function __construct(
+        private readonly string $guid,
+        private readonly string $type,
+        private readonly string $message,
+        private readonly string $defaultValue,
+    ) {
+        //
+    }
+
+    /**
+     * Returns the dialog's GUID for debugging.
+     */
+    public function guid(): string
+    {
+        return $this->guid;
+    }
+
+    /**
+     * Returns the dialog's message.
+     */
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * Returns the dialog's type (alert, confirm, prompt, beforeunload).
+     */
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns the dialog's default value (for prompt dialogs).
+     */
+    public function defaultValue(): string
+    {
+        return $this->defaultValue;
+    }
+
+    /**
+     * Accepts the dialog.
+     * For prompt dialogs, you can provide text input.
+     */
+    public function accept(?string $promptText = null): void
+    {
+        $params = [];
+        if ($promptText !== null) {
+            $params['promptText'] = $promptText;
+        }
+
+        $response = $this->sendMessage('accept', $params);
+        $this->processVoidResponse($response);
+    }
+
+    /**
+     * Dismisses the dialog.
+     */
+    public function dismiss(): void
+    {
+        $response = $this->sendMessage('dismiss');
+        $this->processVoidResponse($response);
+    }
+
+    /**
+     * Send a message to the dialog via the channel.
+     *
+     * @param  array<string, mixed>  $params
+     */
+    private function sendMessage(string $method, array $params = []): \Generator
+    {
+        return Client::instance()->execute($this->guid, $method, $params);
+    }
+}

--- a/src/Playwright/Dialog.php
+++ b/src/Playwright/Dialog.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Playwright;
 
+use Generator;
 use Pest\Browser\Playwright\Concerns\InteractsWithPlaywright;
 
 /**
  * @internal
  */
-final class Dialog
+final readonly class Dialog
 {
     use InteractsWithPlaywright;
 
@@ -17,10 +18,10 @@ final class Dialog
      * Creates a new dialog instance.
      */
     public function __construct(
-        private readonly string $guid,
-        private readonly string $type,
-        private readonly string $message,
-        private readonly string $defaultValue,
+        private string $guid,
+        private string $type,
+        private string $message,
+        private string $defaultValue,
     ) {
         //
     }
@@ -86,7 +87,7 @@ final class Dialog
      *
      * @param  array<string, mixed>  $params
      */
-    private function sendMessage(string $method, array $params = []): \Generator
+    private function sendMessage(string $method, array $params = []): Generator
     {
         return Client::instance()->execute($this->guid, $method, $params);
     }

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -583,6 +583,7 @@ final class Page
             'event' => 'dialog',
             'enabled' => true,
         ]);
+
         $this->processVoidResponse($response);
     }
 
@@ -597,6 +598,7 @@ final class Page
             'event' => 'dialog',
             'enabled' => false,
         ]);
+
         $this->processVoidResponse($response);
     }
 

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -605,7 +605,7 @@ final class Page
      */
     public function hasDialogHandler(): bool
     {
-        return $this->dialogHandler !== null;
+        return $this->dialogHandler instanceof Closure;
     }
 
     /**
@@ -621,7 +621,7 @@ final class Page
      */
     public function handleDialogEvent(Dialog $dialog): void
     {
-        if ($this->dialogHandler !== null) {
+        if ($this->dialogHandler instanceof Closure) {
             ($this->dialogHandler)($dialog);
         }
     }

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Playwright;
 
+use Closure;
 use Generator;
 use Pest\Browser\Execution;
 use Pest\Browser\Support\ImageDiffView;
@@ -33,6 +34,11 @@ final class Page
     private bool $strictLocators = true;
 
     /**
+     * Dialog event handler.
+     */
+    private ?Closure $dialogHandler = null;
+
+    /**
      * Creates a new page instance.
      */
     public function __construct(
@@ -40,7 +46,7 @@ final class Page
         private readonly string $guid,
         private readonly string $frameGuid,
     ) {
-        //
+        Client::instance()->setCurrentPage($this);
     }
 
     /**
@@ -563,6 +569,60 @@ final class Page
                   - Expected? Update the snapshots with [--update-snapshots].
                 EOT,
             );
+        }
+    }
+
+    /**
+     * Sets up a dialog handler for this page.
+     */
+    public function onDialog(Closure $handler): void
+    {
+        $this->dialogHandler = $handler;
+
+        $response = Client::instance()->execute($this->guid, 'updateSubscription', [
+            'event' => 'dialog',
+            'enabled' => true,
+        ]);
+        $this->processVoidResponse($response);
+    }
+
+    /**
+     * Removes any previously set dialog handler.
+     */
+    public function removeDialogHandler(): void
+    {
+        $this->dialogHandler = null;
+
+        $response = Client::instance()->execute($this->guid, 'updateSubscription', [
+            'event' => 'dialog',
+            'enabled' => false,
+        ]);
+        $this->processVoidResponse($response);
+    }
+
+    /**
+     * Checks if a dialog handler is currently set.
+     */
+    public function hasDialogHandler(): bool
+    {
+        return $this->dialogHandler !== null;
+    }
+
+    /**
+     * Gets the current dialog handler.
+     */
+    public function getDialogHandler(): ?Closure
+    {
+        return $this->dialogHandler;
+    }
+
+    /**
+     * Handles a dialog event from the Playwright server.
+     */
+    public function handleDialogEvent(Dialog $dialog): void
+    {
+        if ($this->dialogHandler !== null) {
+            ($this->dialogHandler)($dialog);
         }
     }
 

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Browser\Playwright;
 
 use Closure;
+use Exception;
 use Generator;
 use Pest\Browser\Execution;
 use Pest\Browser\Support\ImageDiffView;
@@ -624,7 +625,13 @@ final class Page
     public function handleDialogEvent(Dialog $dialog): void
     {
         if ($this->dialogHandler instanceof Closure) {
-            ($this->dialogHandler)($dialog);
+            try {
+                ($this->dialogHandler)($dialog);
+            } catch (Exception $e) {
+                $dialog->dismiss();
+
+                throw $e;
+            }
         }
     }
 

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\ExpectationFailedException;
 
 it('can handle alert dialog with custom handler', function (): void {
     Route::get('/', fn (): string => '
@@ -37,4 +38,18 @@ it('can auto dismiss dialog', function (): void {
 
     $page->assertSee('Normal text on page.');
 });
+
+it('can not auto dismiss dialog when interupted', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="alert-btn" onclick="alert(\'Hello World!\');">Show Alert</button>
+        <p>Normal text on page.</p>
+    ');
+
+    $page = visit('/')
+        ->onDialog(function ($dialog) {
+            //
+        });
+
+    $page->click('#alert-btn');
+})->throws(ExpectationFailedException::class);
 

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -12,7 +12,9 @@ it('can handle alert dialog with custom handler', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function (Dialog $dialog): void {
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
         expect($dialog->type())->toBe('alert');
         expect($dialog->message())->toBe('Hello World!');
 
@@ -41,10 +43,11 @@ it('can not auto dismiss dialog when interupted', function (): void {
         <p>Normal text on page.</p>
     ');
 
-    $page = visit('/')
-        ->onDialog(function (Dialog $dialog): void {
-            //
-        });
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
+        //
+    });
 
     $page->click('#alert-btn');
 })->throws(ExpectationFailedException::class);
@@ -58,7 +61,9 @@ it('can handle confirm dialog with acceptance', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function (Dialog $dialog): void {
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
         expect($dialog->message())->toBe('Are you sure?');
 
         $dialog->accept();
@@ -78,7 +83,9 @@ it('can handle confirm dialog with dismissal', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function (Dialog $dialog): void {
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
         expect($dialog->message())->toBe('Are you sure?');
 
         $dialog->dismiss();
@@ -98,7 +105,9 @@ it('can handle prompt dialog with custom input', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function (Dialog $dialog): void {
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
         expect($dialog->message())->toBe('What is your name?');
         expect($dialog->defaultValue())->toBe('Default Name');
 
@@ -119,7 +128,9 @@ it('can handle prompt dialog with dismissal', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function (Dialog $dialog): void {
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
         $dialog->dismiss();
     });
 
@@ -139,7 +150,9 @@ it('can auto-accept all dialogs', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->acceptAllDialogs('Test User');
+    $page = visit('/');
+
+    $page->acceptAllDialogs('Test User');
 
     $page->click('#multi-btn');
 
@@ -157,7 +170,9 @@ it('can auto-dismiss all dialogs', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->dismissAllDialogs();
+    $page = visit('/');
+
+    $page->dismissAllDialogs();
 
     $page->click('#multi-btn');
 
@@ -174,7 +189,9 @@ it('can selectively accept only confirm dialogs', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->acceptingConfirms();
+    $page = visit('/');
+
+    $page->acceptingConfirms();
 
     $page->click('#mixed-btn');
 
@@ -191,7 +208,9 @@ it('can selectively dismiss only confirm dialogs', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->dismissingConfirms();
+    $page = visit('/');
+
+    $page->dismissingConfirms();
 
     $page->click('#mixed-btn');
 
@@ -226,7 +245,9 @@ it('can handle multiple sequential dialogs with different types', function (): v
     ');
 
     $stepCount = 0;
-    $page = visit('/')->onDialog(function (Dialog $dialog) use (&$stepCount): void {
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog) use (&$stepCount): void {
         $stepCount++;
 
         if ($stepCount === 1) {

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Pest\Browser\Playwright\Dialog;
 use PHPUnit\Framework\ExpectationFailedException;
 
 it('can handle alert dialog with custom handler', function (): void {
@@ -11,20 +12,15 @@ it('can handle alert dialog with custom handler', function (): void {
         <div id="result"></div>
     ');
 
-    $dialogHandled = false;
-    $dialogMessage = '';
-
-    $page = visit('/')->onDialog(function ($dialog) use (&$dialogHandled, &$dialogMessage) {
-        $dialogHandled = true;
-        $dialogMessage = $dialog->message();
+    $page = visit('/')->onDialog(function (Dialog $dialog) {
         expect($dialog->type())->toBe('alert');
+        expect($dialog->message())->toBe('Hello World!');
+
         $dialog->accept();
     });
 
     $page->click('#alert-btn');
 
-    expect($dialogHandled)->toBeTrue();
-    expect($dialogMessage)->toBe('Hello World!');
     expect($page->text('#result'))->toBe('Alert handled');
 });
 
@@ -46,7 +42,7 @@ it('can not auto dismiss dialog when interupted', function (): void {
     ');
 
     $page = visit('/')
-        ->onDialog(function ($dialog) {
+        ->onDialog(function (Dialog $dialog) {
             //
         });
 

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -129,3 +129,39 @@ it('can handle prompt dialog with dismissal', function (): void {
     expect($page->text('#result'))->toBe('No input');
 });
 
+it('can auto-accept all dialogs', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="multi-btn" onclick="
+            alert(\'First alert\');
+            var confirm_result = confirm(\'Continue?\');
+            var prompt_result = prompt(\'Your name?\', \'Default\');
+            document.getElementById(\'result\').textContent = confirm_result + \'-\' + prompt_result;
+        ">Show Multiple</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->acceptAllDialogs('Test User');
+
+    $page->click('#multi-btn');
+
+    expect($page->text('#result'))->toBe('true-Test User');
+});
+
+it('can auto-dismiss all dialogs', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="multi-btn" onclick="
+            alert(\'First alert\');
+            var confirm_result = confirm(\'Continue?\');
+            var prompt_result = prompt(\'Your name?\');
+            document.getElementById(\'result\').textContent = (confirm_result || \'false\') + \'-\' + (prompt_result || \'null\');
+        ">Show Multiple</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->dismissAllDialogs();
+
+    $page->click('#multi-btn');
+
+    expect($page->text('#result'))->toBe('false-null');
+});
+

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -12,7 +12,7 @@ it('can handle alert dialog with custom handler', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function (Dialog $dialog) {
+    $page = visit('/')->onDialog(function (Dialog $dialog): void {
         expect($dialog->type())->toBe('alert');
         expect($dialog->message())->toBe('Hello World!');
 
@@ -42,7 +42,7 @@ it('can not auto dismiss dialog when interupted', function (): void {
     ');
 
     $page = visit('/')
-        ->onDialog(function (Dialog $dialog) {
+        ->onDialog(function (Dialog $dialog): void {
             //
         });
 
@@ -58,7 +58,7 @@ it('can handle confirm dialog with acceptance', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function ($dialog) {
+    $page = visit('/')->onDialog(function (Dialog $dialog): void {
         expect($dialog->message())->toBe('Are you sure?');
 
         $dialog->accept();
@@ -78,7 +78,7 @@ it('can handle confirm dialog with dismissal', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function ($dialog) {
+    $page = visit('/')->onDialog(function (Dialog $dialog): void {
         expect($dialog->message())->toBe('Are you sure?');
 
         $dialog->dismiss();
@@ -98,7 +98,7 @@ it('can handle prompt dialog with custom input', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function ($dialog) {
+    $page = visit('/')->onDialog(function (Dialog $dialog): void {
         expect($dialog->message())->toBe('What is your name?');
         expect($dialog->defaultValue())->toBe('Default Name');
 
@@ -119,7 +119,7 @@ it('can handle prompt dialog with dismissal', function (): void {
         <div id="result"></div>
     ');
 
-    $page = visit('/')->onDialog(function ($dialog) {
+    $page = visit('/')->onDialog(function (Dialog $dialog): void {
         $dialog->dismiss();
     });
 
@@ -226,7 +226,7 @@ it('can handle multiple sequential dialogs with different types', function (): v
     ');
 
     $stepCount = 0;
-    $page = visit('/')->onDialog(function ($dialog) use (&$stepCount) {
+    $page = visit('/')->onDialog(function (Dialog $dialog) use (&$stepCount): void {
         $stepCount++;
 
         if ($stepCount === 1) {

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('can handle alert dialog with custom handler', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="alert-btn" onclick="alert(\'Hello World!\'); document.getElementById(\'result\').textContent = \'Alert handled\';">Show Alert</button>
+        <div id="result"></div>
+    ');
+
+    $dialogHandled = false;
+    $dialogMessage = '';
+
+    $page = visit('/')->onDialog(function ($dialog) use (&$dialogHandled, &$dialogMessage) {
+        $dialogHandled = true;
+        $dialogMessage = $dialog->message();
+        expect($dialog->type())->toBe('alert');
+        $dialog->accept();
+    });
+
+    $page->click('#alert-btn');
+
+    expect($dialogHandled)->toBeTrue();
+    expect($dialogMessage)->toBe('Hello World!');
+    expect($page->text('#result'))->toBe('Alert handled');
+});

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -26,3 +26,15 @@ it('can handle alert dialog with custom handler', function (): void {
     expect($dialogMessage)->toBe('Hello World!');
     expect($page->text('#result'))->toBe('Alert handled');
 });
+
+it('can auto dismiss dialog', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="alert-btn" onclick="alert(\'Hello World!\');">Show Alert</button>
+        <p>Normal text on page.</p>
+    ');
+
+    $page = visit('/');
+
+    $page->assertSee('Normal text on page.');
+});
+

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -179,6 +179,32 @@ it('can auto-dismiss all dialogs', function (): void {
     expect($page->text('#result'))->toBe('false-null');
 });
 
+it('can accept one and dismiss all dialogs', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="multi-btn" onclick="
+            alert(\'First alert\');
+            var confirm_result = confirm(\'Continue?\');
+            var prompt_result = prompt(\'Your name?\');
+            document.getElementById(\'result\').textContent = (confirm_result || \'false\') + \'-\' + (prompt_result || \'null\');
+        ">Show Multiple</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
+        if ($dialog->type() === 'alert') {
+            $dialog->accept();
+        }
+    });
+
+    $page->dismissAllDialogs();
+
+    $page->click('#multi-btn');
+
+    expect($page->text('#result'))->toBe('false-null');
+});
+
 it('can selectively accept only confirm dialogs', function (): void {
     Route::get('/', fn (): string => '
         <button id="mixed-btn" onclick="

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -296,3 +296,19 @@ it('can handle multiple sequential dialogs with different types', function (): v
     expect($stepCount)->toBe(3);
     expect($page->text('#result'))->toBe('Hello Integration Test');
 });
+
+it('can handle dialog expectation failure', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="confirm-btn" onclick="confirm(\'Are you sure?\');">Show Confirm</button>
+    ');
+
+    $page = visit('/');
+
+    $page->onDialog(function (Dialog $dialog): void {
+        expect($dialog->message())->toBe('Wrong text');
+
+        $dialog->accept();
+    });
+
+    $page->click('Show Confirm');
+})->throws(ExpectationFailedException::class);

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -49,3 +49,83 @@ it('can not auto dismiss dialog when interupted', function (): void {
     $page->click('#alert-btn');
 })->throws(ExpectationFailedException::class);
 
+it('can handle confirm dialog with acceptance', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="confirm-btn" onclick="
+            var result = confirm(\'Are you sure?\');
+            document.getElementById(\'result\').textContent = result ? \'Confirmed\' : \'Cancelled\';
+        ">Show Confirm</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->onDialog(function ($dialog) {
+        expect($dialog->type())->toBe('confirm');
+        expect($dialog->message())->toBe('Are you sure?');
+        $dialog->accept();
+    });
+
+    $page->click('#confirm-btn');
+
+    expect($page->text('#result'))->toBe('Confirmed');
+});
+
+it('can handle confirm dialog with dismissal', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="confirm-btn" onclick="
+            var result = confirm(\'Are you sure?\');
+            document.getElementById(\'result\').textContent = result ? \'Confirmed\' : \'Cancelled\';
+        ">Show Confirm</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->onDialog(function ($dialog) {
+        expect($dialog->type())->toBe('confirm');
+        expect($dialog->message())->toBe('Are you sure?');
+        $dialog->dismiss();
+    });
+
+    $page->click('#confirm-btn');
+
+    expect($page->text('#result'))->toBe('Cancelled');
+});
+
+it('can handle prompt dialog with custom input', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="prompt-btn" onclick="
+            var result = prompt(\'What is your name?\', \'Default Name\');
+            document.getElementById(\'result\').textContent = result || \'No input\';
+        ">Show Prompt</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->onDialog(function ($dialog) {
+        expect($dialog->type())->toBe('prompt');
+        expect($dialog->message())->toBe('What is your name?');
+        expect($dialog->defaultValue())->toBe('Default Name');
+        $dialog->accept('John Doe');
+    });
+
+    $page->click('#prompt-btn');
+
+    expect($page->text('#result'))->toBe('John Doe');
+});
+
+it('can handle prompt dialog with dismissal', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="prompt-btn" onclick="
+            var result = prompt(\'What is your name?\');
+            document.getElementById(\'result\').textContent = result || \'No input\';
+        ">Show Prompt</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->onDialog(function ($dialog) {
+        expect($dialog->type())->toBe('prompt');
+        $dialog->dismiss();
+    });
+
+    $page->click('#prompt-btn');
+
+    expect($page->text('#result'))->toBe('No input');
+});
+

--- a/tests/Browser/Webpage/DialogTest.php
+++ b/tests/Browser/Webpage/DialogTest.php
@@ -59,8 +59,8 @@ it('can handle confirm dialog with acceptance', function (): void {
     ');
 
     $page = visit('/')->onDialog(function ($dialog) {
-        expect($dialog->type())->toBe('confirm');
         expect($dialog->message())->toBe('Are you sure?');
+
         $dialog->accept();
     });
 
@@ -79,8 +79,8 @@ it('can handle confirm dialog with dismissal', function (): void {
     ');
 
     $page = visit('/')->onDialog(function ($dialog) {
-        expect($dialog->type())->toBe('confirm');
         expect($dialog->message())->toBe('Are you sure?');
+
         $dialog->dismiss();
     });
 
@@ -99,9 +99,9 @@ it('can handle prompt dialog with custom input', function (): void {
     ');
 
     $page = visit('/')->onDialog(function ($dialog) {
-        expect($dialog->type())->toBe('prompt');
         expect($dialog->message())->toBe('What is your name?');
         expect($dialog->defaultValue())->toBe('Default Name');
+
         $dialog->accept('John Doe');
     });
 
@@ -120,7 +120,6 @@ it('can handle prompt dialog with dismissal', function (): void {
     ');
 
     $page = visit('/')->onDialog(function ($dialog) {
-        expect($dialog->type())->toBe('prompt');
         $dialog->dismiss();
     });
 
@@ -165,3 +164,88 @@ it('can auto-dismiss all dialogs', function (): void {
     expect($page->text('#result'))->toBe('false-null');
 });
 
+it('can selectively accept only confirm dialogs', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="mixed-btn" onclick="
+            alert(\'Alert message\');
+            var confirm_result = confirm(\'Confirm message\');
+            document.getElementById(\'result\').textContent = \'confirm:\' + confirm_result;
+        ">Show Mixed</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->acceptingConfirms();
+
+    $page->click('#mixed-btn');
+
+    expect($page->text('#result'))->toBe('confirm:true');
+});
+
+it('can selectively dismiss only confirm dialogs', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="mixed-btn" onclick="
+            alert(\'Alert message\');
+            var confirm_result = confirm(\'Confirm message\');
+            document.getElementById(\'result\').textContent = \'confirm:\' + confirm_result;
+        ">Show Mixed</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/')->dismissingConfirms();
+
+    $page->click('#mixed-btn');
+
+    expect($page->text('#result'))->toBe('confirm:false');
+});
+
+it('can remove dialog handlers', function (): void {
+    $page = visit('/');
+
+    expect($page->hasDialogHandler())->toBeFalse();
+
+    $page->acceptAllDialogs();
+    expect($page->hasDialogHandler())->toBeTrue();
+
+    $page->removeDialogHandler();
+    expect($page->hasDialogHandler())->toBeFalse();
+});
+
+it('can handle multiple sequential dialogs with different types', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="sequence-btn" onclick="
+            alert(\'Step 1: Alert\');
+            var confirm_result = confirm(\'Step 2: Confirm?\');
+            if (confirm_result) {
+                var prompt_result = prompt(\'Step 3: Your name?\', \'Anonymous\');
+                document.getElementById(\'result\').textContent = \'Hello \' + (prompt_result || \'Anonymous\');
+            } else {
+                document.getElementById(\'result\').textContent = \'Process cancelled\';
+            }
+        ">Start Sequence</button>
+        <div id="result"></div>
+    ');
+
+    $stepCount = 0;
+    $page = visit('/')->onDialog(function ($dialog) use (&$stepCount) {
+        $stepCount++;
+
+        if ($stepCount === 1) {
+            expect($dialog->message())->toBe('Step 1: Alert');
+
+            $dialog->accept();
+        } elseif ($stepCount === 2) {
+            expect($dialog->message())->toBe('Step 2: Confirm?');
+
+            $dialog->accept();
+        } elseif ($stepCount === 3) {
+            expect($dialog->message())->toBe('Step 3: Your name?');
+
+            $dialog->accept('Integration Test');
+        }
+    });
+
+    $page->click('#sequence-btn');
+
+    expect($stepCount)->toBe(3);
+    expect($page->text('#result'))->toBe('Hello Integration Test');
+});


### PR DESCRIPTION
This pull request adds the ability to test and interact with browser dialogs. Playwright automatically dismisses the dialogs if they are not explicitly interrupted in tests. However, sometimes you might want to make sure if certain dialogs appear, under certain conditions and maybe with some dynamic content or alert.

Example: 

```php
use Pest\Browser\Playwright\Dialog;

$page = visit('/');

$page->onDialog(function (Dialog $dialog): void {
    expect($dialog->type())->toBe('alert');
    expect($dialog->message())->toBe('Hello World!');

    $dialog->accept();
});

$page->click('#alert-btn');
```

