### PR TITLE
[4.x] Fix CI flakiness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer install --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
+      run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+      run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi --optimize-autoloader
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Install PHP dependencies
       run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
 
+    - name: Dump optimized autoloader
+      run: composer dump-autoload --optimize --ansi
+
     - name: Install dependencies
       run: npm ci
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+      run: composer install --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi --optimize-autoloader
+      run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
+      run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi --optimize-autoloader
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,6 @@ jobs:
     - name: Install PHP dependencies
       run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --ansi
 
-    - name: Dump optimized autoloader
-      run: composer dump-autoload --optimize --ansi
-
     - name: Install dependencies
       run: npm ci
 


### PR DESCRIPTION
I had an action failure here on some Livewire component see :

 https://github.com/pestphp/pest-plugin-browser/actions/runs/20607627136/job/59186426436#step:9:80
 
 But, it's also happened previously: https://github.com/pestphp/pest-plugin-browser/actions/runs/20522952475/job/58961196854#step:9:80

This adds: 
- `--prefer-dist` to improve download speed
- `--optimize-autoloader` maps all the classes faster 

I believe with adding the two, it sorts it out.

See the commit history how it's passing and then the revert to cause faliure. 
