### PR TITLE
waitForFunction bug fix

### DIFF
--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -254,14 +254,13 @@ final class Page
     {
         $params = [
             'expression' => $content,
+            'isFunction' => true,
             'arg' => JavaScriptSerializer::serializeArgument($arg),
         ];
 
-        Client::instance()->execute(
-            $this->guid,
-            'waitForFunction',
-            $params
-        );
+        $response = $this->sendMessage('waitForFunction', $params);
+
+        $this->processVoidResponse($response);
 
         return $this;
     }


### PR DESCRIPTION
I found two issues when trying to use this function (both are corrected in this PR)

1) the `isFunction` flag needs to be set (I verified this by looking at events sent by the node version of Playwright)

2) The generator was not being run. Adding the `processVoidResponse()` by itself didn't work, because `waitForFunction` is not Page operation, it's a Frame operation. So I switched to using `sendMessage()` which properly makes this distinction.

I found a few other similar bugs but wanted to limit this PR's scope. I also have a few suggestions/requests to allow me to use this in my CI pipeline that I'd love to discuss when you have time. Great work on this package!