### PR TITLE
fix: allow assertUrlIs() to accept path-only notation

### DIFF
--- a/src/Api/Concerns/MakesUrlAssertions.php
+++ b/src/Api/Concerns/MakesUrlAssertions.php
@@ -19,22 +19,31 @@ trait MakesUrlAssertions
     {
         $pattern = str_replace('\*', '.*', preg_quote($url, '/'));
 
-        /** @var array{ scheme: string, host: string, port?: int, path?: string} $segments */
         $segments = parse_url($this->page->url());
 
-        $currentUrl = sprintf(
-            '%s://%s%s%s',
-            $segments['scheme'],
-            $segments['host'],
-            isset($segments['port']) ? ':'.$segments['port'] : '',
-            $segments['path'] ?? ''
-        );
+        if (parse_url($url, PHP_URL_SCHEME) !== null) {
+            $currentUrl = sprintf(
+                '%s://%s%s%s',
+                $segments['scheme'],
+                $segments['host'],
+                isset($segments['port'])
+                    ? ':'.$segments['port']
+                    : '',
+                $segments['path'] ?? ''
+            );
 
-        $currentUrl = mb_rtrim($currentUrl, '/');
+            $currentUrl = mb_rtrim($currentUrl, '/');
 
-        $message = "Actual URL [{$currentUrl}] does not equal expected URL [{$url}].";
+            $message = "Actual URL [{$currentUrl}] does not equal expected URL [{$url}].";
 
-        expect($currentUrl)->toMatch('/^'.$pattern.'$/u', $message);
+            expect($currentUrl)->toMatch('/^'.$pattern.'$/u', $message);
+        } else {
+            $currentPath = $segments['path'] ?? '';
+
+            $message = "Actual path [{$currentPath}] does not equal expected path [{$url}].";
+
+            expect($currentPath)->toMatch('/^'.$pattern.'$/u', $message);
+        }
 
         return $this;
     }

--- a/tests/Browser/Webpage/AssertUrlTest.php
+++ b/tests/Browser/Webpage/AssertUrlTest.php
@@ -12,6 +12,22 @@ it('may assert current URL matches expected URL', function (): void {
     $page->assertUrlIs(url('/test-url'));
 });
 
+it('may assert current URL path using path-only notation', function (): void {
+    Route::get('/login', fn (): string => 'Login Page');
+
+    $page = visit('/login');
+
+    $page->assertUrlIs('/login');
+});
+
+it('may fail when asserting URL path using path-only notation but it does not match', function (): void {
+    Route::get('/login', fn (): string => 'Login Page');
+
+    $page = visit('/login');
+
+    $page->assertUrlIs('/wrong-path');
+})->throws(ExpectationFailedException::class);
+
 it('may fail when asserting URL matches but it does not', function (): void {
     Route::get('/test-url', fn (): string => 'Test URL Page');
 


### PR DESCRIPTION
Previously, assertUrlIs() only accepted full URLs because it matched against the complete URL including scheme, host, and port. 

This made tests like ->assertUrlIs('/login') fail even when the browser was on the correct path.

Now the function intelligently detects whether the input is a full URL or just a path:
- If input contains a scheme (e.g., http://), matches full URL
- If input is just a path (e.g., /login), matches only the path portion

This change maintains backward compatibility while adding the expected convenience of path-only assertions.

Reported by https://github.com/pestphp/pest/issues/1607