### PR TITLE
Support cookies and server variables in LaravelHttpServer

### DIFF
--- a/src/Browsable.php
+++ b/src/Browsable.php
@@ -11,8 +11,6 @@ use Pest\Browser\Playwright\Client;
 use Pest\Browser\Playwright\Playwright;
 
 /**
- * @property array<string, string> $serverVariables
- *
  * @internal
  */
 trait Browsable
@@ -68,6 +66,6 @@ trait Browsable
      */
     protected function serverVariables(): array
     {
-        return $this->serverVariables;
+        return property_exists($this, 'serverVariables') ? $this->serverVariables : [];
     }
 }

--- a/src/Browsable.php
+++ b/src/Browsable.php
@@ -11,6 +11,8 @@ use Pest\Browser\Playwright\Client;
 use Pest\Browser\Playwright\Playwright;
 
 /**
+ * @property array<string, string> $serverVariables
+ *
  * @internal
  */
 trait Browsable
@@ -59,5 +61,13 @@ trait Browsable
                 $options,
             ), $url),
         );
+    }
+
+    /**
+     * @return array <string, string>
+     */
+    protected function serverVariables(): array
+    {
+        return $this->serverVariables;
     }
 }

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -244,14 +244,9 @@ final class LaravelHttpServer implements HttpServer
             parse_str($rawBody, $parameters);
         }
         $cookies = array_map(fn (RequestCookie $cookie): string => urldecode($cookie->getValue()), $request->getCookies());
-        /** @phpstan-ignore-next-line  */
-        $cookies = array_merge($cookies, test()->prepareCookiesForRequest());
-        /**
-         * @var array<string, string> $serverVariables
-         *
-         * @phpstan-ignore-next-line
-         */
-        $serverVariables = test()->serverVariables();
+        $cookies = array_merge($cookies, test()->prepareCookiesForRequest()); // @phpstan-ignore-line
+        /** @var array<string, string> $serverVariables */
+        $serverVariables = test()->serverVariables(); // @phpstan-ignore-line
 
         $symfonyRequest = Request::create(
             $absoluteUrl,

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -244,7 +244,14 @@ final class LaravelHttpServer implements HttpServer
             parse_str($rawBody, $parameters);
         }
         $cookies = array_map(fn (RequestCookie $cookie): string => urldecode($cookie->getValue()), $request->getCookies());
+        /** @phpstan-ignore-next-line  */
         $cookies = array_merge($cookies, test()->prepareCookiesForRequest());
+        /**
+         * @var array<string, string> $serverVariables
+         *
+         * @phpstan-ignore-next-line
+         */
+        $serverVariables = test()->serverVariables();
 
         $symfonyRequest = Request::create(
             $absoluteUrl,
@@ -252,7 +259,7 @@ final class LaravelHttpServer implements HttpServer
             $parameters,
             $cookies,
             [], // @TODO files...
-            test()->serverVariables(),
+            $serverVariables,
             $rawBody
         );
 

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Browser\Drivers;
 
 use Amp\ByteStream\ReadableResourceStream;
+use Amp\Http\Cookie\RequestCookie;
 use Amp\Http\Server\DefaultErrorHandler;
 use Amp\Http\Server\HttpServer as AmpHttpServer;
 use Amp\Http\Server\HttpServerStatus;
@@ -242,14 +243,16 @@ final class LaravelHttpServer implements HttpServer
         if ($method !== 'GET' && str_starts_with(mb_strtolower($contentType), 'application/x-www-form-urlencoded')) {
             parse_str($rawBody, $parameters);
         }
+        $cookies = array_map(fn (RequestCookie $cookie): string => urldecode($cookie->getValue()), $request->getCookies());
+        $cookies = array_merge($cookies, test()->prepareCookiesForRequest());
 
         $symfonyRequest = Request::create(
             $absoluteUrl,
             $method,
             $parameters,
-            $request->getCookies(),
+            $cookies,
             [], // @TODO files...
-            [], // @TODO server variables...
+            test()->serverVariables(),
             $rawBody
         );
 

--- a/src/Support/JavaScriptSerializer.php
+++ b/src/Support/JavaScriptSerializer.php
@@ -148,7 +148,7 @@ final class JavaScriptSerializer
 
         // Handle arrays
         if (isset($value['a'])) {
-            return array_map(fn (mixed $item): mixed => self::parseValue($item), $value['a']);
+            return array_map(self::parseValue(...), $value['a']);
         }
 
         // Handle objects

--- a/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
+++ b/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
@@ -2,11 +2,10 @@
 
 declare(strict_types=1);
 
-use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
 
-use function Pest\Laravel\withCookie;
 use function Pest\Laravel\withServerVariables;
+use function Pest\Laravel\withUnencryptedCookie;
 
 it('rewrites the URLs on JS files', function (): void {
     @file_put_contents(
@@ -23,10 +22,9 @@ it('rewrites the URLs on JS files', function (): void {
 });
 
 it('includes cookies set in the test', function (): void {
-    Route::middleware(EncryptCookies::class)
-        ->get('/cookies', fn (Request $request): array => $request->cookies->all());
+    Route::get('/cookies', fn (Request $request): array => $request->cookies->all());
 
-    withCookie('test-cookie', value: 'test value');
+    withUnencryptedCookie('test-cookie', value: 'test value');
     visit('/cookies')
         ->assertSee(json_encode(['test-cookie' => 'test value']));
 });

--- a/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
+++ b/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
@@ -2,6 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Http\Request;
+
+use function Pest\Laravel\withCookie;
+use function Pest\Laravel\withServerVariables;
+
 it('rewrites the URLs on JS files', function (): void {
     @file_put_contents(
         public_path('app.js'),
@@ -14,4 +20,21 @@ it('rewrites the URLs on JS files', function (): void {
 
     $page->assertSee('http://127.0.0.1')
         ->assertDontSee('http://localhost');
+});
+
+it('includes cookies set in the test', function (): void {
+    Route::middleware(EncryptCookies::class)
+        ->get('/cookies', fn (Request $request): array => $request->cookies->all());
+
+    withCookie('test-cookie', value: 'test value');
+    visit('/cookies')
+        ->assertSee(json_encode(['test-cookie' => 'test value']));
+});
+
+it('includes server variables set in the test', function (): void {
+    Route::get('/server-variables', fn (Request $request): array => $request->server->all());
+
+    withServerVariables(['test-server-key' => 'test value']);
+    visit('/server-variables')
+        ->assertSee('"test-server-key":"test value"');
 });


### PR DESCRIPTION
Within `handleRequest()` `$request->getCookies()` returns an array of `Amp\Cookie\RequestCookie` objects. Before this PR those were being passed directly to the Laravel `Request` class, even though that expects an array of string key-value pairs.

So we first map over the amp cookie objects and get them into the format Laravel expects. We have to call urldecode because the browser engines give amp encoded strings, but the laravel request expects decoded strings.

After that, we merge in any cookies set within the test cases.

The server variables is a little more straightforward. We create a method on the `Browsable` trait that gives us access to the `protected $serverVariables` property on the `TestCase`/`MakesHttpRequests`.