### PR TITLE
Fix stopping playwright server

### DIFF
--- a/src/Playwright/Servers/PlaywrightNpmServer.php
+++ b/src/Playwright/Servers/PlaywrightNpmServer.php
@@ -60,11 +60,11 @@ final class PlaywrightNpmServer implements PlaywrightServer
             return;
         }
 
-        $this->systemProcess = SystemProcess::fromShellCommandline(sprintf(
+        $this->systemProcess = new SystemProcess(explode(' ', sprintf(
             $this->command,
             $this->host,
             $this->port,
-        ), $this->baseDirectory, [
+        )), $this->baseDirectory, [
             'APP_URL' => sprintf('http://%s:%d', $this->host, $this->port),
         ]);
 

--- a/src/ServerManager.php
+++ b/src/ServerManager.php
@@ -58,20 +58,22 @@ final class ServerManager
             return AlreadyStartedPlaywrightServer::fromPersisted();
         }
 
-        $port = Port::find();
+        if (! $this->playwright instanceof PlaywrightServer) {
+            $port = Port::find();
 
-        $this->playwright ??= PlaywrightNpmServer::create(
-            PackageJsonDirectory::find(),
-            '.'.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR.'.bin'.DIRECTORY_SEPARATOR.'playwright run-server --host %s --port %d --mode launchServer',
-            self::DEFAULT_HOST,
-            $port,
-            'Listening on',
-        );
+            $this->playwright = PlaywrightNpmServer::create(
+                PackageJsonDirectory::find(),
+                '.'.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR.'.bin'.DIRECTORY_SEPARATOR.'playwright run-server --host %s --port %d --mode launchServer',
+                self::DEFAULT_HOST,
+                $port,
+                'Listening on',
+            );
 
-        AlreadyStartedPlaywrightServer::persist(
-            self::DEFAULT_HOST,
-            $port,
-        );
+            AlreadyStartedPlaywrightServer::persist(
+                self::DEFAULT_HOST,
+                $port,
+            );
+        }
 
         return $this->playwright;
     }


### PR DESCRIPTION
When pest completes, a terminate signal is sent to stop the playwright server. As it is run using a shell (by passing commandline as a string), the shell receives this signal, which it does not forward to playwright.

This means that the `playwright run-server` command continues running after pest exits.

## Solution

Run playwright server command without shell (passing commandline as an array) so that signals can be sent directly to playwright to terminate it.

## Related change

Avoid persisting a new port for `AlreadyStartedPlaywrightServer` if playwright is already set.