### PR TITLE
Fix incorrect @mixin in PendingAwaitablePage

### DIFF
--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -12,7 +12,7 @@ use Pest\Browser\Playwright\Playwright;
 use Pest\Browser\Support\ComputeUrl;
 
 /**
- * @mixin Webpage|AwaitableWebpage
+ * @mixin AwaitableWebpage
  */
 final class PendingAwaitablePage
 {


### PR DESCRIPTION
### Issue
I believe the `@mixin` directive inside [PendingAwaitablePage](https://github.com/pestphp/pest-plugin-browser/blob/37ce5e0bce6791bc168afccfbe25b3ed76723025/src/Api/PendingAwaitablePage.php#L15) class is currently wrong.

 **PendingAwaitablePage** makes calls to **AwaitableWebpage**, not the **Webpage** class. 
It's the **AwaitableWebpage** that makes calls to **Webpage** afterwards.

As far as I can see the order is: PendingAwaitablePage **=>** AwaitableWebpage **=>** Webpage

_The currently incorrect `@mixin`, is the reason for the following [issue](https://github.com/bmewburn/vscode-intelephense/issues/3378) with VS Code PHP Intelephense extension. PHPStorm on the other hand seems to consider union mixin as intersection, so the problem does not occur there._

### Solution
**AwaitableWebpage** does have `@mixin Webpage`, so we can just remove the `Webpage` from the mixin in **PendingAwaitablePage** class, since it's redundant anyway.
