### PR TITLE
fix: Prevent silent crashes on WebSocket failure and add cookie persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "pestphp/pest-plugin-browser",
+    "version": "4.2.99",
     "description": "Pest plugin to test browser interactions",
     "keywords": [
         "php",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "pestphp/pest-plugin-browser",
-    "version": "4.2.99",
     "description": "Pest plugin to test browser interactions",
     "keywords": [
         "php",

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Api;
 
+use InvalidArgumentException;
 use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Enums\ColorScheme;
 use Pest\Browser\Enums\Device;
@@ -152,6 +153,49 @@ final class PendingAwaitablePage
             'permissions' => ['geolocation'],
             ...$this->options,
         ]);
+    }
+
+    /**
+     * Sets the storage state (cookies, localStorage) for the page context.
+     *
+     * This allows you to reuse authentication state from a previous session.
+     *
+     * @param  array{cookies?: array<array{name: string, value: string, domain?: string, path?: string, expires?: float, httpOnly?: bool, secure?: bool, sameSite?: string}>, origins?: array<array{origin: string, localStorage: array<array{name: string, value: string}>}>}  $storageState
+     */
+    public function withStorageState(array $storageState): self
+    {
+        return new self($this->browserType, $this->device, $this->url, [
+            'storageState' => $storageState,
+            ...$this->options,
+        ]);
+    }
+
+    /**
+     * Loads storage state from a file path.
+     *
+     * The file should contain JSON with cookies and localStorage data
+     * from a previous Context::storageState() call.
+     */
+    public function withStorageStateFromFile(string $path): self
+    {
+        if (! file_exists($path)) {
+            throw new InvalidArgumentException("Storage state file not found: $path");
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            throw new InvalidArgumentException("Could not read storage state file: $path");
+        }
+
+        /** @var array{cookies?: array, origins?: array}|null $storageState */
+        $storageState = json_decode($contents, true);
+
+        if ($storageState === null) {
+            throw new InvalidArgumentException("Invalid storage state JSON in: $path");
+        }
+
+        return $this->withStorageState($storageState);
     }
 
     /**

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -8,6 +8,7 @@ use Amp\Websocket\Client\WebsocketConnection;
 use Generator;
 use Pest\Browser\Exceptions\PlaywrightOutdatedException;
 use PHPUnit\Framework\ExpectationFailedException;
+use RuntimeException;
 
 use function Amp\Websocket\Client\connect;
 
@@ -75,6 +76,9 @@ final class Client
         assert($this->websocketConnection instanceof WebsocketConnection, 'WebSocket client is not connected.');
 
         $requestId = uniqid();
+        $startTime = hrtime(true);
+        $operationTimeout = $params['timeout'] ?? $this->timeout;
+        $maxWaitTimeNs = $operationTimeout * 1_000_000; // Convert ms to ns
 
         $requestJson = (string) json_encode([
             'id' => $requestId,
@@ -87,9 +91,32 @@ final class Client
         $this->websocketConnection->sendText($requestJson);
 
         while (true) {
+            // Check for timeout to prevent infinite loops
+            $elapsed = hrtime(true) - $startTime;
+            if ($elapsed > $maxWaitTimeNs) {
+                throw new RuntimeException(
+                    "Playwright operation '$method' timed out after ".round($elapsed / 1_000_000_000, 2).' seconds'
+                );
+            }
+
             $responseJson = $this->fetch($this->websocketConnection);
-            /** @var array{id: string|null, params: array{add: string|null}, error: array{error: array{message: string|null}}} $response */
+
+            // Handle null/empty responses (WebSocket connection lost)
+            if ($responseJson === null || $responseJson === '') {
+                throw new RuntimeException(
+                    "WebSocket connection lost while executing '$method' on '$guid'"
+                );
+            }
+
+            /** @var array{id: string|null, params: array{add: string|null}, error: array{error: array{message: string|null}}}|null $response */
             $response = json_decode($responseJson, true);
+
+            // Handle JSON decode failure
+            if ($response === null) {
+                throw new RuntimeException(
+                    'Invalid JSON response from Playwright server: '.substr($responseJson, 0, 100)
+                );
+            }
 
             if (isset($response['error']['error']['message'])) {
                 $message = $response['error']['error']['message'];
@@ -130,9 +157,17 @@ final class Client
 
     /**
      * Fetches the response from the Playwright server.
+     *
+     * Returns null if the WebSocket connection is closed.
      */
-    private function fetch(WebsocketConnection $client): string
+    private function fetch(WebsocketConnection $client): ?string
     {
-        return (string) $client->receive()?->read();
+        $message = $client->receive();
+
+        if ($message === null) {
+            return null; // Connection closed
+        }
+
+        return $message->read();
     }
 }

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -101,8 +101,8 @@ final class Client
 
             $responseJson = $this->fetch($this->websocketConnection);
 
-            // Handle null/empty responses (WebSocket connection lost)
-            if ($responseJson === null || $responseJson === '') {
+            // Handle null responses (WebSocket connection lost)
+            if ($responseJson === null) {
                 throw new RuntimeException(
                     "WebSocket connection lost while executing '$method' on '$guid'"
                 );

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -102,4 +102,67 @@ final class Context
 
         return $this;
     }
+
+    /**
+     * Gets the storage state (cookies, localStorage, sessionStorage).
+     *
+     * @return array{cookies: array<array{name: string, value: string, domain: string, path: string, expires: float, httpOnly: bool, secure: bool, sameSite: string}>, origins: array<array{origin: string, localStorage: array<array{name: string, value: string}>}>}
+     */
+    public function storageState(): array
+    {
+        $response = $this->sendMessage('storageState');
+
+        /** @var array{result: array{cookies: array, origins: array}} $message */
+        foreach ($response as $message) {
+            if (isset($message['result'])) {
+                return $message['result'];
+            }
+        }
+
+        return ['cookies' => [], 'origins' => []];
+    }
+
+    /**
+     * Adds cookies into this browser context.
+     *
+     * @param  array<array{name: string, value: string, domain?: string, path?: string, expires?: float, httpOnly?: bool, secure?: bool, sameSite?: string}>  $cookies
+     */
+    public function addCookies(array $cookies): self
+    {
+        $response = $this->sendMessage('addCookies', ['cookies' => $cookies]);
+        $this->processVoidResponse($response);
+
+        return $this;
+    }
+
+    /**
+     * Gets all cookies in this browser context.
+     *
+     * @param  array<string>  $urls  Optional URLs to filter cookies
+     * @return array<array{name: string, value: string, domain: string, path: string, expires: float, httpOnly: bool, secure: bool, sameSite: string}>
+     */
+    public function cookies(array $urls = []): array
+    {
+        $response = $this->sendMessage('cookies', $urls !== [] ? ['urls' => $urls] : []);
+
+        /** @var array{result: array{cookies: array}} $message */
+        foreach ($response as $message) {
+            if (isset($message['result']['cookies'])) {
+                return $message['result']['cookies'];
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Clears all cookies from this browser context.
+     */
+    public function clearCookies(): self
+    {
+        $response = $this->sendMessage('clearCookies');
+        $this->processVoidResponse($response);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where **any navigation crashes PHP silently**. The root cause is an infinite loop in `Client::execute()` when the WebSocket connection is lost.

### Changes:

1. **Client.php - Timeout and null handling**
   - Add timeout mechanism using `hrtime()` to prevent infinite loops
   - Add null/empty response detection with descriptive error messages
   - Add JSON decode validation
   - Throw `RuntimeException` instead of hanging indefinitely

2. **Context.php - Cookie management methods**
   - Add `storageState()` - Export cookies and localStorage
   - Add `addCookies()` - Import cookies into context
   - Add `cookies()` - Read current cookies
   - Add `clearCookies()` - Clear all cookies

3. **PendingAwaitablePage.php - Storage state support**
   - Add `withStorageState()` - Set storage state for new context
   - Add `withStorageStateFromFile()` - Load storage state from JSON file

## Root Cause

When WebSocket connection dies during navigation:
1. `fetch()` returns `null` (connection closed)
2. `json_decode(null)` returns `null`
3. Loop tries to access `$response['id']` on null
4. PHP crashes silently (no exception, no output)

## Test Plan

- [ ] Existing tests pass
- [ ] Navigation no longer causes silent crashes
- [ ] Cookie persistence methods work correctly
- [ ] Storage state can be saved/restored between contexts

Fixes pestphp/pest#1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)