### PR TITLE
feat: add withCookie / withCookies API for browser visits

### DIFF
--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -16,6 +16,8 @@ use Pest\Browser\Support\ComputeUrl;
  */
 final class PendingAwaitablePage
 {
+    private const string COOKIES_KEY = '__pestCookies';
+
     /**
      * The webpage instance that will be returned when the page is visited.
      */
@@ -155,6 +157,53 @@ final class PendingAwaitablePage
     }
 
     /**
+     * Sets a cookie for the browser context.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function withCookie(string $name, string $value, array $options = []): self
+    {
+        return $this->withCookies([['name' => $name, 'value' => $value] + $options]);
+    }
+
+    /**
+     * Sets multiple cookies for the browser context.
+     *
+     * @param  array<int, array<string, mixed>>  $cookies
+     */
+    public function withCookies(array $cookies): self
+    {
+        /** @var array<int, array<string, mixed>> $existing */
+        $existing = $this->options[self::COOKIES_KEY] ?? [];
+
+        return new self($this->browserType, $this->device, $this->url, [
+            ...$this->options,
+            self::COOKIES_KEY => [...$existing, ...$cookies],
+        ]);
+    }
+
+    /**
+     * Defaults each cookie's url to the navigation target when neither
+     * url nor domain is given — Playwright requires one of them.
+     *
+     * @param  array<int, array<string, mixed>>  $cookies
+     * @return array<int, array<string, mixed>>
+     */
+    private static function resolveCookieUrls(array $cookies, string $targetUrl): array
+    {
+        return array_map(
+            static function (array $cookie) use ($targetUrl): array {
+                if (! isset($cookie['url']) && ! isset($cookie['domain'])) {
+                    $cookie['url'] = $targetUrl;
+                }
+
+                return $cookie;
+            },
+            $cookies,
+        );
+    }
+
+    /**
      * Creates the webpage instance.
      */
     private function createAwaitablePage(): AwaitableWebpage
@@ -170,6 +219,10 @@ final class PendingAwaitablePage
      */
     private function buildAwaitablePage(array $options): AwaitableWebpage
     {
+        /** @var array<int, array<string, mixed>> $cookies */
+        $cookies = $options[self::COOKIES_KEY] ?? [];
+        unset($options[self::COOKIES_KEY]);
+
         $browser = Playwright::browser($this->browserType)->launch();
 
         $context = $browser->newContext([
@@ -183,6 +236,10 @@ final class PendingAwaitablePage
         $context->addInitScript(InitScript::get());
 
         $url = ComputeUrl::from($this->url);
+
+        if ($cookies !== []) {
+            $context->addCookies(self::resolveCookieUrls($cookies, $url));
+        }
 
         return new AwaitableWebpage(
             $context->newPage()->goto($url, $options),

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -102,4 +102,17 @@ final class Context
 
         return $this;
     }
+
+    /**
+     * Adds cookies to the browser context.
+     *
+     * @param  array<int, array<string, mixed>>  $cookies
+     */
+    public function addCookies(array $cookies): self
+    {
+        $response = $this->sendMessage('addCookies', ['cookies' => $cookies]);
+        $this->processVoidResponse($response);
+
+        return $this;
+    }
 }

--- a/tests/Browser/Visit/CookieTest.php
+++ b/tests/Browser/Visit/CookieTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+test('may set a single cookie via withCookie()', function (): void {
+    Route::get('/cookie-check', fn (Request $request): array => $request->cookies->all());
+
+    visit('/cookie-check')
+        ->withCookie('via_browser', 'forwarded')
+        ->assertSee('"via_browser":"forwarded"');
+});
+
+test('may set multiple cookies via withCookies()', function (): void {
+    Route::get('/cookie-check', fn (Request $request): array => $request->cookies->all());
+
+    visit('/cookie-check')
+        ->withCookies([
+            ['name' => 'first', 'value' => 'one'],
+            ['name' => 'second', 'value' => 'two'],
+        ])
+        ->assertSee('"first":"one"')
+        ->assertSee('"second":"two"');
+});
+
+test('subsequent withCookie() calls accumulate', function (): void {
+    Route::get('/cookie-check', fn (Request $request): array => $request->cookies->all());
+
+    visit('/cookie-check')
+        ->withCookie('a', '1')
+        ->withCookie('b', '2')
+        ->assertSee('"a":"1"')
+        ->assertSee('"b":"2"');
+});


### PR DESCRIPTION
There's currently no public way to set browser-context cookies on a `visit()`. `Context` is final and only exposes `newPage`/`close`/`addInitScript`; its `$guid` and `sendMessage()` are private. `PendingAwaitablePage` is also final.

Consumers that need to pre-set a cookie (typical case: dropping into an authenticated session without filling a login form) currently route around it by replicating `buildAwaitablePage()` and reflecting into Pest's private internals to call Playwright's `Browser.Context.addCookies`:

```php
\$guid = (new ReflectionProperty(Context::class, 'guid'))->getValue(\$context);
\$response = Client::instance()->execute(\$guid, 'addCookies', [
    'cookies' => [['name' => 'be_typo_user', 'value' => \$jwt, ...]],
]);
foreach (\$response as \$_) {}
```

Real-world example: [bambamboole/typo3-pest-browser-testing's `BrowserTestCase::visitAsAdmin()`](https://github.com/bambamboole/typo3-pest-browser-testing/blob/main/src/Testing/BrowserTestCase.php#L93-L150) — TYPO3 backend logged-in session via a forged be_typo_user JWT.

## What this PR adds

**Low level — `Context::addCookies(array $cookies): self`:** mirrors `addInitScript`'s shape. Passes the cookie array straight to Playwright.

**High level — `PendingAwaitablePage::withCookie()` and `withCookies()`:**

```php
visit('/admin')
    ->withCookie('session', \$jwt)
    ->assertSee('Dashboard');

visit('/admin')
    ->withCookies([
        ['name' => 'a', 'value' => '1'],
        ['name' => 'b', 'value' => '2', 'httpOnly' => true],
    ])
    ->assertSee('logged in');
```

Cookies are stashed inside the existing `$options` bag under a private const sentinel key — keeps the diff small (no `On`/`From`/`Browsable` constructor changes). `buildAwaitablePage()` extracts them and calls `$context->addCookies()` between `addInitScript` and `goto`. If a cookie has neither `url` nor `domain`, the navigation target URL is used automatically — so the common case (`->withCookie(name, value)`) just works without the caller having to know about Playwright's scoping requirement.

## What consumers get to delete

After this lands, the typo3-testing example collapses from ~60 lines of reflection + replicated `buildAwaitablePage` to:

```php
return \$this->visit('/typo3/')
    ->withCookie('be_typo_user', \$jwt, [
        'httpOnly' => true,
        'sameSite' => 'Strict',
    ]);
```

## Tests

`tests/Browser/Visit/CookieTest.php` (new, 3 cases mirroring `GeolocationTest.php`):

- single cookie via `withCookie()` reaches the server
- multiple cookies via `withCookies()` all reach
- chained `withCookie()` calls accumulate

Full `tests/Browser/Visit/` suite passes (14/14). Pint clean, PHPStan clean.