### PR TITLE
Additional `source` assertions

### DIFF
--- a/src/Api/Concerns/MakesElementAssertions.php
+++ b/src/Api/Concerns/MakesElementAssertions.php
@@ -200,6 +200,19 @@ trait MakesElementAssertions
     }
 
     /**
+     * Assert that the given source code is present within the selector.
+     */
+    public function assertSourceInHas(string $selector, string $code): Webpage
+    {
+        $locator = $this->guessLocator($selector);
+        $html = $locator->innerHTML();
+        $message = "Expected page source to contain [{$code}] on the page initially with the url [{$this->initialUrl}], but it was not found.";
+        expect(str_contains($html, $code))->toBeTrue($message);
+
+        return $this;
+    }
+
+    /**
      * Assert that the given source code is not present on the page.
      */
     public function assertSourceMissing(string $code): Webpage
@@ -207,6 +220,19 @@ trait MakesElementAssertions
         $content = $this->page->content();
         $message = "Expected page source not to contain [{$code}] on the page initially with the url [{$this->initialUrl}], but it was found.";
         expect(str_contains($content, $code))->toBeFalse($message);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given source code is not present within the selector.
+     */
+    public function assertSourceInMissing(string $selector, string $code): Webpage
+    {
+        $locator = $this->guessLocator($selector);
+        $html = $locator->innerHTML();
+        $message = "Expected page source not to contain [{$code}] on the page initially with the url [{$this->initialUrl}], but it was found.";
+        expect(str_contains($html, $code))->toBeFalse($message);
 
         return $this;
     }

--- a/src/Support/JavaScriptSerializer.php
+++ b/src/Support/JavaScriptSerializer.php
@@ -148,7 +148,7 @@ final class JavaScriptSerializer
 
         // Handle arrays
         if (isset($value['a'])) {
-            return array_map(fn (mixed $item): mixed => self::parseValue($item), $value['a']);
+            return array_map(self::parseValue(...), $value['a']);
         }
 
         // Handle objects

--- a/tests/Browser/Webpage/AssertSourceTest.php
+++ b/tests/Browser/Webpage/AssertSourceTest.php
@@ -20,6 +20,22 @@ it('may fail when asserting source code is present but it is not', function (): 
     $page->assertSourceHas('<div id="content">Hello Universe</div>');
 })->throws(ExpectationFailedException::class);
 
+it('may assert source code is present within a selector', function (): void {
+    Route::get('/', fn (): string => '<div id="content"><strong>Hello World</strong></div>');
+
+    $page = visit('/');
+
+    $page->assertSourceInHas('#content', '<strong>Hello World</strong>');
+});
+
+it('may fail when asserting source code is present within a selector but it is not', function (): void {
+    Route::get('/', fn (): string => '<div id="content">Hello World</div>');
+
+    $page = visit('/');
+
+    $page->assertSourceInHas('#content', '<strong>Hello World</strong>');
+})->throws(ExpectationFailedException::class);
+
 it('may assert source code is not present on the page', function (): void {
     Route::get('/', fn (): string => '<div id="content">Hello World</div>');
 
@@ -34,4 +50,20 @@ it('may fail when asserting source code is not present but it is', function (): 
     $page = visit('/');
 
     $page->assertSourceMissing('<div id="content">Hello World</div>');
+})->throws(ExpectationFailedException::class);
+
+it('may assert source code is not present within a selector', function (): void {
+    Route::get('/', fn (): string => '<div id="content">Hello World</div>');
+
+    $page = visit('/');
+
+    $page->assertSourceInMissing('#content', '<strong>Hello World</strong>');
+});
+
+it('may fail when asserting source code is not present within a selector but it is', function (): void {
+    Route::get('/', fn (): string => '<div id="content"><strong>Hello World</strong></div>');
+
+    $page = visit('/');
+
+    $page->assertSourceInMissing('#content', '<strong>Hello World</strong>');
 })->throws(ExpectationFailedException::class);


### PR DESCRIPTION
Sometimes you need to ensure a specific element contains some code.

In our use case, we want to assert that only some rows within a table have an SVG icon.

This implementation is similar to `assertSeeIn` and `assertSeeMissingIn`