### PR TITLE
Add optional screenshot scale support

### DIFF
--- a/src/Api/Concerns/InteractsWithScreen.php
+++ b/src/Api/Concerns/InteractsWithScreen.php
@@ -9,11 +9,11 @@ trait InteractsWithScreen
     /**
      * Performs a screenshot of the current page and saves it to the given path.
      */
-    public function screenshot(bool $fullPage = true, ?string $filename = null): self
+    public function screenshot(bool $fullPage = true, ?string $filename = null, ?string $scale = null): self
     {
         $filename = $this->getFilename($filename);
 
-        $this->page->screenshot($fullPage, $filename);
+        $this->page->screenshot($fullPage, $filename, $scale);
 
         return $this;
     }
@@ -21,11 +21,11 @@ trait InteractsWithScreen
     /**
      * Performs a screenshot of an element and saves it to the given path.
      */
-    public function screenshotElement(string $selector, ?string $filename = null): self
+    public function screenshotElement(string $selector, ?string $filename = null, ?string $scale = null): self
     {
         $filename = $this->getFilename($filename);
 
-        $this->page->screenshotElement($selector, $filename);
+        $this->page->screenshotElement($selector, $filename, $scale);
 
         return $this;
     }

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -427,9 +427,9 @@ final class Page
     /**
      * Make screenshot of the page.
      */
-    public function screenshot(bool $fullPage = true, ?string $filename = null): ?string
+    public function screenshot(bool $fullPage = true, ?string $filename = null, ?string $scale = null): ?string
     {
-        $binary = $this->screenshotBinary($fullPage);
+        $binary = $this->screenshotBinary($fullPage, $scale);
 
         if ($binary === null) {
             return null;
@@ -441,10 +441,12 @@ final class Page
     /**
      * Make screenshot of a specific element.
      */
-    public function screenshotElement(string $selector, ?string $filename = null): string
+    public function screenshotElement(string $selector, ?string $filename = null, ?string $scale = null): string
     {
         $locator = $this->locator($selector);
-        $binary = $locator->screenshot();
+        $binary = $locator->screenshot([
+            'scale' => $scale ?? 'css',
+        ]);
 
         return Screenshot::save($binary, $filename);
     }
@@ -594,12 +596,12 @@ final class Page
     /**
      * Screenshots the page and returns the binary data.
      */
-    private function screenshotBinary(bool $fullPage = true): ?string
+    private function screenshotBinary(bool $fullPage = true, ?string $scale = null): ?string
     {
         $response = Client::instance()->execute(
             $this->guid,
             'screenshot',
-            $this->screenshotOptions($fullPage)
+            $this->screenshotOptions($fullPage, $scale)
         );
 
         /** @var array{result: array{binary: string|null}} $message */
@@ -651,14 +653,14 @@ final class Page
     /**
      * @return array<string, mixed>
      */
-    private function screenshotOptions(bool $fullPage = true): array
+    private function screenshotOptions(bool $fullPage = true, ?string $scale = null): array
     {
         return [
             'type' => 'png',
             'fullPage' => $fullPage,
             'caret' => 'hide',
             'animations' => 'disabled',
-            'scale' => 'css',
+            'scale' => $scale ?? 'css', // 'css' or 'device'
         ];
     }
 

--- a/tests/Browser/Webpage/ScreenshotTest.php
+++ b/tests/Browser/Webpage/ScreenshotTest.php
@@ -29,6 +29,17 @@ it('captures a full-page screenshot with default filename', function (): void {
         ->toBeTrue();
 });
 
+it('captures a screenshot with device scale', function (): void {
+    Route::get('/', fn (): string => 'Hello World');
+
+    $page = visit('/');
+
+    $page->screenshot(filename: 'device-scale-screenshot.png', scale: 'device');
+
+    expect(file_exists(Screenshot::path('device-scale-screenshot.png')))
+        ->toBeTrue();
+});
+
 it('captures a screenshot of an specific element', function (): void {
     Route::get('/', fn (): string => '<div>
         <h1>Text outside of screenshot element</h1>
@@ -40,5 +51,19 @@ it('captures a screenshot of an specific element', function (): void {
     $page->screenshotElement('#screenshot-element', 'element-screenshot.png');
 
     expect(file_exists(Screenshot::path('element-screenshot.png')))
+        ->toBeTrue();
+});
+
+it('captures a screenshot of an element with device scale', function (): void {
+    Route::get('/', fn (): string => '<div>
+        <h1>Text outside of screenshot element</h1>
+        <div id="screenshot-element">Text inside of screenshot element</div>
+    </div>');
+
+    $page = visit('/');
+
+    $page->screenshotElement('#screenshot-element', 'element-device-scale-screenshot.png', scale: 'device');
+
+    expect(file_exists(Screenshot::path('element-device-scale-screenshot.png')))
         ->toBeTrue();
 });


### PR DESCRIPTION
Add optional screenshot scale support across the page and element APIs, defaulting to css when scale is omitted or null, wire the value into Playwright screenshot options, and add browser tests covering device scale screenshots to keep existing behavior intact.