### PR TITLE
fix: use null to set static property

### DIFF
--- a/src/Execution.php
+++ b/src/Execution.php
@@ -171,7 +171,6 @@ final class Execution
         $reflector = new ReflectionClass(Assert::class);
         $property = $reflector->getProperty('count');
 
-        // @phpstan-ignore-next-line
-        $property->setValue(Assert::class, $originalCount);
+        $property->setValue(null, $originalCount);
     }
 }


### PR DESCRIPTION
Fix deprecation warning. Pass `null` to set value for static property.