### PR TITLE
fix: at selector with value filtering

### DIFF
--- a/src/Support/GuessLocator.php
+++ b/src/Support/GuessLocator.php
@@ -38,6 +38,16 @@ final readonly class GuessLocator
         if (Selector::isDataTest($selector)) {
             $id = Selector::escapeForAttributeSelectorOrRegex(str_replace('@', '', $selector), true);
 
+            if ($value !== null) {
+                $value = sprintf('[value=%s]', Selector::escapeForAttributeSelectorOrRegex($value, true));
+
+                return $this->page->unstrict(
+                    fn (): Locator => $this->page->locator(
+                        "[data-testid=$id]$value, [data-test=$id]$value",
+                    ),
+                );
+            }
+
             return $this->page->unstrict(
                 fn (): Locator => $this->page->locator(
                     "[data-testid=$id], [data-test=$id]",

--- a/tests/Browser/Webpage/AssertRadioTest.php
+++ b/tests/Browser/Webpage/AssertRadioTest.php
@@ -36,6 +36,22 @@ it('may fail when asserting radio is not selected but it is', function (): void 
     $page->assertRadioNotSelected('color', 'red');
 })->throws(ExpectationFailedException::class);
 
+it('may assert radio is selected by data-testid and value', function (): void {
+    Route::get('/', fn (): string => '<input type="radio" data-testid="color" name="color" value="red"><input type="radio" data-testid="color" name="color" value="blue" checked>');
+
+    $page = visit('/');
+
+    $page->assertRadioSelected('@color', 'blue');
+});
+
+it('may assert radio is not selected by data-testid and value', function (): void {
+    Route::get('/', fn (): string => '<input type="radio" data-testid="color" name="color" value="red" checked><input type="radio" data-testid="color" name="color" value="blue">');
+
+    $page = visit('/');
+
+    $page->assertRadioNotSelected('@color', 'blue');
+});
+
 it('may assert all radios in a group are not selected', function (): void {
     Route::get('/', fn (): string => '<input type="radio" name="size" value="small"><input type="radio" name="size" value="medium"><input type="radio" name="size" value="large">');
 


### PR DESCRIPTION
This fixes a bug in GuessLocator.php where `@...` selectors using an optional value would resolve `[data-testid=...]` / `[data-test=...]` before applying the `[value=...]` filter.

In grouped radios or checkboxes that share the same test id, that meant assertions and interactions could fall back to the first matching element instead of the one with the requested value. Without this change, calls like `assertRadioSelected('@color', 'blue')` could inspect the first `@color` radio instead of the radio with value `blue`.

Test coverage is added to validate the correct behavior.