### PR TITLE
Fix assertSeeIn when there are multiple matches

### DIFF
--- a/src/Api/Concerns/MakesElementAssertions.php
+++ b/src/Api/Concerns/MakesElementAssertions.php
@@ -98,13 +98,17 @@ trait MakesElementAssertions
 
         $entries = $this->page->unstrict(fn () => $locator->getByText($text));
 
-        expect($entries->count())->toBeGreaterThan(0, "Expected to see text [{$text}] within element [{$selector}] on the page initially with the url [{$this->initialUrl}], but it was not found.");
-
         foreach ($entries->all() as $entry) {
-            expect($entry->isVisible())->toBeTrue("Expected to see text [{$text}] within element [{$selector}] on the page initially with the url [{$this->initialUrl}], but it was not found or not visible.");
+            if ($entry->isVisible()) {
+                expect(true)->toBeTrue();
+
+                return $this;
+            }
         }
 
-        return $this;
+        throw new ExpectationFailedException(
+            "Expected to see text [{$text}] within element [{$selector}] on the page initially with the url [{$this->initialUrl}], but it was not found or not visible.",
+        );
     }
 
     /**
@@ -459,7 +463,7 @@ trait MakesElementAssertions
     {
         $value = (string) $value;
 
-        return $this->assertAttribute($selector, 'aria-'.$attribute, $value);
+        return $this->assertAttribute($selector, 'aria-' . $attribute, $value);
     }
 
     /**
@@ -469,7 +473,7 @@ trait MakesElementAssertions
     {
         $value = (string) $value;
 
-        return $this->assertAttribute($selector, 'data-'.$attribute, $value);
+        return $this->assertAttribute($selector, 'data-' . $attribute, $value);
     }
 
     /**

--- a/src/Api/Concerns/MakesElementAssertions.php
+++ b/src/Api/Concerns/MakesElementAssertions.php
@@ -96,7 +96,13 @@ trait MakesElementAssertions
 
         $locator = $this->guessLocator($selector);
 
-        expect($locator->getByText($text)->isVisible())->toBeTrue("Expected to see text [{$text}] within element [{$selector}] on the page initially with the url [{$this->initialUrl}], but it was not found or not visible.");
+        $entries = $this->page->unstrict(fn () => $locator->getByText($text));
+
+        expect($entries->count())->toBeGreaterThan(0, "Expected to see text [{$text}] within element [{$selector}] on the page initially with the url [{$this->initialUrl}], but it was not found.");
+
+        foreach ($entries->all() as $entry) {
+            expect($entry->isVisible())->toBeTrue("Expected to see text [{$text}] within element [{$selector}] on the page initially with the url [{$this->initialUrl}], but it was not found or not visible.");
+        }
 
         return $this;
     }

--- a/tests/Browser/Webpage/AssertSeeInTest.php
+++ b/tests/Browser/Webpage/AssertSeeInTest.php
@@ -35,3 +35,11 @@ it('may fail when asserting text is not in a selector but it is', function (): v
 
     $page->assertDontSeeIn('#content', 'Hello World');
 })->throws(ExpectationFailedException::class);
+
+it('may assert text is in a selector when contains multiple', function (): void {
+    Route::get('/', fn (): string => '<div data-test="content"><span>Hello</span><span>Hello</span><span>Hello</span></div>');
+
+    $page = visit('/');
+
+    $page->assertSeeIn('@content', 'Hello');
+});


### PR DESCRIPTION
### Changed

- Sometimes there are multiple entries of the test I want to assert on the element and having multiple makes the `assertSeeIn` break (because of strict mode). This fixes it, even though we're only checking the first element... but should be fine since this is the same implementation as the `assertSee`