### PR TITLE
Exposed guessLocator via element function on Webpage class

### DIFF
--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -96,6 +96,16 @@ final readonly class Webpage
     }
 
     /**
+     * Get a locator for the given selector for use in custom assertions.
+     *
+     * When multiple elements match, use `->all()` to iterate or `->first()` / `->nth()` for one.
+     */
+    public function element(string $selector, ?string $value = null): Locator
+    {
+        return $this->guessLocator($selector, $value);
+    }
+
+    /**
      * Gets the locator for the given selector.
      */
     private function guessLocator(string $selector, ?string $value = null): Locator

--- a/tests/Browser/Webpage/ElementTest.php
+++ b/tests/Browser/Webpage/ElementTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+it('may assert text on all matching elements', function (): void {
+    Route::get('/', fn (): string => '
+        <a class="link">wow</a>
+        <a class="link">wow</a>
+        <a class="link">wow</a>
+    ');
+
+    $page = visit('/');
+
+    foreach ($page->element('.link')->all() as $element) {
+        expect($element->textContent())->toBe('wow');
+    }
+});
+
+it('may assert text on the first matching element', function (): void {
+    Route::get('/', fn (): string => '
+        <a class="link">wow</a>
+        <a class="link">other</a>
+    ');
+
+    $page = visit('/');
+
+    expect($page->element('.link')->first()->textContent())->toBe('wow');
+});


### PR DESCRIPTION
This is more of a question than an improvement. I was wondering why elements aren't exposed to the end user to test directly. To give some context, I ran into a bit of an issue testing where I needed to check the order of elements when using sorting on the page and I couldn't find any way to do it with the current assertion function. This requires the user to use the script function to retrieve element content using querySelector 

EG
```php
$page->click('@sort-button');

$names = $page->script('
    const names = document.querySelectorAll("[data-test=\'names\']")
    Array
        .from(names)
        .map(name => name.textContent);
');  

 expect($names)->toBe(['Name 1', 'Name 2']);
```

Resorting to the query selector means that all of playwrights locator magic gets lost! I could be missing something but it seems like it would be useful to be able to access the locator returned from guessLocator directly instead. 

EG
```php
$page->click('@sort-button');

$names = $page->element('@names')->all()
$names = array_map(fn ($name_el) => $name_el->textContent())

 expect($names)->toBe(['Name 1', 'Name 2']);
```

Let me know if I'm missing something, or if another approach can be taken. 