### PR TITLE
[Bug] `Selector::isExplicit()` assume any `.` refers to CSS selector

### DIFF
--- a/tests/Unit/Support/SelectorTest.php
+++ b/tests/Unit/Support/SelectorTest.php
@@ -242,7 +242,7 @@ it('properly detects explicit selectors', function (): void {
         ->and(Selector::isExplicit('test'))->toBeFalse()
         ->and(Selector::isExplicit('Click Me Button'))->toBeFalse()
         ->and(Selector::isExplicit('Submit Form'))->toBeFalse()
-        ->and(Selector::isExplicit('Mr. Nuno Maduro'))->toToFalse();
+        ->and(Selector::isExplicit('Mr. Nuno Maduro'))->toBeFalse();
 });
 
 it('properly detects data-test selectors', function (): void {

--- a/tests/Unit/Support/SelectorTest.php
+++ b/tests/Unit/Support/SelectorTest.php
@@ -241,7 +241,8 @@ it('properly detects explicit selectors', function (): void {
         // Plain text should be false
         ->and(Selector::isExplicit('test'))->toBeFalse()
         ->and(Selector::isExplicit('Click Me Button'))->toBeFalse()
-        ->and(Selector::isExplicit('Submit Form'))->toBeFalse();
+        ->and(Selector::isExplicit('Submit Form'))->toBeFalse()
+        ->and(Selector::isExplicit('Mr. Nuno Maduro'))->toToFalse();
 });
 
 it('properly detects data-test selectors', function (): void {


### PR DESCRIPTION
This only illustrates the issue and a proper fix needs to be implemented:

<img width="2566" height="646" alt="image" src="https://github.com/user-attachments/assets/ac256928-86fb-4363-9feb-cfa6c54755bb" />
