### PR TITLE
Only check screenshots on Mac

### DIFF
--- a/tests/Browser/Visit/SingleUrl.php
+++ b/tests/Browser/Visit/SingleUrl.php
@@ -27,7 +27,7 @@ it('may visit a page', function (string $method): void {
 
     $page->assertSee('Experience elegance across every device.')
         ->assertScreenshotMatches();
-})->with($methods)->skipOnCI();
+})->with($methods)->onlyOnMac()->skipOnCI();
 
 it('may visit a page in light/dark mode', function (ColorScheme $scheme): void {
     Route::get('/', fn (): string => '
@@ -71,7 +71,7 @@ it('may visit a page in light/dark mode', function (ColorScheme $scheme): void {
     };
 
     $page->assertScreenshotMatches();
-})->with(ColorScheme::cases())->skipOnCI();
+})->with(ColorScheme::cases())->onlyOnMac()->skipOnCI();
 
 it('may visit a page with custom locale and timezone', function (): void {
     Route::get('/', fn (): string => '

--- a/tests/Browser/Webpage/AssertScreenshotMatchesTest.php
+++ b/tests/Browser/Webpage/AssertScreenshotMatchesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-beforeEach()->skipOnCI();
+beforeEach()->onlyOnMac()->skipOnCI();
 
 it('may match a screenshot', function (): void {
     Route::get('/', fn (): string => '


### PR DESCRIPTION
## Problem

Trying to run the tests on Linux, I find that the screenshots are not pixel perfect so any tests with `assertScreenshotMatches()` fail.

I note that the `MakesScreenshotAssertions` concern sets some css to make screenshots more consistent. According to MDN, `-webkit-font-smoothing` and `-moz-osx-font-smoothing` only work on MacOS.

## Solution

Set `assertScreenshotMatches()` tests to only run on Mac (in addition to the existing call to skip on CI).