### PR TITLE
[4.x] Add missing route facade import to test

### DIFF
--- a/tests/Browser/Visit/MultipleUrls.php
+++ b/tests/Browser/Visit/MultipleUrls.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Route;
+
 it('may visit multiple pages', function (): void {
     Route::get('/page1', fn (): string => '<div>
         <h1>Page 1</h1>


### PR DESCRIPTION
Noticed this while poking about, just helps for IDE completion and what not- used elsewhere so keeps it consistent. 