### PR TITLE
feat: expose ServerManager::setHttp for custom HTTP drivers

### DIFF
--- a/src/ServerManager.php
+++ b/src/ServerManager.php
@@ -91,4 +91,14 @@ final class ServerManager
             default => new NullableHttpServer(),
         };
     }
+
+    /**
+     * Registers the HTTP server to use for browser tests. Call once from your
+     * test bootstrap (e.g. setUpBeforeClass) before the first visit(). When
+     * unset, the manager falls back to Laravel detection / NullableHttpServer.
+     */
+    public function setHttp(HttpServer $http): void
+    {
+        $this->http = $http;
+    }
 }


### PR DESCRIPTION
`ServerManager::http()` currently auto-picks `LaravelHttpServer` when `function_exists('app_path')` is true and otherwise falls back to `NullableHttpServer`. There's no way to register a third driver — the `$http` property is private and the lazy `match` is the only assignment path.

Consumers shipping their own `HttpServer` implementation (e.g. for non-Laravel frameworks running an in-process server) currently route around this by reflecting into the private property at test setup:

```php
\$prop = new ReflectionProperty(ServerManager::class, 'http');
\$prop->setValue(ServerManager::instance(), new MyHttpServer(...));
```

Real-world example: [bambamboole/typo3-pest-browser-testing](https://github.com/bambamboole/typo3-pest-browser-testing/blob/main/src/Testing/BrowserTestCase.php#L37-L46), which runs TYPO3 in-process via amphp.

This PR adds a single public method so consumers can register through a proper API instead:

```php
ServerManager::instance()->setHttp(new MyHttpServer(...));
```

No behavior change for Laravel users — the lazy default still kicks in when nothing's been registered. `@internal @codeCoverageIgnore` on the class is unchanged.