### PR TITLE
feat: Assert no console messages at given level(s)

### DIFF
--- a/src/Api/Concerns/MakesConsoleAssertions.php
+++ b/src/Api/Concerns/MakesConsoleAssertions.php
@@ -75,7 +75,7 @@ trait MakesConsoleAssertions
     /**
      * Asserts there are no console messages at given levels on the page.
      *
-     * @param array<int, string>|string $levels Console message level(s) to check for (debug, info, error, warning).
+     * @param  array<int, string>|string  $levels  Console message level(s) to check for (debug, info, error, warning).
      */
     public function assertNoConsoleMessages(array|string $levels = ['info', 'error', 'warning']): Webpage
     {
@@ -89,7 +89,7 @@ trait MakesConsoleAssertions
             implode(', ', $levels),
             $this->initialUrl,
             count($messages),
-            implode(', ', array_map(fn (array $log) => "{$log['level']}: {$log['message']}", $messages)),
+            implode(', ', array_map(fn (array $log): string => "{$log['level']}: {$log['message']}", $messages)),
         ));
 
         return $this;

--- a/src/Api/Concerns/MakesConsoleAssertions.php
+++ b/src/Api/Concerns/MakesConsoleAssertions.php
@@ -73,6 +73,29 @@ trait MakesConsoleAssertions
     }
 
     /**
+     * Asserts there are no console messages at given levels on the page.
+     *
+     * @param array<int, string>|string $levels Console message level(s) to check for (debug, info, error, warning).
+     */
+    public function assertNoConsoleMessages(array|string $levels = ['info', 'error', 'warning']): Webpage
+    {
+        if (is_string($levels)) {
+            $levels = [$levels];
+        }
+        $messages = $this->page->consoleMessages($levels);
+
+        expect($messages)->toBeEmpty(sprintf(
+            'Expected no console messages at levels [%s] on the page initially with the url [%s], but found %d: %s',
+            implode(', ', $levels),
+            $this->initialUrl,
+            count($messages),
+            implode(', ', array_map(fn (array $log) => "{$log['level']}: {$log['message']}", $messages)),
+        ));
+
+        return $this;
+    }
+
+    /**
      * Asserts there are no JavaScript errors on the page.
      */
     public function assertNoJavaScriptErrors(): Webpage

--- a/src/Exceptions/BrowserExpectationFailedException.php
+++ b/src/Exceptions/BrowserExpectationFailedException.php
@@ -39,6 +39,15 @@ final class BrowserExpectationFailedException
             ));
         }
 
+        $consoleMessages = $page->consoleMessages();
+
+        if (count($consoleMessages) > 0) {
+            $message .= "\n\nThe following console messages were found:\n".implode("\n", array_map(
+                fn (array $error): string => $error['level'] . ': ' . $error['message'],
+                $consoleMessages,
+            ));
+        }
+
         $javaScriptErrors = $page->javaScriptErrors();
 
         if (count($javaScriptErrors) > 0) {

--- a/src/Playwright/InitScript.php
+++ b/src/Playwright/InitScript.php
@@ -23,7 +23,8 @@ final class InitScript
 
             window.__pestBrowser = {
                 jsErrors: [],
-                consoleLogs: []
+                consoleLogs: [],
+                consoleMessages: []
             };
 
             const originalConsoleLog = console.log;
@@ -34,6 +35,19 @@ final class InitScript
                 });
                 originalConsoleLog.apply(console, args);
             };
+
+            ['debug', 'error', 'info', 'warning'].forEach(function (level) {
+                const methodName = level === 'warning' ? 'warn' : level;
+                const originalConsoleMethod = console[methodName];
+                console[methodName] = function(...args) {
+                    window.__pestBrowser.consoleMessages.push({
+                        timestamp: new Date().getTime(),
+                        level: level,
+                        message: args.map(arg => String(arg)).join(' ')
+                    });
+                    originalConsoleMethod.apply(console, args);
+                };
+            });
 
             window.addEventListener('error', (e) => {
                 window.__pestBrowser.jsErrors.push({

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -464,6 +464,36 @@ final class Page
     }
 
     /**
+     * Get the console messages at given levels from the page, if any.
+     *
+     * @param array<int, string>|string $levels Message levels to filter for ('debug', 'info', 'error', 'warning')
+     *
+     * @return array<int, array{level: string, message: string}>
+     */
+    public function consoleMessages(array|string $levels = ['info', 'error', 'warning']): array
+    {
+        $consoleMessages = $this->evaluate('window.__pestBrowser.consoleMessages || []');
+
+        /** @var array<int, array{level: string, message: string}> $consoleMessages */
+
+        if (is_string($levels)) {
+            $checkLevels = [$levels => true];
+        } else {
+            $checkLevels = array_flip($levels);
+            if (array_key_exists('warn', $checkLevels)) {
+                $checkLevels['warning'] = true;
+            }
+        }
+
+        $messages = array_filter(
+            $consoleMessages,
+            fn (array $log) => array_key_exists($log['level'], $checkLevels)
+        );
+
+        return $messages;
+    }
+
+    /**
      * Get the broken images from the page, if any.
      *
      * @return array<int, string>

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -466,8 +466,7 @@ final class Page
     /**
      * Get the console messages at given levels from the page, if any.
      *
-     * @param array<int, string>|string $levels Message levels to filter for ('debug', 'info', 'error', 'warning')
-     *
+     * @param  array<int, string>|string  $levels  Message levels to filter for ('debug', 'info', 'error', 'warning')
      * @return array<int, array{level: string, message: string}>
      */
     public function consoleMessages(array|string $levels = ['info', 'error', 'warning']): array
@@ -475,7 +474,6 @@ final class Page
         $consoleMessages = $this->evaluate('window.__pestBrowser.consoleMessages || []');
 
         /** @var array<int, array{level: string, message: string}> $consoleMessages */
-
         if (is_string($levels)) {
             $checkLevels = [$levels => true];
         } else {
@@ -485,12 +483,10 @@ final class Page
             }
         }
 
-        $messages = array_filter(
+        return array_filter(
             $consoleMessages,
-            fn (array $log) => array_key_exists($log['level'], $checkLevels)
+            fn (array $log): bool => array_key_exists($log['level'], $checkLevels)
         );
-
-        return $messages;
     }
 
     /**

--- a/tests/Browser/Webpage/AssertNoConsoleMessagesTest.php
+++ b/tests/Browser/Webpage/AssertNoConsoleMessagesTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('asserts that there are no console messages', function (): void {
+    Route::get('/', fn (): string => '
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages();
+});
+
+it('ignores debug messages by default', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            console.debug("Hello, World!");
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages();
+});
+
+it('asserts that there are console messages', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            console.error("Hello, World!");
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages();
+})->throws(ExpectationFailedException::class, 'but found 1: error: Hello, World!');
+
+it('asserts that there are console debug messages', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            console.debug("Hello, World!");
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages('debug');
+})->throws(ExpectationFailedException::class, 'but found 1: debug: Hello, World!');
+
+it('asserts that there are console error messages', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            console.error("Hello, World!");
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages('error');
+})->throws(ExpectationFailedException::class, 'but found 1: error: Hello, World!');
+
+it('asserts that there are console info messages', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            console.info("Hello, World!");
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages('info');
+})->throws(ExpectationFailedException::class, 'but found 1: info: Hello, World!');
+
+it('asserts that there are console warning messages', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            console.warn("Hello, World!");
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages('warning');
+})->throws(ExpectationFailedException::class, 'but found 1: warning: Hello, World!');
+
+it('allows alias warn for console warning messages', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            console.warn("Hello, World!");
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoConsoleMessages('warn');
+})->throws(ExpectationFailedException::class, 'but found 1: warning: Hello, World!');


### PR DESCRIPTION
Add `assertNoConsoleMessages(array|string $levels)`

Check page for console messages at specified levels:

`'debug'`: `console.debug()` calls (not checked by default)
`'error'`: `console.error() `calls
`'info'`: `console.info()` calls
`'warning'`: `console.warn()` calls (can also specify level as `'warn'`)

Usage:

```php
// assert no console messages have been made at any level
$page->assertNoConsoleMessages(['debug', 'error', 'info', 'warning']);

// assert no console.warn() calls have been made
$page->assertNoConsoleMessages('warning');

// get list of console.warn() and console.error() calls made on page
$page->consoleMessages(['error', 'warning']);
```

Note: I have not added this assertion to `assertNoSmoke()` as it may not be desired by every project.