### PR TITLE
fix: use file_get_contents to prevent large JS files (>8KB) from being truncated

### DIFF
--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Drivers;
 
+use Amp\ByteStream\ReadableResourceStream;
 use Amp\Http\Cookie\RequestCookie;
 use Amp\Http\Server\DefaultErrorHandler;
 use Amp\Http\Server\HttpServer as AmpHttpServer;
@@ -316,25 +317,38 @@ final class LaravelHttpServer implements HttpServer
      */
     private function asset(string $filepath): Response
     {
-        $rawContent = file_get_contents($filepath);
-
-        if ($rawContent === false) {
-            return new Response(404);
-        }
-
         $mimeTypes = new MimeTypes();
         $contentType = $mimeTypes->getMimeTypes(pathinfo($filepath, PATHINFO_EXTENSION));
-
         $contentType = $contentType[0] ?? 'application/octet-stream';
 
         if (str_ends_with($filepath, '.js')) {
-            $rawContent = $this->rewriteAssetUrl($rawContent);
+            // ReadableResourceStream sets php://temp to non-blocking mode, causing
+            // AMPHP's event loop to deliver only the first 8192-byte chunk for files
+            // written to a php://temp stream. Using file_get_contents + a string body
+            // sends the full content in one shot, avoiding the truncation.
+            $content = file_get_contents($filepath);
+
+            if ($content === false) {
+                return new Response(404);
+            }
+
+            $content = $this->rewriteAssetUrl($content);
+
+            return new Response(200, [
+                'Content-Type' => $contentType,
+                'Content-Length' => (string) strlen($content),
+            ], $content);
+        }
+
+        $file = fopen($filepath, 'r');
+
+        if ($file === false) {
+            return new Response(404);
         }
 
         return new Response(200, [
             'Content-Type' => $contentType,
-            'Content-Length' => (string) strlen($rawContent),
-        ], $rawContent);
+        ], new ReadableResourceStream($file));
     }
 
     /**

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Drivers;
 
-use Amp\ByteStream\ReadableResourceStream;
 use Amp\Http\Cookie\RequestCookie;
 use Amp\Http\Server\DefaultErrorHandler;
 use Amp\Http\Server\HttpServer as AmpHttpServer;
@@ -317,9 +316,9 @@ final class LaravelHttpServer implements HttpServer
      */
     private function asset(string $filepath): Response
     {
-        $file = fopen($filepath, 'r');
+        $rawContent = file_get_contents($filepath);
 
-        if ($file === false) {
+        if ($rawContent === false) {
             return new Response(404);
         }
 
@@ -329,26 +328,13 @@ final class LaravelHttpServer implements HttpServer
         $contentType = $contentType[0] ?? 'application/octet-stream';
 
         if (str_ends_with($filepath, '.js')) {
-            $temporaryStream = fopen('php://temp', 'r+');
-            assert($temporaryStream !== false, 'Failed to open temporary stream.');
-
-            // @phpstan-ignore-next-line
-            $temporaryContent = fread($file, (int) filesize($filepath));
-
-            assert($temporaryContent !== false, 'Failed to open temporary stream.');
-
-            $content = $this->rewriteAssetUrl($temporaryContent);
-
-            fwrite($temporaryStream, $content);
-
-            rewind($temporaryStream);
-
-            $file = $temporaryStream;
+            $rawContent = $this->rewriteAssetUrl($rawContent);
         }
 
         return new Response(200, [
             'Content-Type' => $contentType,
-        ], new ReadableResourceStream($file));
+            'Content-Length' => (string) strlen($rawContent),
+        ], $rawContent);
     }
 
     /**

--- a/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
+++ b/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
@@ -21,6 +21,19 @@ it('rewrites the URLs on JS files', function (): void {
         ->assertDontSee('http://localhost');
 });
 
+it('serves JS files larger than 8192 bytes in full without truncation', function (): void {
+    // Create a JS file well over 8KB with a sentinel value at the very end.
+    // Before the fix, ReadableResourceStream on a php://temp stream would only
+    // deliver the first 8192-byte chunk, so the sentinel would be missing.
+    $padding = str_repeat('//' . str_repeat('x', 78) . PHP_EOL, 110); // ~8250 bytes of padding
+    @file_put_contents(
+        public_path('large.js'),
+        $padding . "console.log('END_SENTINEL');",
+    );
+
+    visit('/large.js')->assertSee('END_SENTINEL');
+});
+
 it('includes cookies set in the test', function (): void {
     Route::get('/cookies', fn (Request $request): array => $request->cookies->all());
 


### PR DESCRIPTION
## Problem

When running browser tests, all static JS files **larger than 8192 bytes** are truncated to exactly 8KB, causing `SyntaxError: Unexpected end of input` in Playwright. This makes `assertNoJavaScriptErrors()` fail on any page loading Livewire, Filament, or any Vite bundle.

### Evidence

Capturing error details via `window.__pestBrowser.jsErrors` after `waitForLoadState('networkidle')`:

```json
[
  { "message": "Uncaught SyntaxError: Unexpected end of input", "filename": ".../livewire.min.js", "lineno": 1, "colno": 8193 },
  { "message": "Uncaught SyntaxError: Unexpected end of input", "filename": ".../support.js",     "lineno": 1, "colno": 8193 },
  { "message": "Uncaught SyntaxError: Invalid or unexpected token", "filename": ".../tables.js", "lineno": 1, "colno": 8189 }
]
```

`colno: 8193` = exactly **8192 bytes** received — one AMPHP read chunk.

### Root Cause

`ReadableResourceStream` sets the stream to **non-blocking mode** (`stream_set_blocking($resource, false)`). For `php://temp` in non-blocking mode, AMPHP's fiber event loop only delivers the first 8192-byte chunk and does not schedule further reads within the same request, so files >8KB are silently truncated.

## Fix

Replace the `fopen`/`fread`/`php://temp`/`ReadableResourceStream` pipeline with `file_get_contents` and a plain string response body. The AMPHP `Response` accepts a string body and sends it in full, bypassing async read-chunk limitations entirely.

This also supersedes PR #203: the `filesize() === 0` guard is no longer needed since `file_get_contents` on an empty file returns `''` rather than crashing.

Fixes pestphp/pest#1664
Also fixes pestphp/pest#1635