### PR TITLE
feat: add withLocale() to global browser configuration

### DIFF
--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -173,7 +173,7 @@ final class PendingAwaitablePage
         $browser = Playwright::browser($this->browserType)->launch();
 
         $context = $browser->newContext([
-            'locale' => 'en-US',
+            'locale' => Playwright::defaultLocale(),
             'timezoneId' => 'UTC',
             'colorScheme' => Playwright::defaultColorScheme()->value,
             ...$this->device->context(),

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -106,6 +106,16 @@ final readonly class Configuration
     }
 
     /**
+     * Sets the default locale for the browser context.
+     */
+    public function withLocale(string $locale): self
+    {
+        Playwright::setDefaultLocale($locale);
+
+        return $this;
+    }
+
+    /**
      * Enables debug mode for assertions.
      */
     public function debug(): self

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -60,6 +60,11 @@ final class Playwright
     private static ?string $host = null;
 
     /**
+     * The default locale.
+     */
+    private static string $defaultLocale = 'en-US';
+
+    /**
      * Get a browser factory for the given browser type.
      */
     public static function browser(BrowserType $browserType): BrowserFactory
@@ -153,6 +158,22 @@ final class Playwright
     public static function host(): ?string
     {
         return self::$host;
+    }
+
+    /**
+     * Set the default locale.
+     */
+    public static function setDefaultLocale(string $locale): void
+    {
+        self::$defaultLocale = $locale;
+    }
+
+    /**
+     * Get the default locale.
+     */
+    public static function defaultLocale(): string
+    {
+        return self::$defaultLocale;
     }
 
     /**

--- a/tests/Unit/Configuration/LocaleConfigurationTest.php
+++ b/tests/Unit/Configuration/LocaleConfigurationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Configuration;
+use Pest\Browser\Playwright\Playwright;
+
+beforeEach(function (): void {
+    Playwright::setDefaultLocale('en-US');
+});
+
+it('can set locale via configuration', function (): void {
+    $config = new Configuration();
+
+    $result = $config->withLocale('fr-FR');
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::defaultLocale())->toBe('fr-FR');
+});
+
+it('follows fluent interface pattern', function (): void {
+    $config = new Configuration();
+
+    $result = $config
+        ->withLocale('fr-FR')
+        ->userAgent('Test Agent')
+        ->timeout(10000);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::defaultLocale())->toBe('fr-FR');
+});
+
+it('stores locale in Playwright global state', function (): void {
+    expect(Playwright::defaultLocale())->toBe('en-US');
+
+    Playwright::setDefaultLocale('ja-JP');
+
+    expect(Playwright::defaultLocale())->toBe('ja-JP');
+});
+
+it('can override locale multiple times', function (): void {
+    Playwright::setDefaultLocale('fr-FR');
+    expect(Playwright::defaultLocale())->toBe('fr-FR');
+
+    Playwright::setDefaultLocale('de-DE');
+    expect(Playwright::defaultLocale())->toBe('de-DE');
+
+    Playwright::setDefaultLocale('ja-JP');
+    expect(Playwright::defaultLocale())->toBe('ja-JP');
+});


### PR DESCRIPTION
## Summary

- Add `Configuration::withLocale()` for global locale setting via `pest()->browser()->withLocale('fr')`
- Add `Playwright::setDefaultLocale()` / `Playwright::defaultLocale()` static methods
- Replace hardcoded `'en-US'` in `PendingAwaitablePage::buildAwaitablePage()` with `Playwright::defaultLocale()`
- Per-visit `withLocale()` override still works as before

Closes pestphp/pest#1659

## Test plan

- [x] Unit tests for `Configuration::withLocale()` fluent API
- [x] Unit tests for `Playwright::setDefaultLocale()` / `defaultLocale()` state management
- [x] PHPStan passes with no errors