### PR TITLE
Add support for popup windows

### DIFF
--- a/src/Api/Concerns/InteractsWithPopups.php
+++ b/src/Api/Concerns/InteractsWithPopups.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Pest\Browser\Api\PendingAwaitablePopup;
+
+trait InteractsWithPopups
+{
+    /**
+     * Set up a popup handler for this page.
+     */
+    public function pendingPopup(): PendingAwaitablePopup
+    {
+        return $this->page->pendingPopup();
+    }
+
+    /**
+     * Remove any previously set popup handler.
+     */
+    public function removePendingPopup(): self
+    {
+        $this->page->removePendingPopup();
+
+        return $this;
+    }
+
+    /**
+     * Check if a popup handler is currently set.
+     */
+    public function hasPendingPopup(): bool
+    {
+        return $this->page->hasPendingPopup();
+    }
+}

--- a/src/Api/PendingAwaitablePopup.php
+++ b/src/Api/PendingAwaitablePopup.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api;
+
+use Pest\Browser\Exceptions\BrowserExpectationFailedException;
+use Pest\Browser\Execution;
+use Pest\Browser\Playwright\Page;
+use PHPUnit\Framework\ExpectationFailedException;
+
+/**
+ * @mixin Webpage|AwaitableWebpage
+ */
+final class PendingAwaitablePopup
+{
+    /**
+     * The webpage instance that will be returned when the popup is created.
+     */
+    private ?AwaitableWebpage $waitablePage = null;
+
+    /**
+     * Creates a new pending awaitable popup instance.
+     */
+    public function __construct(
+        private readonly Page $opener,
+    ) {
+        //
+    }
+
+    /**
+     * Calls the given method on page, waiting if needed for it to be created.
+     *
+     * @param  array<int, mixed>  $arguments
+     */
+    public function __call(string $name, array $arguments): mixed
+    {
+        if ($this->waitablePage instanceof AwaitableWebpage) {
+            // @phpstan-ignore-next-line
+            return $this->waitablePage->{$name}(...$arguments);
+        }
+
+        $result = Execution::instance()->waitForExpectation(function () use ($name, $arguments): mixed {
+            if (is_null($this->waitablePage)) {
+                $e = new ExpectationFailedException('No popup opened');
+                throw BrowserExpectationFailedException::from($this->opener, $e);
+            }
+
+            // @phpstan-ignore-next-line
+            return $this->waitablePage->{$name}(...$arguments);
+        });
+
+        return $result === $this->waitablePage
+            ? $this
+            : $result;
+    }
+
+    public function handlePopupCreation(string $popupGuid, string $frameGuid): void
+    {
+        $page = new Page($this->opener->context(), $popupGuid, $frameGuid);
+        $this->waitablePage = new AwaitableWebpage($page, '(popup)');
+    }
+}

--- a/src/Api/PendingAwaitablePopup.php
+++ b/src/Api/PendingAwaitablePopup.php
@@ -10,7 +10,7 @@ use Pest\Browser\Playwright\Page;
 use PHPUnit\Framework\ExpectationFailedException;
 
 /**
- * @mixin Webpage|AwaitableWebpage
+ * @mixin AwaitableWebpage
  */
 final class PendingAwaitablePopup
 {

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -14,6 +14,7 @@ final readonly class Webpage
     use Concerns\HasWaitCapabilities,
         Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
+        Concerns\InteractsWithPopups,
         Concerns\InteractsWithScreen,
         Concerns\InteractsWithTab,
         Concerns\InteractsWithToolbar,

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -97,7 +97,7 @@ final class Client
             // @phpstan-ignore-next-line
             $responseJson = $this->fetch($this->websocketConnection);
 
-            /** @var array{id: string|null, guid: string|null, method: string|null, params: array{add: string|null}, error: array{error: array{message: string|null}}} $response */
+            /** @var array{id: string|null, guid: string|null, method: string|null, params: array{add: string|null, type: string|null, guid: string|null, initializer: array{mainFrame: array{guid: string}, opener: array{guid: string}}|null }, error: array{error: array{message: string|null}}} $response */
             $response = json_decode($responseJson, true);
 
             if (isset($response['error']['error']['message'])) {
@@ -108,6 +108,12 @@ final class Client
                 }
 
                 throw new ExpectationFailedException($message);
+            }
+
+            if (isset($response['method']) && $response['method'] === '__create__'
+                && isset($response['params']['type']) && $response['params']['type'] === 'Page'
+                && isset($response['guid'], $response['params']['guid'], $response['params']['initializer']['opener']['guid'])) {
+                $this->handlePopupCreation($response['params']['initializer']['opener']['guid'], $response['params']['guid'], $response['params']['initializer']);
             }
 
             if (isset($response['method']) && $response['method'] === '__dispose__'
@@ -156,6 +162,18 @@ final class Client
     public function unregisterPage(string $guid): void
     {
         unset($this->pages[$guid]);
+    }
+
+    /**
+     * Handles popup creation events.
+     *
+     * @param  array{mainFrame: array{guid: string}, opener: array{guid: string}}  $initializer
+     */
+    private function handlePopupCreation(string $openerGuid, string $popupGuid, array $initializer): void
+    {
+        if (isset($this->pages[$openerGuid]) && $this->pages[$openerGuid]->hasPendingPopup()) {
+            $this->pages[$openerGuid]->handlePopupCreation($popupGuid, $initializer['mainFrame']['guid']);
+        }
     }
 
     /**

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -27,6 +27,13 @@ final class Client
     private ?WebsocketConnection $websocketConnection = null;
 
     /**
+     * Registry of Page instances for handling events.
+     *
+     * @var Page[]
+     */
+    private array $pages = [];
+
+    /**
      * Default timeout for requests in milliseconds.
      */
     private int $timeout = 5_000;
@@ -87,8 +94,10 @@ final class Client
         $this->websocketConnection->sendText($requestJson);
 
         while (true) {
+            // @phpstan-ignore-next-line
             $responseJson = $this->fetch($this->websocketConnection);
-            /** @var array{id: string|null, params: array{add: string|null}, error: array{error: array{message: string|null}}} $response */
+
+            /** @var array{id: string|null, guid: string|null, method: string|null, params: array{add: string|null}, error: array{error: array{message: string|null}}} $response */
             $response = json_decode($responseJson, true);
 
             if (isset($response['error']['error']['message'])) {
@@ -99,6 +108,11 @@ final class Client
                 }
 
                 throw new ExpectationFailedException($message);
+            }
+
+            if (isset($response['method']) && $response['method'] === '__dispose__'
+                && isset($response['guid'], $this->pages[$response['guid']])) {
+                $this->unregisterPage($response['guid']);
             }
 
             yield $response;
@@ -126,6 +140,22 @@ final class Client
     public function timeout(): int
     {
         return $this->timeout;
+    }
+
+    /**
+     * Registers the current page for event handling.
+     */
+    public function registerPage(string $guid, Page $page): void
+    {
+        $this->pages[$guid] = $page;
+    }
+
+    /**
+     * Removes page from event handling.
+     */
+    public function unregisterPage(string $guid): void
+    {
+        unset($this->pages[$guid]);
     }
 
     /**

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -8,6 +8,7 @@ use Amp\Websocket\Client\WebsocketConnection;
 use Generator;
 use Pest\Browser\Exceptions\PlaywrightOutdatedException;
 use PHPUnit\Framework\ExpectationFailedException;
+use WeakReference;
 
 use function Amp\Websocket\Client\connect;
 
@@ -29,7 +30,7 @@ final class Client
     /**
      * Registry of Page instances for handling events.
      *
-     * @var Page[]
+     * @var array<string, WeakReference<Page>>
      */
     private array $pages = [];
 
@@ -117,7 +118,7 @@ final class Client
             }
 
             if (isset($response['method']) && $response['method'] === '__dispose__'
-                && isset($response['guid'], $this->pages[$response['guid']])) {
+                && isset($response['guid']) && $this->getPage($response['guid']) instanceof Page) {
                 $this->unregisterPage($response['guid']);
             }
 
@@ -153,7 +154,7 @@ final class Client
      */
     public function registerPage(string $guid, Page $page): void
     {
-        $this->pages[$guid] = $page;
+        $this->pages[$guid] = WeakReference::create($page);
     }
 
     /**
@@ -164,6 +165,15 @@ final class Client
         unset($this->pages[$guid]);
     }
 
+    private function getPage(string $guid): ?Page
+    {
+        if (! array_key_exists($guid, $this->pages)) {
+            return null;
+        }
+
+        return $this->pages[$guid]->get();
+    }
+
     /**
      * Handles popup creation events.
      *
@@ -171,8 +181,9 @@ final class Client
      */
     private function handlePopupCreation(string $openerGuid, string $popupGuid, array $initializer): void
     {
-        if (isset($this->pages[$openerGuid]) && $this->pages[$openerGuid]->hasPendingPopup()) {
-            $this->pages[$openerGuid]->handlePopupCreation($popupGuid, $initializer['mainFrame']['guid']);
+        $opener = $this->getPage($openerGuid);
+        if ($opener instanceof Page && $opener->hasPendingPopup()) {
+            $opener->handlePopupCreation($popupGuid, $initializer['mainFrame']['guid']);
         }
     }
 

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Browser\Playwright;
 
 use Generator;
+use Pest\Browser\Api\PendingAwaitablePopup;
 use Pest\Browser\Execution;
 use Pest\Browser\Support\ImageDiffView;
 use Pest\Browser\Support\JavaScriptSerializer;
@@ -31,6 +32,11 @@ final class Page
      * Enable or disable strict locators.
      */
     private bool $strictLocators = true;
+
+    /**
+     * Pending AwaitablePage for a Popup.
+     */
+    private ?PendingAwaitablePopup $pendingPopup = null;
 
     /**
      * Creates a new page instance.
@@ -563,6 +569,43 @@ final class Page
                   - Expected? Update the snapshots with [--update-snapshots].
                 EOT,
             );
+        }
+    }
+
+    /**
+     * Sets up a popup handler for this page.
+     */
+    public function pendingPopup(): PendingAwaitablePopup
+    {
+        $this->pendingPopup = new PendingAwaitablePopup($this);
+
+        return $this->pendingPopup;
+    }
+
+    /**
+     * Removes any previously set popup handler from this page.
+     */
+    public function removePendingPopup(): void
+    {
+        $this->pendingPopup = null;
+    }
+
+    /**
+     * Checks if a popup handler is currently set.
+     */
+    public function hasPendingPopup(): bool
+    {
+        return $this->pendingPopup instanceof PendingAwaitablePopup;
+    }
+
+    /**
+     * Handles a popup creation event from the Playwright server.
+     */
+    public function handlePopupCreation(string $popupGuid, string $frameGuid): void
+    {
+        if ($this->pendingPopup instanceof PendingAwaitablePopup) {
+            $this->pendingPopup->handlePopupCreation($popupGuid, $frameGuid);
+            $this->removePendingPopup();
         }
     }
 

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -40,7 +40,7 @@ final class Page
         private readonly string $guid,
         private readonly string $frameGuid,
     ) {
-        //
+        Client::instance()->registerPage($guid, $this);
     }
 
     /**

--- a/src/Support/JavaScriptSerializer.php
+++ b/src/Support/JavaScriptSerializer.php
@@ -148,7 +148,7 @@ final class JavaScriptSerializer
 
         // Handle arrays
         if (isset($value['a'])) {
-            return array_map(fn (mixed $item): mixed => self::parseValue($item), $value['a']);
+            return array_map(self::parseValue(...), $value['a']);
         }
 
         // Handle objects

--- a/tests/Browser/Webpage/PopupTest.php
+++ b/tests/Browser/Webpage/PopupTest.php
@@ -29,6 +29,23 @@ it('can handle window.open', function (): void {
     expect($page->text('#result'))->toBe('Window opened');
 });
 
+it('can handle link with target', function (): void {
+    Route::get('/', fn (): string => '
+        <a id="popup-link" href="/popup" target="_blank">Open Link in new tab</a>
+    ');
+
+    Route::get('/popup', fn(): string => '
+        <div id="popup-content">Another tab</div>
+    ');
+
+    $page = visit('/');
+
+    $popup = $page->pendingPopup();
+    $page->click('#popup-link');
+
+    $popup->assertSeeIn('#popup-content', 'Another tab');
+});
+
 it('can interact with popup', function (): void {
     Route::get('/', fn (): string => '
         <button id="popup-btn" onclick="window.open(\'/popup\'); document.getElementById(\'result\').textContent = \'Window opened\';">Open Window</button>

--- a/tests/Browser/Webpage/PopupTest.php
+++ b/tests/Browser/Webpage/PopupTest.php
@@ -34,7 +34,7 @@ it('can handle link with target', function (): void {
         <a id="popup-link" href="/popup" target="_blank">Open Link in new tab</a>
     ');
 
-    Route::get('/popup', fn(): string => '
+    Route::get('/popup', fn (): string => '
         <div id="popup-content">Another tab</div>
     ');
 

--- a/tests/Browser/Webpage/PopupTest.php
+++ b/tests/Browser/Webpage/PopupTest.php
@@ -8,7 +8,10 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 it('can handle window.open', function (): void {
     Route::get('/', fn (): string => '
-        <button id="popup-btn" onclick="window.open(\'/popup\'); document.getElementById(\'result\').textContent = \'Window opened\';">Open Window</button>
+        <button id="popup-btn" onclick="
+            window.open(\'/popup\', \'Popup-target\', \'width=600,height=400\');
+            document.getElementById(\'result\').textContent = \'Window opened\';
+        ">Open Window</button>
         <div id="result"></div>
     ');
 

--- a/tests/Browser/Webpage/PopupTest.php
+++ b/tests/Browser/Webpage/PopupTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Pest\Browser\Api\PendingAwaitablePopup;
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('can handle window.open', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="popup-btn" onclick="window.open(\'/popup\'); document.getElementById(\'result\').textContent = \'Window opened\';">Open Window</button>
+        <div id="result"></div>
+    ');
+
+    Route::get('/popup', fn (): string => '
+        <div id="popup-content">Another page</div>
+    ');
+
+    $page = visit('/');
+
+    $popup = $page->pendingPopup();
+    $page->click('#popup-btn');
+
+    $popup->assertSeeIn('#popup-content', 'Another page');
+
+    expect($page->text('#result'))->toBe('Window opened');
+});
+
+it('can interact with popup', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="popup-btn" onclick="window.open(\'/popup\'); document.getElementById(\'result\').textContent = \'Window opened\';">Open Window</button>
+        <div id="result"></div>
+    ');
+
+    Route::get('/popup', fn (): string => '
+        <button id="change-btn" onclick="document.getElementById(\'result\').textContent = \'altered\';">Change text</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/');
+
+    $popup = $page->pendingPopup();
+    $page->click('#popup-btn');
+
+    $popup->click('#change-btn');
+
+    expect($page->text('#result'))->toBe('Window opened');
+
+    expect($popup->text('#result'))->toBe('altered');
+});
+
+it('removes pending popup from page when opened', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="popup-btn" onclick="window.open(\'/popup\');">Open Window</button>
+    ');
+
+    Route::get('/popup', fn (): string => '
+        <div id="popup-content">Another page</div>
+    ');
+
+    $page = visit('/');
+
+    $popup = $page->pendingPopup();
+    $page->click('#popup-btn');
+
+    $popup->assertSeeIn('#popup-content', 'Another page');
+
+    expect($page->hasPendingPopup())->toBeFalse();
+});
+
+it('can remove pending popup', function (): void {
+    $page = visit('/');
+
+    expect($page->hasPendingPopup())->toBeFalse();
+
+    $popup = $page->pendingPopup();
+    expect($popup)->toBeInstanceOf(PendingAwaitablePopup::class);
+    expect($page->hasPendingPopup())->toBeTrue();
+
+    $page->removePendingPopup();
+    expect($page->hasPendingPopup())->toBeFalse();
+});
+
+it('can open popups for multiple pages', function (): void {
+    Route::get('/a', fn (): string => '
+        <button id="popup-btn" onclick="window.open(\'/popup-a\');">Open Window</button>
+    ');
+    Route::get('/b', fn (): string => '
+        <button id="popup-btn" onclick="window.open(\'/popup-b\');">Open Window</button>
+    ');
+
+    Route::get('/popup-a', fn (): string => '
+        <div id="popup-content">Popup Window A</div>
+    ');
+    Route::get('/popup-b', fn (): string => '
+        <div id="popup-content">Popup Window B</div>
+    ');
+
+    $pageA = visit('/a');
+    $pageB = visit('/b');
+
+    $popupA = $pageA->pendingPopup();
+    $popupB = $pageB->pendingPopup();
+
+    $pageB->click('#popup-btn');
+    $pageA->click('#popup-btn');
+
+    $popupA->assertSeeIn('#popup-content', 'Popup Window A');
+    $popupB->assertSeeIn('#popup-content', 'Popup Window B');
+});
+
+it('can open a nested popup', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="popup-btn" onclick="window.open(\'/popup\');">Open Window</button>
+    ');
+
+    Route::get('/popup', fn (): string => '
+        <button id="nested-popup-btn" onclick="window.open(\'/nested-popup\');">Open Nested Window</button>
+    ');
+    Route::get('/nested-popup', fn (): string => '
+        <div id="popup-content">Nested Window</div>
+    ');
+
+    $page = visit('/');
+
+    $popup = $page->pendingPopup();
+    $page->click('#popup-btn');
+
+    $nested = $popup->pendingPopup();
+    $popup->click('#nested-popup-btn');
+
+    $nested->assertSeeIn('#popup-content', 'Nested Window');
+});
+
+it('fails interaction if popup does not open', function (): void {
+    $page = visit('/');
+
+    $popup = $page->pendingPopup();
+
+    $popup->click('#no-btn');
+})->throws(ExpectationFailedException::class, 'No popup opened');

--- a/tests/Browser/Webpage/PopupTest.php
+++ b/tests/Browser/Webpage/PopupTest.php
@@ -159,3 +159,23 @@ it('fails interaction if popup does not open', function (): void {
 
     $popup->click('#no-btn');
 })->throws(ExpectationFailedException::class, 'No popup opened');
+
+it('can check for smoke in popup window', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="popup-btn" onclick="window.open(\'/popup\')">Open Window</button>
+    ');
+
+    Route::get('/popup', fn (): string => '
+        <button id="log-btn" onclick="console.log(\'popped up and logged\');">Log Message</button>
+        <div>Some Content</div>
+    ');
+
+    $page = visit('/');
+
+    $popup = $page->pendingPopup();
+    $page->click('#popup-btn');
+
+    $popup->click('#log-btn');
+
+    $popup->assertNoConsoleLogs();
+})->throws(ExpectationFailedException::class, 'but found 1: popped up and logged');


### PR DESCRIPTION
Add ability to use a popup window opened by the page.

## Example Usage

On a page with an interaction that opens a window or tab:

```html
<button id="open-popup" onclick="window.open('/popup', 'target', 'width=600,height=400')">Open a window</button>

or

<a id="open-popup" href="/popup" target="_blank">Open a tab</a>
```

Usage:

```php
$page = visit('/');

$popup = $page->pendingPopup();
$page->click('#open-popup');

$popup->assertSee('Text in popup window');
// $popup interactions and assertions will wait for popup to open
```