### PR TITLE
feat: add saving storage states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage.xml
 # Playwright
 node_modules/
 /tests/Browser/Screenshots
+/tests/Browser/StorageState
 
 # MacOS
 .DS_Store

--- a/src/Api/AwaitableWebpage.php
+++ b/src/Api/AwaitableWebpage.php
@@ -28,6 +28,7 @@ final readonly class AwaitableWebpage
         private array $nonAwaitableMethods = [
             'assertScreenshotMatches',
             'assertNoAccessibilityIssues',
+            'saveStorageState',
         ],
     ) {
         //

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -176,7 +176,7 @@ final class PendingAwaitablePage
         $options = $this->options;
         $host = $this->extractHost($options);
 
-        return $this->withTemporaryHost($host, fn (): AwaitableWebpage => $this->buildAwaitablePage($options));
+        return $this->withTemporaryHost($host, fn(): AwaitableWebpage => $this->buildAwaitablePage($options));
     }
 
     /**
@@ -184,6 +184,13 @@ final class PendingAwaitablePage
      */
     private function buildAwaitablePage(array $options): AwaitableWebpage
     {
+        if (isset($options['storageState']) && is_string($options['storageState'])) {
+            $options['storageState'] = json_decode(
+                (string) file_get_contents($options['storageState']),
+                true,
+            );
+        }
+
         $browser = Playwright::browser($this->browserType)->launch();
 
         $context = $browser->newContext([
@@ -198,8 +205,10 @@ final class PendingAwaitablePage
 
         $url = ComputeUrl::from($this->url);
 
+        $gotoOptions = array_diff_key($options, array_flip(['storageState', 'host']));
+
         return new AwaitableWebpage(
-            $context->newPage()->goto($url, $options),
+            $context->newPage()->goto($url, $gotoOptions),
             $url,
         );
     }

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -176,7 +176,7 @@ final class PendingAwaitablePage
         $options = $this->options;
         $host = $this->extractHost($options);
 
-        return $this->withTemporaryHost($host, fn(): AwaitableWebpage => $this->buildAwaitablePage($options));
+        return $this->withTemporaryHost($host, fn (): AwaitableWebpage => $this->buildAwaitablePage($options));
     }
 
     /**

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -10,6 +10,7 @@ use Pest\Browser\Enums\Device;
 use Pest\Browser\Playwright\InitScript;
 use Pest\Browser\Playwright\Playwright;
 use Pest\Browser\Support\ComputeUrl;
+use Pest\Browser\Support\StorageState;
 
 /**
  * @mixin Webpage|AwaitableWebpage
@@ -150,6 +151,19 @@ final class PendingAwaitablePage
         return new self($this->browserType, $this->device, $this->url, [
             'geolocation' => $geolocation,
             'permissions' => ['geolocation'],
+            ...$this->options,
+        ]);
+    }
+
+    /**
+     * Loads a previously saved storage state (cookies and localStorage) into the browser context.
+     *
+     * This allows tests to skip login flows by reusing authenticated state saved with saveStorageState().
+     */
+    public function withStorageState(string $name): self
+    {
+        return new self($this->browserType, $this->device, $this->url, [
+            'storageState' => StorageState::path($name),
             ...$this->options,
         ]);
     }

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -96,6 +96,19 @@ final readonly class Webpage
     }
 
     /**
+     * Saves the current browser context's storage state (cookies and localStorage) to a file.
+     *
+     * The file is saved to tests/Browser/StorageState/<name>.json and can be loaded in
+     * subsequent tests via withStorageState() to avoid repetitive login flows.
+     */
+    public function saveStorageState(?string $name = null): self
+    {
+        $this->page->saveStorageState($name);
+
+        return $this;
+    }
+
+    /**
      * Gets the locator for the given selector.
      */
     private function guessLocator(string $selector, ?string $value = null): Locator

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -102,4 +102,15 @@ final class Context
 
         return $this;
     }
+
+    /**
+     * Returns the current storage state (cookies and localStorage) as a JSON string.
+     */
+    public function storageState(): string
+    {
+        $response = $this->sendMessage('storageState');
+        $result = $this->processResultResponse($response);
+
+        return (string) json_encode($result);
+    }
 }

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -109,8 +109,13 @@ final class Context
     public function storageState(): string
     {
         $response = $this->sendMessage('storageState');
-        $result = $this->processResultResponse($response);
 
-        return (string) json_encode($result);
+        foreach ($response as $message) {
+            if (isset($message['result'])) {
+                return (string) json_encode($message['result']);
+            }
+        }
+
+        return '{"cookies":[],"origins":[]}';
     }
 }

--- a/src/Playwright/Page.php
+++ b/src/Playwright/Page.php
@@ -11,6 +11,7 @@ use Pest\Browser\Support\JavaScriptSerializer;
 use Pest\Browser\Support\Screenshot;
 use Pest\Browser\Support\Selector;
 use Pest\Browser\Support\Shell;
+use Pest\Browser\Support\StorageState;
 use Pest\TestSuite;
 use PHPUnit\Framework\ExpectationFailedException;
 use RuntimeException;
@@ -436,6 +437,19 @@ final class Page
         }
 
         return Screenshot::save($binary, $filename);
+    }
+
+    /**
+     * Saves the current browser context's storage state (cookies and localStorage) to a file.
+     *
+     * The file is stored under tests/Browser/StorageState/ and can be loaded in subsequent
+     * tests via withStorageState() to skip repetitive login flows.
+     */
+    public function saveStorageState(?string $name = null): string
+    {
+        $json = $this->context->storageState();
+
+        return StorageState::save($json, $name);
     }
 
     /**

--- a/src/Support/StorageState.php
+++ b/src/Support/StorageState.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Support;
+
+use Pest\TestSuite;
+
+/**
+ * @internal
+ */
+final class StorageState
+{
+    /**
+     * Return the path to the storage state directory.
+     */
+    public static function dir(): string
+    {
+        return TestSuite::getInstance()->rootPath
+            .'/tests/Browser/StorageState';
+    }
+
+    /**
+     * Return the full path for a storage state file.
+     */
+    public static function path(string $name): string
+    {
+        return self::dir().DIRECTORY_SEPARATOR.mb_ltrim($name, '/').'.json';
+    }
+
+    /**
+     * Save a storage state JSON string to the filesystem.
+     */
+    public static function save(string $json, ?string $name = null): string
+    {
+        if ($name === null) {
+            // @phpstan-ignore-next-line
+            $name = str_replace('__pest_evaluable_', '', test()->name());
+        }
+
+        if (is_dir(self::dir()) === false) {
+            mkdir(self::dir(), 0755, true);
+        }
+
+        file_put_contents(self::path($name), $json);
+
+        return $name;
+    }
+}

--- a/tests/Unit/Support/StorageStateTest.php
+++ b/tests/Unit/Support/StorageStateTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Support\StorageState;
+
+it('places storage state files under tests/Browser/StorageState', function (): void {
+    StorageState::save('{"cookies":[],"origins":[]}', 'auth');
+
+    expect(file_exists(StorageState::path('auth')))->toBeTrue();
+
+    @unlink(StorageState::path('auth'));
+});
+
+it('returns the name used to save the state', function (): void {
+    $name = StorageState::save('{"cookies":[],"origins":[]}', 'my-session');
+
+    expect($name)->toBe('my-session');
+
+    @unlink(StorageState::path('my-session'));
+});
+
+it('builds the correct file path from a name', function (): void {
+    $path = StorageState::path('auth');
+
+    expect($path)->toEndWith('tests/Browser/StorageState/auth.json');
+});
+
+it('strips a leading slash from the name', function (): void {
+    $path = StorageState::path('/auth');
+
+    expect($path)->not->toContain('//');
+    expect($path)->toEndWith('tests/Browser/StorageState/auth.json');
+});
+
+it('overwrites an existing state file on re-save', function (): void {
+    StorageState::save('{"cookies":[],"origins":[]}', 'overwrite-test');
+    StorageState::save('{"cookies":[{"name":"session"}],"origins":[]}', 'overwrite-test');
+
+    $contents = file_get_contents(StorageState::path('overwrite-test'));
+
+    expect($contents)->toContain('session');
+
+    @unlink(StorageState::path('overwrite-test'));
+});


### PR DESCRIPTION
Adds support for Playwright's storage state feature, allowing tests to save and restore browser context state (cookies and localStorage). The primary use case is skipping repetitive login flows across tests.

After a login flow, save the authenticated state:

```
// tests/Browser/Auth/LoginTest.php
test('store authenticated state', function (): void {
    visit('/login')
        ->fill('#email', 'admin@example.com')
        ->fill('#password', 'secret')
        ->click('Login')
        ->assertUrlContains('/dashboard')
        ->saveStorageState('logged_in');  <--- this
});
```

All other tests just reuse it:

```
// tests/Browser/DashboardTest.php
test('can see dashboard', function (): void {
    visit('/dashboard')
        ->withStorageState('logged_in')  <--- this
        ->assertSee('Welcome back');
});

test('can see settings', function (): void {
    visit('/settings')
        ->withStorageState('logged_in')  <--- this
        ->assertSee('Account Settings');
});
```

This will save significant time when executing e2e browser tests that include logging before each test.