### PR TITLE
Add playwright tracing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage.xml
 # Playwright
 node_modules/
 /tests/Browser/Screenshots
+/tests/Browser/Tracing
 
 # MacOS
 .DS_Store

--- a/src/Api/Concerns/HasTracing.php
+++ b/src/Api/Concerns/HasTracing.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Pest\Browser\Api\Webpage;
+use Pest\Browser\Playwright\Tracing;
+
+/**
+ * @mixin Webpage
+ */
+trait HasTracing
+{
+    /**
+     * Starts tracing
+     */
+    public function startTracing(
+        bool $screenshots = true,
+        bool $snapshots = true,
+    ): self {
+        $this->page->context()->tracing()->start([
+            'screenshots' => $screenshots,
+            'snapshots' => $snapshots,
+        ]);
+        $this->page->context()->tracing()->startChunk();
+
+        return $this;
+    }
+
+    /**
+     * Stops tracing and saves artifact
+     */
+    public function stopTracing(?string $filename = null): self
+    {
+        $artifact = $this->page->context()->tracing()->stopChunk([
+            'mode' => 'archive',
+        ]);
+        $this->page->context()->tracing()->stop();
+
+        $artifact->saveAs(['path' => Tracing::path($filename)]);
+
+        return $this;
+    }
+}

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -11,7 +11,8 @@ use Pest\Browser\Support\GuessLocator;
 
 final readonly class Webpage
 {
-    use Concerns\HasWaitCapabilities,
+    use Concerns\HasTracing,
+        Concerns\HasWaitCapabilities,
         Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
         Concerns\InteractsWithScreen,

--- a/src/Enums/TracingOption.php
+++ b/src/Enums/TracingOption.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Enums;
+
+/**
+ * @internal
+ */
+enum TracingOption: string
+{
+    case OFF = 'off';
+    case ON = 'on';
+    case RETAIN_ON_FAILURE = 'retain-on-failure';
+}

--- a/src/Exceptions/TracingOptionNotSupportedException.php
+++ b/src/Exceptions/TracingOptionNotSupportedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Exceptions;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class TracingOptionNotSupportedException extends RuntimeException
+{
+    //
+}

--- a/src/Filters/UsesBrowserTestCaseMethodFilter.php
+++ b/src/Filters/UsesBrowserTestCaseMethodFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Browser\Filters;
 
 use Pest\Browser\Playwright\Playwright;
+use Pest\Browser\Playwright\Tracing;
 use Pest\Browser\Plugin;
 use Pest\Browser\ServerManager;
 use Pest\Browser\Support\BrowserTestIdentifier;
@@ -59,6 +60,7 @@ final readonly class UsesBrowserTestCaseMethodFilter implements TestCaseMethodFi
 
             ServerManager::instance()->playwright()->start();
             Screenshot::cleanup();
+            Tracing::cleanup();
         }
 
         return true;

--- a/src/Playwright/Artifact.php
+++ b/src/Playwright/Artifact.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Playwright;
+
+/**
+ * @internal
+ */
+final readonly class Artifact
+{
+    use Concerns\InteractsWithPlaywright;
+
+    /**
+     * Creates a new context instance.
+     */
+    public function __construct(
+        private string $guid
+    ) {
+        //
+    }
+
+    /**
+     * Save artifact
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function saveAs(array $params = []): void
+    {
+        $response = Client::instance()->execute($this->guid, 'saveAs', $params);
+        $this->processVoidResponse($response);
+    }
+}

--- a/src/Playwright/Browser.php
+++ b/src/Playwright/Browser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Playwright;
 
+use Pest\Browser\Enums\TracingOption;
 use Pest\Browser\Exceptions\BrowserAlreadyClosedException;
 
 /**
@@ -47,14 +48,28 @@ final class Browser
 
         $response = Client::instance()->execute($this->guid, 'newContext', $options);
 
-        /** @var array{result: array{context: array{guid: string|null}}} $message */
+        /** @var array{result: array{context: array{guid: string|null}}, params: array{type: string|null, guid: string}} $message */
         foreach ($response as $message) {
+            if (isset($message['params']['type']) && $message['params']['type'] === 'Tracing') {
+                $tracing = new Tracing($message['params']['guid']);
+            }
             if (isset($message['result']['context']['guid'])) {
-                $context = new Context($this, $message['result']['context']['guid']);
+                assert(isset($tracing), 'Tracing object was not initialized.');
+                $context = new Context($this, $tracing, $message['result']['context']['guid']);
             }
         }
 
+        assert(isset($tracing), 'Tracing object was not initialized.');
         assert(isset($context), 'Browser context was not created successfully.');
+
+        // Auto start tracing
+        if (Playwright::tracingOption() !== TracingOption::OFF) {
+            $tracing->start([
+                'screenshots' => true,
+                'snapshots' => true,
+            ]);
+            $tracing->startChunk();
+        }
 
         $this->contexts[] = $context;
 

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -23,6 +23,7 @@ final class Context
      */
     public function __construct(
         private readonly Browser $browser,
+        private readonly Tracing $tracing,
         private readonly string $guid
     ) {
         //
@@ -34,6 +35,14 @@ final class Context
     public function browser(): Browser
     {
         return $this->browser;
+    }
+
+    /**
+     * Gets the tracing instance.
+     */
+    public function tracing(): Tracing
+    {
+        return $this->tracing;
     }
 
     /**
@@ -68,6 +77,8 @@ final class Context
         if ($this->browser->isClosed() || $this->closed) {
             return;
         }
+
+        $this->tracing->close();
 
         try {
             // fix this...

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -6,6 +6,7 @@ namespace Pest\Browser\Playwright;
 
 use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Enums\ColorScheme;
+use Pest\Browser\Enums\TracingOption;
 
 /**
  * @internal
@@ -33,6 +34,11 @@ final class Playwright
      * Whether to show the diff on screenshot assertions.
      */
     private static bool $shouldDiffOnScreenshotAssertions = false;
+
+    /**
+     * The tracing option.
+     */
+    private static TracingOption $tracingOption = TracingOption::OFF;
 
     /**
      * The default browser type.
@@ -195,6 +201,22 @@ final class Playwright
         foreach (self::$browserTypes as $browserType) {
             $browserType->reset();
         }
+    }
+
+    /**
+     * Sets the default browser type.
+     */
+    public static function setTracingOption(TracingOption $tracingOption): void
+    {
+        self::$tracingOption = $tracingOption;
+    }
+
+    /**
+     * Get the default browser type.
+     */
+    public static function tracingOption(): TracingOption
+    {
+        return self::$tracingOption;
     }
 
     /**

--- a/src/Playwright/Tracing.php
+++ b/src/Playwright/Tracing.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Playwright;
+
+use Pest\Browser\Enums\TracingOption;
+use Pest\TestSuite;
+
+/**
+ * @internal
+ */
+final class Tracing
+{
+    use Concerns\InteractsWithPlaywright;
+
+    private bool $isTracing = false;
+
+    private bool $isTracingChunk = false;
+
+    /**
+     * Creates a new context instance.
+     */
+    public function __construct(
+        private readonly string $guid
+    ) {
+        //
+    }
+
+    /**
+     * Return the path to the tracings' directory.
+     */
+    public static function dir(): string
+    {
+        return TestSuite::getInstance()->rootPath
+            .'/tests/Browser/Tracing';
+    }
+
+    /**
+     * Return the path for a tracing file.
+     */
+    public static function path(?string $filename = null): string
+    {
+        if ($filename === null) {
+            // @phpstan-ignore-next-line
+            $filename = str_replace('__pest_evaluable_', '', test()->name());
+        }
+
+        $path = self::dir().'/'.mb_ltrim($filename, '/');
+
+        // check if there is extension, if not, add .zip
+        if (pathinfo($path, PATHINFO_EXTENSION) === '') {
+            $path .= '.zip';
+        }
+
+        return $path;
+    }
+
+    /**
+     * Clean up the tracing directory.
+     */
+    public static function cleanup(): void
+    {
+        if (is_dir(self::dir()) === false) {
+            return;
+        }
+
+        $files = glob(self::dir().'/*');
+
+        if (is_array($files)) {
+            foreach ($files as $file) {
+                @unlink($file);
+            }
+        }
+
+        @rmdir(self::dir());
+    }
+
+    /**
+     * Start tracing
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function start(array $params = []): void
+    {
+        if ($this->isTracing) {
+            return;
+        }
+        $response = Client::instance()->execute($this->guid, 'tracingStart', $params);
+        $this->processVoidResponse($response);
+        $this->isTracing = true;
+    }
+
+    /**
+     * Start chunk
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function startChunk(array $params = []): void
+    {
+        if ($this->isTracingChunk) {
+            return;
+        }
+        $response = Client::instance()->execute($this->guid, 'tracingStartChunk', $params);
+        $this->processVoidResponse($response);
+        $this->isTracingChunk = true;
+    }
+
+    /**
+     * Stop chunk
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function stopChunk(array $params = []): Artifact
+    {
+        $response = Client::instance()->execute($this->guid, 'tracingStopChunk', $params);
+
+        /** @var array{result: array{artifact: array{guid: string|null}}} $message */
+        foreach ($response as $message) {
+            if (isset($message['result']['artifact']['guid'])) {
+                $artifact = new Artifact($message['result']['artifact']['guid']);
+            }
+        }
+
+        assert(isset($artifact), 'Tracing artifact was not created');
+
+        $this->isTracingChunk = false;
+
+        return $artifact;
+    }
+
+    /**
+     * Stop tracing
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function stop(array $params = []): void
+    {
+        $response = Client::instance()->execute($this->guid, 'tracingStop', $params);
+        $this->processVoidResponse($response);
+
+        $this->isTracing = false;
+    }
+
+    public function close(): void
+    {
+        if ($this->isTracingChunk) {
+            if (Playwright::tracingOption() === TracingOption::OFF) {
+                $this->stopChunk([
+                    'mode' => 'discard',
+                ]);
+            } else {
+                $artifact = $this->stopChunk([
+                    'mode' => 'archive',
+                ]);
+
+                if (is_dir(self::dir()) === false) {
+                    @mkdir(self::dir(), 0755, true);
+                }
+
+                $artifact->saveAs(['path' => self::path()]);
+            }
+        }
+
+        if ($this->isTracing) {
+            $this->stop();
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,10 +7,13 @@ namespace Pest\Browser;
 use Error;
 use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Enums\ColorScheme;
+use Pest\Browser\Enums\TracingOption;
 use Pest\Browser\Exceptions\BrowserNotSupportedException;
 use Pest\Browser\Exceptions\OptionNotSupportedInParallelException;
+use Pest\Browser\Exceptions\TracingOptionNotSupportedException;
 use Pest\Browser\Filters\UsesBrowserTestCaseMethodFilter;
 use Pest\Browser\Playwright\Playwright;
+use Pest\Browser\Playwright\Tracing;
 use Pest\Contracts\Plugins\Bootable;
 use Pest\Contracts\Plugins\HandlesArguments;
 use Pest\Contracts\Plugins\Terminable;
@@ -41,18 +44,24 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
             ->addTestCaseMethodFilter(new UsesBrowserTestCaseMethodFilter());
 
         pest()->afterEach(function (): void {
-            if (Playwright::shouldDebugAssertions()) {
-                /** @var TestStatus $status */
-                $status = $this->status(); // @phpstan-ignore-line
+            /** @var TestStatus $status */
+            $status = $this->status(); // @phpstan-ignore-line
+            $failed_or_error = $status->isFailure() || $status->isError();
 
-                if ($status->isFailure() || $status->isError()) {
-                    Execution::instance()->debug($status);
-                }
+            if (Playwright::shouldDebugAssertions() && $failed_or_error) {
+                Execution::instance()->debug($status);
             }
 
             ServerManager::instance()->http()->flush();
 
             Playwright::reset();
+
+            if (Playwright::tracingOption() === TracingOption::RETAIN_ON_FAILURE && $failed_or_error === false) {
+                @unlink(Tracing::path());
+                if (glob(Tracing::dir().'/*') === []) {
+                    @rmdir(Tracing::dir());
+                }
+            }
         })->in($this->in());
     }
 
@@ -91,6 +100,31 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
             Playwright::setColorScheme(ColorScheme::LIGHT);
 
             $arguments = $this->popArgument('--light', $arguments);
+        }
+
+        if ($this->hasArgument('--trace', $arguments)) {
+            $index = array_search('--trace', $arguments, true);
+
+            if ($index === false || ! isset($arguments[$index + 1])) {
+                throw new TracingOptionNotSupportedException(
+                    'The "--trace" argument requires a value. Usage: --trace <option> (e.g., on, retain-on-failure).'
+                );
+            }
+
+            $option = $arguments[$index + 1];
+
+            if (($option = TracingOption::tryFrom($option)) === null) {
+                throw new TracingOptionNotSupportedException(
+                    'The specified tracing type is not supported. Supported types are: '.
+                    implode(', ', array_map(fn (TracingOption $type): string => mb_strtolower($type->name), TracingOption::cases()))
+                );
+            }
+
+            Playwright::setTracingOption($option);
+
+            unset($arguments[$index], $arguments[$index + 1]);
+
+            $arguments = array_values($arguments);
         }
 
         if ($this->hasArgument('--browser', $arguments)) {

--- a/tests/Browser/Webpage/TracingTest.php
+++ b/tests/Browser/Webpage/TracingTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Pest\Browser\Playwright\Tracing;
+
+it('captures a tracing', function (): void {
+    Route::get('/', fn (): string => 'Hello World');
+
+    $page = visit('/');
+
+    $page->startTracing();
+    $page->stopTracing('trace.zip');
+
+    expect(file_exists(Tracing::path('trace.zip')))
+        ->toBeTrue();
+});
+
+it('captures a tracing with default filename', function (): void {
+    Route::get('/', fn (): string => 'Hello World');
+
+    $page = visit('/');
+
+    $page->startTracing();
+    $page->stopTracing();
+
+    expect(file_exists(Tracing::path()))
+        ->toBeTrue();
+});


### PR DESCRIPTION
This pull request adds playwright tracing support with a low level API closely following playwright interface. A higher level API accessible from webpage and command line options similar to playwright.

High level API:
```
$page = visit('/');
$page->startTracing();
// Do stuff
$page->stopTracing();
```
or it can be started with command line options
`pest --trace on`
`pest --trace retain-on-failure`
