### PR TITLE
Make ->withHost available when using visit(..)

### DIFF
--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -119,6 +119,16 @@ final class PendingAwaitablePage
     }
 
     /**
+     * Sets the host for the server.
+     */
+    public function withHost(string $host): self
+    {
+        Playwright::setHost($host);
+
+        return new self($this->browserType, $this->device, $this->url, $this->options);
+    }
+
+    /**
      * Sets the timezone for the page.
      */
     public function withTimezone(string $timezone): self

--- a/tests/Browser/Visit/SubdomainTest.php
+++ b/tests/Browser/Visit/SubdomainTest.php
@@ -15,9 +15,8 @@ it('can visit non-subdomain routes with subdomain host browser testing', functio
         </html>
     ');
 
-    pest()->browser()->withHost('app.localhost');
-
     visit('/app-test')
+        ->withHost('app.localhost')
         ->assertSee('Welcome to NON Subdomain')
         ->assertSeeIn('#content', 'This is the non subdomain content')
         ->assertTitle('Non Subdomain');
@@ -33,9 +32,8 @@ it('works with Laravel subdomain style', function (): void {
         ]);
     });
 
-    pest()->browser()->withHost('api.localhost');
-
     visit('/api/health')
+        ->withHost('api.localhost')
         ->assertSee('"status":"ok"')
         ->assertSee('"subdomain":"api"')
         ->assertSee('"host":"api.localhost"');


### PR DESCRIPTION
## Make  `withHost`  chainable directly on `visit()`

Currently  `withHost`  is **not** chainable directly on `visit()`

Added missing function `withHost(..)` in  `PendingAwaitablePage` 


### Usage

```php
visit('/dashboard')
    ->withHost('app.localhost')
    ->assertSee('Welcome');
