### PR TITLE
Implement pest --record command for browser test generation

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+Please refer to the [Pest Security Policy](https://github.com/pestphp/pest/security/policy) for information on how to report security vulnerabilities.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "5.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: ['push', 'pull_request']
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Setup Node ${{ matrix.node }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ matrix.node }}
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
       with:
         php-version: ${{ matrix.php }}
         tools: composer:v2

--- a/README.md
+++ b/README.md
@@ -16,37 +16,75 @@ Playwright's codegen opens a browser window. Interact with your application, the
 
 | Option | Default | Description |
 |---|---|---|
-| `--url=` | `http://localhost:8000` | Base URL to open |
-| `--visit=` | `/` | Path to open on start (e.g. `/login`) |
-| `--test-id-attribute=` | `data-test` | HTML attribute used for element selectors |
+| `--url=` | `APP_URL` from `.env` | Base URL to open |
+| `--visit=` | `/` | Path to open on start (e.g. `/dashboard`) |
+| `--test-id-attribute=` | `id` | HTML attribute used for element selectors |
 | `--device=` | — | Emulate a device (e.g. `"iPhone 15"`) |
 | `--viewport=` | — | Viewport size in pixels (e.g. `1280,800`) |
-| `--acting-as=` | — | Name of a saved browser auth state to load |
+| `--acting-as=` | — | Name of a saved auth state (see below) |
+| `--server` | — | Start `php artisan serve` before recording |
+| `--env=` | `local` | Environment passed to `--server` and `--migrate-fresh` |
+| `--migrate-fresh` | — | Run `migrate:fresh` before opening the browser |
+| `--seed` | — | Seed the database after `--migrate-fresh` |
 
 **Example:**
 
 ```bash
-vendor/bin/pest --record --url=https://example.com --visit=/login --test-id-attribute=id
+vendor/bin/pest --record --visit=/dashboard --acting-as=user
 ```
 
 **Example output:**
 
 ```php
-it('can login', function (): void {
-    $page = visit('/login');
-    $page->fill('#email', 'user@example.com');
-    $page->fill('#password', 'secret');
-    $page->click('Sign in');
-    $page->assertSee('Dashboard');
+it('can switch to dark mode', function (): void {
+    $this->actingAs(\App\Models\User::factory()->create());
+
+    visit('/dashboard')
+        ->click('Settings')
+        ->click('Appearance')
+        ->click('Dark');
 });
 ```
 
-**Auth state (`--acting-as`):**
+**Why you need `--server`:**
 
-Saves and reloads browser-level auth state (cookies, localStorage) between recordings. On first use, a login sequence is recorded and saved. Subsequent recordings load the saved state automatically.
+`pest --record` opens a real browser (Playwright codegen) against a running HTTP server. The recorder connects to your app just like a normal user would — it does NOT use the in-process test server that runs during `vendor/bin/pest`.
+
+If your app is not already running, pass `--server` to start `php artisan serve` automatically:
 
 ```bash
-vendor/bin/pest --record --acting-as=admin
+vendor/bin/pest --record --server --env=local --visit=/dashboard
+```
+
+Without `--server`, you must start the dev server yourself before recording:
+
+```bash
+php artisan serve &
+vendor/bin/pest --record
+```
+
+**Auth state and the environment mismatch problem (`--acting-as`):**
+
+Tests run with a fresh, isolated database (`APP_ENV=testing`). If you record a login sequence without `--acting-as`, your real credentials from the local environment are captured — but those credentials don't exist in the test database.
+
+`--acting-as` solves this in two steps:
+
+1. **First use:** a browser opens at `/login`. Log in with your real credentials. The browser session (cookies, localStorage) is saved to a temp file.
+2. **Subsequent recordings:** the saved session is loaded automatically, so the browser starts already authenticated. No login form is filled, so no credentials are captured.
+
+The generated test replaces the login flow with `actingAs(User::factory()->create())`, which creates a real user in the test database and authenticates without touching the login form:
+
+```bash
+# First run saves the auth session; subsequent runs reuse it
+vendor/bin/pest --record --server --acting-as=user --visit=/dashboard
+```
+
+If you record without `--acting-as` and Pest detects a password field in the recording, it automatically strips the login sequence and injects `actingAs()` instead.
+
+**Fresh database before recording:**
+
+```bash
+vendor/bin/pest --record --server --migrate-fresh --seed --env=local --visit=/dashboard
 ```
 
 **Requirements:** `npm install -D @playwright/test` and `npx playwright install`.

--- a/README.md
+++ b/README.md
@@ -2,92 +2,15 @@ This repository contains the Pest Plugin for Browser.
 
 > If you want to start testing your application with Pest, visit the main **[Pest Repository](https://github.com/pestphp/pest)**.
 
-## Recording Tests
+### Recording Tests
 
-Generate a browser test by recording your interactions live in the browser — no test code to write by hand.
+Generate browser-tests by recording your interactions in the browser:
 
 ```bash
 vendor/bin/pest --record
 ```
 
-Playwright's codegen opens a browser window. Interact with your application, then close the browser. Pest prompts for a test description and output file, then writes the generated test to `tests/Browser/`.
-
-**Options:**
-
-| Option | Default | Description |
-|---|---|---|
-| `--url=` | `APP_URL` from `.env` | Base URL to open |
-| `--visit=` | `/` | Path to open on start (e.g. `/dashboard`) |
-| `--test-id-attribute=` | `id` | HTML attribute used for element selectors |
-| `--device=` | — | Emulate a device (e.g. `"iPhone 15"`) |
-| `--viewport=` | — | Viewport size in pixels (e.g. `1280,800`) |
-| `--acting-as=` | — | Name of a saved auth state (see below) |
-| `--server` | — | Start `php artisan serve` before recording |
-| `--env=` | `local` | Environment passed to `--server` and `--migrate-fresh` |
-| `--migrate-fresh` | — | Run `migrate:fresh` before opening the browser |
-| `--seed` | — | Seed the database after `--migrate-fresh` |
-
-**Example:**
-
-```bash
-vendor/bin/pest --record --visit=/dashboard --acting-as=user
-```
-
-**Example output:**
-
-```php
-it('can switch to dark mode', function (): void {
-    $this->actingAs(\App\Models\User::factory()->create());
-
-    visit('/dashboard')
-        ->click('Settings')
-        ->click('Appearance')
-        ->click('Dark');
-});
-```
-
-**Why you need `--server`:**
-
-`pest --record` opens a real browser (Playwright codegen) against a running HTTP server. The recorder connects to your app just like a normal user would — it does NOT use the in-process test server that runs during `vendor/bin/pest`.
-
-If your app is not already running, pass `--server` to start `php artisan serve` automatically:
-
-```bash
-vendor/bin/pest --record --server --env=local --visit=/dashboard
-```
-
-Without `--server`, you must start the dev server yourself before recording:
-
-```bash
-php artisan serve &
-vendor/bin/pest --record
-```
-
-**Auth state and the environment mismatch problem (`--acting-as`):**
-
-Tests run with a fresh, isolated database (`APP_ENV=testing`). If you record a login sequence without `--acting-as`, your real credentials from the local environment are captured — but those credentials don't exist in the test database.
-
-`--acting-as` solves this in two steps:
-
-1. **First use:** a browser opens at `/login`. Log in with your real credentials. The browser session (cookies, localStorage) is saved to a temp file.
-2. **Subsequent recordings:** the saved session is loaded automatically, so the browser starts already authenticated. No login form is filled, so no credentials are captured.
-
-The generated test replaces the login flow with `actingAs(User::factory()->create())`, which creates a real user in the test database and authenticates without touching the login form:
-
-```bash
-# First run saves the auth session; subsequent runs reuse it
-vendor/bin/pest --record --server --acting-as=user --visit=/dashboard
-```
-
-If you record without `--acting-as` and Pest detects a password field in the recording, it automatically strips the login sequence and injects `actingAs()` instead.
-
-**Fresh database before recording:**
-
-```bash
-vendor/bin/pest --record --server --migrate-fresh --seed --env=local --visit=/dashboard
-```
-
-**Requirements:** `npm install -D @playwright/test` and `npx playwright install`.
+See **[RECORDING.md](RECORDING.md)** for more information.
 
 - Explore our docs at **[pestphp.com »](https://pestphp.com)**
 - Follow the creator Nuno Maduro:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,55 @@ This repository contains the Pest Plugin for Browser.
 
 > If you want to start testing your application with Pest, visit the main **[Pest Repository](https://github.com/pestphp/pest)**.
 
+## Recording Tests
+
+Generate a browser test by recording your interactions live in the browser — no test code to write by hand.
+
+```bash
+vendor/bin/pest --record
+```
+
+Playwright's codegen opens a browser window. Interact with your application, then close the browser. Pest prompts for a test description and output file, then writes the generated test to `tests/Browser/`.
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `--url=` | `http://localhost:8000` | Base URL to open |
+| `--visit=` | `/` | Path to open on start (e.g. `/login`) |
+| `--test-id-attribute=` | `data-test` | HTML attribute used for element selectors |
+| `--device=` | — | Emulate a device (e.g. `"iPhone 15"`) |
+| `--viewport=` | — | Viewport size in pixels (e.g. `1280,800`) |
+| `--acting-as=` | — | Name of a saved browser auth state to load |
+
+**Example:**
+
+```bash
+vendor/bin/pest --record --url=https://example.com --visit=/login --test-id-attribute=id
+```
+
+**Example output:**
+
+```php
+it('can login', function (): void {
+    $page = visit('/login');
+    $page->fill('#email', 'user@example.com');
+    $page->fill('#password', 'secret');
+    $page->click('Sign in');
+    $page->assertSee('Dashboard');
+});
+```
+
+**Auth state (`--acting-as`):**
+
+Saves and reloads browser-level auth state (cookies, localStorage) between recordings. On first use, a login sequence is recorded and saved. Subsequent recordings load the saved state automatically.
+
+```bash
+vendor/bin/pest --record --acting-as=admin
+```
+
+**Requirements:** `npm install -D @playwright/test` and `npx playwright install`.
+
 - Explore our docs at **[pestphp.com »](https://pestphp.com)**
 - Follow the creator Nuno Maduro:
     - YouTube: **[youtube.com/@nunomaduro](https://www.youtube.com/@nunomaduro)** — Videos every weekday

--- a/RECORDING.md
+++ b/RECORDING.md
@@ -1,0 +1,51 @@
+# Recording Guide
+
+## How it works
+
+`vendor/bin/pest --record` automatically starts an HTTP server with `APP_ENV=testing` before the browser opens, then shuts it down when recording ends — matching the same behavior as running browser tests normally with `vendor/bin/pest`.
+
+The browser opens at full screen resolution by default (auto-detected per OS). Close the browser when done. Pest prompts for a test description and output file, then writes the generated test to `tests/Browser/`.
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--url=` | auto | Skip auto-server; connect to this URL instead |
+| `--visit=` | `/` | Path to open on start |
+| `--test-id-attribute=` | `id` | HTML attribute used for element selectors |
+| `--device=` | — | Emulate a device (e.g. `"iPhone 15"`) |
+| `--viewport=` | screen resolution | Viewport size in pixels (e.g. `1280,800`) |
+| `--acting-as=` | — | Name for the auth state (see below) |
+| `--env=` | `testing` | Environment for the auto-started server |
+| `--migrate-fresh` | — | Run `migrate:fresh` before opening the browser |
+| `--seed` | — | Seed the database after `--migrate-fresh` |
+
+## Recording authenticated flows (`--acting-as`)
+
+Tests run with `APP_ENV=testing` (fresh, isolated DB). Recording against credentials that only exist in your local DB means those credentials won't exist when the test runs.
+
+`--acting-as` solves this without manual login: before the browser opens, Pest bootstraps the Laravel app, creates a factory user, starts a session authenticated as that user, and injects a valid session cookie into the browser. The browser starts pre-authenticated.
+
+```bash
+vendor/bin/pest --record --acting-as=user --visit=/dashboard
+```
+
+The generated test uses `$this->actingAs(\App\Models\User::factory()->create())` — no real credentials, works in any environment.
+
+## Fresh database before recording
+
+```bash
+vendor/bin/pest --record --migrate-fresh --seed --visit=/dashboard
+```
+
+Useful when you want to record against a predictable dataset.
+
+## Recording against an existing server
+
+Pass `--url=` to skip the auto-server entirely:
+
+```bash
+vendor/bin/pest --record --url=http://localhost:8000 --visit=/dashboard
+```
+
+Useful when you have Herd, Valet, or a running `php artisan serve` instance.

--- a/RECORDING.md
+++ b/RECORDING.md
@@ -2,30 +2,54 @@
 
 ## How it works
 
-`vendor/bin/pest --record` automatically starts an HTTP server with `APP_ENV=testing` before the browser opens, then shuts it down when recording ends — matching the same behavior as running browser tests normally with `vendor/bin/pest`.
+`vendor/bin/pest --record` automatically starts an HTTP server with `APP_ENV=testing` before the browser opens, then
+shuts it down when recording ends — matching the same behavior as running browser tests normally with `vendor/bin/pest`.
 
-The browser opens at full screen resolution by default (auto-detected per OS). Close the browser when done. Pest prompts for a test description and output file, then writes the generated test to `tests/Browser/`.
+The browser opens at full screen resolution by default (auto-detected per OS). Close the browser when done. Pest prompts
+for a test description and output file, then writes the generated test to `tests/Browser/`.
 
 ## Options
 
-| Option | Default | Description |
-|---|---|---|
-| `--url=` | auto | Skip auto-server; connect to this URL instead |
-| `--visit=` | `/` | Path to open on start |
-| `--test-id-attribute=` | `id` | HTML attribute used for element selectors |
-| `--device=` | — | Emulate a device (e.g. `"iPhone 15"`) |
-| `--viewport=` | screen resolution | Viewport size in pixels (e.g. `1280,800`) |
-| `--auth` / `--user` | — | Start browser pre-authenticated as a factory user (see below) |
-| `--auth-script=` | — | Path to a custom auth bootstrap script (non-Laravel apps) |
-| `--env=` | `testing` | Environment for the auto-started server |
-| `--migrate-fresh` | — | Run `migrate:fresh` before opening the browser |
-| `--seed` | — | Seed the database after `--migrate-fresh` |
+| Option                 | Default           | Description                                                   |
+|------------------------|-------------------|---------------------------------------------------------------|
+| `--url=`               | auto              | Skip auto-server; connect to this URL instead                 |
+| `--visit=`             | `/`               | Path to open on start                                         |
+| `--test-id-attribute=` | `id`              | HTML attribute used for element selectors                     |
+| `--device=`            | —                 | Emulate a device (e.g. `"iPhone 15"`)                         |
+| `--viewport=`          | screen resolution | Viewport size in pixels (e.g. `1280,800`)                     |
+| `--auth` / `--user`    | —                 | Start browser pre-authenticated as a factory user (see below) |
+| `--auth-script=`       | —                 | Path to a custom auth bootstrap script (non-Laravel apps)     |
+| `--env=`               | `testing`         | Environment for the auto-started server                       |
+| `--migrate-fresh`      | —                 | Run `migrate:fresh` before opening the browser                |
+| `--seed`               | —                 | Seed the database after `--migrate-fresh`                     |
+| `--browser=`           | `chrome`          | Browser to record with: `chrome`, `firefox`, `safari`         |
+| `--channel=`           | —                 | Browser channel (e.g. `msedge`, `chrome-canary`)              |
+| `--lang=`              | —                 | Override browser locale (e.g. `fr`, `nl`)                     |
+| `--timezone=`          | —                 | Override browser timezone (e.g. `Europe/Paris`)               |
+| `--color-scheme=`      | —                 | Preferred color scheme: `dark`, `light`, `no-preference`      |
+
+## Recording in a specific browser
+
+```bash
+vendor/bin/pest --record --browser=firefox
+vendor/bin/pest --record --browser=chrome --channel=msedge
+```
+
+## Recording with locale or timezone
+
+```bash
+vendor/bin/pest --record --lang=fr --timezone=Europe/Paris
+vendor/bin/pest --record --color-scheme=dark
+```
 
 ## Recording authenticated flows (`--auth`)
 
-Tests run with `APP_ENV=testing` (fresh, isolated DB). Recording against credentials that only exist in your local DB means those credentials won't exist when the test runs.
+Tests run with `APP_ENV=testing` (fresh, isolated DB). Recording against credentials that only exist in your local DB
+means those credentials won't exist when the test runs.
 
-`--auth` solves this without manual login: before the browser opens, Pest bootstraps the Laravel app, creates a factory user, starts a session authenticated as that user, and injects a valid session cookie into the browser. The browser starts pre-authenticated.
+`--auth` solves this without manual login: before the browser opens, Pest bootstraps the Laravel app, creates a factory
+user, starts a session authenticated as that user, and injects a valid session cookie into the browser. The browser
+starts pre-authenticated.
 
 ```bash
 vendor/bin/pest --record --auth --visit=/dashboard
@@ -33,7 +57,8 @@ vendor/bin/pest --record --auth --visit=/dashboard
 
 `--user` is an alias for `--auth`.
 
-The generated test uses `$this->actingAs(\App\Models\User::factory()->create())` — no real credentials, works in any environment.
+The generated test uses `$this->actingAs(\App\Models\User::factory()->create())` — no real credentials, works in any
+environment.
 
 ## Fresh database before recording
 

--- a/RECORDING.md
+++ b/RECORDING.md
@@ -15,20 +15,23 @@ The browser opens at full screen resolution by default (auto-detected per OS). C
 | `--test-id-attribute=` | `id` | HTML attribute used for element selectors |
 | `--device=` | — | Emulate a device (e.g. `"iPhone 15"`) |
 | `--viewport=` | screen resolution | Viewport size in pixels (e.g. `1280,800`) |
-| `--acting-as=` | — | Name for the auth state (see below) |
+| `--auth` / `--user` | — | Start browser pre-authenticated as a factory user (see below) |
+| `--auth-script=` | — | Path to a custom auth bootstrap script (non-Laravel apps) |
 | `--env=` | `testing` | Environment for the auto-started server |
 | `--migrate-fresh` | — | Run `migrate:fresh` before opening the browser |
 | `--seed` | — | Seed the database after `--migrate-fresh` |
 
-## Recording authenticated flows (`--acting-as`)
+## Recording authenticated flows (`--auth`)
 
 Tests run with `APP_ENV=testing` (fresh, isolated DB). Recording against credentials that only exist in your local DB means those credentials won't exist when the test runs.
 
-`--acting-as` solves this without manual login: before the browser opens, Pest bootstraps the Laravel app, creates a factory user, starts a session authenticated as that user, and injects a valid session cookie into the browser. The browser starts pre-authenticated.
+`--auth` solves this without manual login: before the browser opens, Pest bootstraps the Laravel app, creates a factory user, starts a session authenticated as that user, and injects a valid session cookie into the browser. The browser starts pre-authenticated.
 
 ```bash
-vendor/bin/pest --record --acting-as=user --visit=/dashboard
+vendor/bin/pest --record --auth --visit=/dashboard
 ```
+
+`--user` is an alias for `--auth`.
 
 The generated test uses `$this->actingAs(\App\Models\User::factory()->create())` — no real credentials, works in any environment.
 

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,8 @@
     "extra": {
         "pest": {
             "plugins": [
-                "Pest\\Browser\\Plugin"
+                "Pest\\Browser\\Plugin",
+                "Pest\\Browser\\Record"
             ]
         }
     }

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,308 @@
+## Pest Browser Testing
+
+- Use `visit('/path')` to navigate to a page. Chain interactions and assertions fluently.
+- You don't need absolute URLs in `visit()`. Just use the path (e.g. `visit('/dashboard')`) and Pest will resolve it.
+- **Note:** Always provide a descriptive `filename:` to screenshots.
+
+### Navigation & Screenshots
+
+```php
+$this->visit('/')->screenshot(filename: 'homepage');
+$this->visit('/dashboard')->screenshot(filename: 'dashboard', fullPage: true);
+$this->visit('/')->screenshotElement('.hero', filename: 'hero-section');
+```
+
+Visual regression testing to catch unintended UI changes:
+
+```php
+$this->visit('/')->assertScreenshotMatches();
+$this->visit('/dashboard')->assertScreenshotMatches(fullPage: true);
+```
+
+### Responsiveness & Device Emulation
+
+Test on mobile and specific devices:
+
+```php
+$this->visit('/')->on()->mobile()->screenshot(filename: 'homepage-mobile');
+$this->visit('/')->on()->iPhone14Pro()->screenshot(filename: 'homepage-iphone14pro');
+$this->visit('/')->on()->macbook14()->screenshot(filename: 'homepage-macbook14');
+```
+
+Custom viewport:
+
+```php
+$this->visit('/')->resize(375, 812)->screenshot(filename: 'homepage-375x812');
+```
+
+Dark mode:
+
+```php
+$this->visit('/')->inDarkMode()->screenshot(filename: 'homepage-dark');
+```
+
+### Interactions
+
+Click, type, and submit forms:
+
+```php
+$this->visit('/')->click('Login')->assertPathIs('/login');
+
+$this->visit('/login')
+    ->type('email', 'user@example.com')
+    ->type('password', 'secret')
+    ->press('Sign in')
+    ->assertPathIs('/dashboard');
+```
+
+Slow typing for fields with debounce or live validation:
+
+```php
+$this->visit('/search')->typeSlowly('query', 'pest php')->assertSee('Results');
+```
+
+Dropdowns, checkboxes, and radio buttons:
+
+```php
+$this->visit('/settings')
+    ->select('timezone', 'America/New_York')
+    ->check('notifications')
+    ->uncheck('marketing')
+    ->radio('plan', 'pro')
+    ->press('Save')
+    ->assertSee('Settings saved');
+```
+
+Clear and append to fields:
+
+```php
+$this->visit('/form')->clear('name')->type('name', 'New Name');
+$this->visit('/form')->append('tags', ', new-tag');
+```
+
+File uploads:
+
+```php
+$this->visit('/upload')->attach('avatar', '/path/to/photo.jpg')->press('Upload');
+```
+
+Hover, drag and drop, and keyboard input:
+
+```php
+$this->visit('/')->hover('.dropdown-trigger')->assertSee('Menu Item');
+$this->visit('/board')->drag('#task-1', '#column-done');
+$this->visit('/editor')->keys('.editor', 'Hello World');
+```
+
+Hold modifier keys during interactions:
+
+```php
+$this->visit('/editor')->withKeyDown('Shift', function ($page) {
+    $page->click('#item-1')->click('#item-5');
+});
+```
+
+Interact within iframes:
+
+```php
+$this->visit('/embed')->withinIframe('#payment-frame', function ($iframe) {
+    $iframe->type('card-number', '4242424242424242')->press('Pay');
+});
+```
+
+Press and wait for async operations:
+
+```php
+$this->visit('/form')->pressAndWaitFor('Submit', 2)->assertSee('Submitted');
+```
+
+### Content Assertions
+
+```php
+$this->visit('/')->assertSee('Welcome');
+$this->visit('/')->assertDontSee('Error');
+$this->visit('/')->assertSeeIn('.alert', 'Success');
+$this->visit('/')->assertDontSeeIn('.alert', 'Warning');
+$this->visit('/')->assertCount('.product-card', 5);
+$this->visit('/')->assertSeeLink('Documentation');
+$this->visit('/')->assertDontSeeLink('Admin');
+$this->visit('/')->assertTitle('Home — My App');
+$this->visit('/')->assertTitleContains('Home');
+$this->visit('/')->assertSourceHas('<meta name="description"');
+$this->visit('/')->assertSourceMissing('<div class="debug"');
+```
+
+### Element State Assertions
+
+```php
+$this->visit('/')->assertVisible('.navbar');
+$this->visit('/')->assertMissing('.loading-spinner');
+$this->visit('/')->assertPresent('input[name=email]');
+$this->visit('/')->assertNotPresent('.modal');
+$this->visit('/form')->assertEnabled('submit');
+$this->visit('/form')->assertDisabled('delete');
+$this->visit('/form')->assertButtonEnabled('Save');
+$this->visit('/form')->assertButtonDisabled('Delete');
+```
+
+### Form Assertions
+
+```php
+$this->visit('/settings')->assertValue('name', 'John Doe');
+$this->visit('/settings')->assertValueIsNot('name', '');
+$this->visit('/settings')->assertChecked('notifications');
+$this->visit('/settings')->assertNotChecked('marketing');
+$this->visit('/settings')->assertIndeterminate('select-all');
+$this->visit('/form')->assertRadioSelected('plan', 'pro');
+$this->visit('/form')->assertRadioNotSelected('plan', 'free');
+$this->visit('/form')->assertSelected('country', 'US');
+$this->visit('/form')->assertNotSelected('country', 'UK');
+```
+
+### URL Assertions
+
+```php
+$this->visit('/dashboard')->assertUrlIs('http://localhost/dashboard');
+$this->visit('/dashboard')->assertPathIs('/dashboard');
+$this->visit('/dashboard')->assertPathIsNot('/login');
+$this->visit('/docs/install')->assertPathBeginsWith('/docs');
+$this->visit('/docs/install')->assertPathEndsWith('/install');
+$this->visit('/docs/install')->assertPathContains('docs');
+$this->visit('/dashboard')->assertSchemeIs('http');
+$this->visit('/dashboard')->assertHostIs('localhost');
+$this->visit('/search?q=pest')->assertQueryStringHas('q');
+$this->visit('/search')->assertQueryStringMissing('q');
+$this->visit('/page#section')->assertFragmentIs('section');
+$this->visit('/page#section-one')->assertFragmentBeginsWith('section');
+```
+
+### Attribute Assertions
+
+```php
+$this->visit('/')->assertAttribute('.logo', 'alt', 'My App');
+$this->visit('/')->assertAttributeMissing('.input', 'disabled');
+$this->visit('/')->assertAttributeContains('.btn', 'class', 'primary');
+$this->visit('/')->assertAttributeDoesntContain('.btn', 'class', 'hidden');
+$this->visit('/')->assertDataAttribute('.card', 'id', '42');
+$this->visit('/')->assertAriaAttribute('.menu', 'expanded', 'true');
+```
+
+### Quality & Accessibility
+
+```php
+$this->visit('/')->assertNoJavaScriptErrors();
+$this->visit('/')->assertNoConsoleLogs();
+$this->visit('/')->assertNoSmoke();
+$this->visit('/')->assertNoAccessibilityIssues();
+$this->visit('/')->assertScript('document.title', 'My App');
+```
+
+### Data Retrieval
+
+```php
+$text = $this->visit('/')->text('.heading');
+$href = $this->visit('/')->attribute('.link', 'href');
+$value = $this->visit('/form')->value('email');
+$html = $this->visit('/')->content();
+$url = $this->visit('/redirect')->url();
+$count = $this->visit('/')->script('document.querySelectorAll(".item").length');
+```
+
+### Waiting
+
+```php
+$this->visit('/')->wait(2); // Wait 2 seconds
+$this->visit('/form')->pressAndWaitFor('Submit', 2); // Press and wait
+```
+
+Configure default timeout in `Pest.php`:
+
+```php
+pest()->browser()->timeout(10000); // 10 seconds
+```
+
+### Multiple Pages
+
+Test multiple pages simultaneously:
+
+```php
+[$home, $about] = visit(['/', '/about']);
+$home->assertSee('Welcome');
+$about->assertSee('About Us');
+```
+
+### Configuration
+
+Set browser in `Pest.php`:
+
+```php
+pest()->browser()->inFirefox();
+pest()->browser()->inWebkit();
+```
+
+Override via CLI: `./vendor/bin/pest --browser firefox`.
+
+Configure locale, timezone, and user agent:
+
+```php
+$this->visit('/')->withLocale('fr-FR')->assertSee('Bienvenue');
+$this->visit('/')->withTimezone('America/New_York');
+$this->visit('/')->withUserAgent('Googlebot');
+$this->visit('/')->withHost('subdomain.localhost');
+```
+
+Geolocation:
+
+```php
+$this->visit('/nearby')->geolocation(40.7128, -74.0060)->assertSee('New York');
+```
+
+### Debugging
+
+- `debug()` — pauses execution and opens the browser, focusing on the current test.
+- `tinker()` — opens an interactive PHP session within the page context.
+- `headed()` — runs the test with a visible browser window.
+- `waitForKey()` — opens the browser and waits for a key press before continuing.
+- `--debug` CLI flag — opens the browser and pauses on test failure.
+- `--headed` CLI flag — runs all tests with visible browser windows.
+
+### Combining Browser and Backend Assertions
+
+- **Important:** Always assert a frontend change first (e.g. `assertSee`, `assertPathIs`) to confirm the action completed before checking backend side effects.
+
+```php
+Mail::fake();
+$this->visit('/contact')
+    ->type('email', 'test@example.com')
+    ->type('message', 'Hello')
+    ->press('Send')
+    ->assertSee('Message sent');
+Mail::assertSent(ContactForm::class);
+```
+
+```php
+Notification::fake();
+$this->visit('/register')
+    ->type('name', 'John')
+    ->type('email', 'john@example.com')
+    ->type('password', 'password')
+    ->press('Register')
+    ->assertPathIs('/dashboard');
+Notification::assertSentTo(User::first(), WelcomeNotification::class);
+```
+
+```php
+$this->visit('/checkout')
+    ->type('card', '4242424242424242')
+    ->press('Pay')
+    ->assertSee('Transaction processed');
+expect(Order::count())->toBe(1);
+```
+
+### Running in Parallel
+
+Run browser tests in parallel for faster execution:
+
+```
+./vendor/bin/pest --parallel
+```

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -7,16 +7,16 @@
 ### Navigation & Screenshots
 
 ```php
-$this->visit('/')->screenshot(filename: 'homepage');
-$this->visit('/dashboard')->screenshot(filename: 'dashboard', fullPage: true);
-$this->visit('/')->screenshotElement('.hero', filename: 'hero-section');
+visit('/')->screenshot(filename: 'homepage');
+visit('/dashboard')->screenshot(filename: 'dashboard', fullPage: true);
+visit('/')->screenshotElement('.hero', filename: 'hero-section');
 ```
 
 Visual regression testing to catch unintended UI changes:
 
 ```php
-$this->visit('/')->assertScreenshotMatches();
-$this->visit('/dashboard')->assertScreenshotMatches(fullPage: true);
+visit('/')->assertScreenshotMatches();
+visit('/dashboard')->assertScreenshotMatches(fullPage: true);
 ```
 
 ### Responsiveness & Device Emulation
@@ -24,21 +24,21 @@ $this->visit('/dashboard')->assertScreenshotMatches(fullPage: true);
 Test on mobile and specific devices:
 
 ```php
-$this->visit('/')->on()->mobile()->screenshot(filename: 'homepage-mobile');
-$this->visit('/')->on()->iPhone14Pro()->screenshot(filename: 'homepage-iphone14pro');
-$this->visit('/')->on()->macbook14()->screenshot(filename: 'homepage-macbook14');
+visit('/')->on()->mobile()->screenshot(filename: 'homepage-mobile');
+visit('/')->on()->iPhone14Pro()->screenshot(filename: 'homepage-iphone14pro');
+visit('/')->on()->macbook14()->screenshot(filename: 'homepage-macbook14');
 ```
 
 Custom viewport:
 
 ```php
-$this->visit('/')->resize(375, 812)->screenshot(filename: 'homepage-375x812');
+visit('/')->resize(375, 812)->screenshot(filename: 'homepage-375x812');
 ```
 
 Dark mode:
 
 ```php
-$this->visit('/')->inDarkMode()->screenshot(filename: 'homepage-dark');
+visit('/')->inDarkMode()->screenshot(filename: 'homepage-dark');
 ```
 
 ### Interactions
@@ -46,9 +46,9 @@ $this->visit('/')->inDarkMode()->screenshot(filename: 'homepage-dark');
 Click, type, and submit forms:
 
 ```php
-$this->visit('/')->click('Login')->assertPathIs('/login');
+visit('/')->click('Login')->assertPathIs('/login');
 
-$this->visit('/login')
+visit('/login')
     ->type('email', 'user@example.com')
     ->type('password', 'secret')
     ->press('Sign in')
@@ -58,13 +58,13 @@ $this->visit('/login')
 Slow typing for fields with debounce or live validation:
 
 ```php
-$this->visit('/search')->typeSlowly('query', 'pest php')->assertSee('Results');
+visit('/search')->typeSlowly('query', 'pest php')->assertSee('Results');
 ```
 
 Dropdowns, checkboxes, and radio buttons:
 
 ```php
-$this->visit('/settings')
+visit('/settings')
     ->select('timezone', 'America/New_York')
     ->check('notifications')
     ->uncheck('marketing')
@@ -76,28 +76,28 @@ $this->visit('/settings')
 Clear and append to fields:
 
 ```php
-$this->visit('/form')->clear('name')->type('name', 'New Name');
-$this->visit('/form')->append('tags', ', new-tag');
+visit('/form')->clear('name')->type('name', 'New Name');
+visit('/form')->append('tags', ', new-tag');
 ```
 
 File uploads:
 
 ```php
-$this->visit('/upload')->attach('avatar', '/path/to/photo.jpg')->press('Upload');
+visit('/upload')->attach('avatar', '/path/to/photo.jpg')->press('Upload');
 ```
 
 Hover, drag and drop, and keyboard input:
 
 ```php
-$this->visit('/')->hover('.dropdown-trigger')->assertSee('Menu Item');
-$this->visit('/board')->drag('#task-1', '#column-done');
-$this->visit('/editor')->keys('.editor', 'Hello World');
+visit('/')->hover('.dropdown-trigger')->assertSee('Menu Item');
+visit('/board')->drag('#task-1', '#column-done');
+visit('/editor')->keys('.editor', 'Hello World');
 ```
 
 Hold modifier keys during interactions:
 
 ```php
-$this->visit('/editor')->withKeyDown('Shift', function ($page) {
+visit('/editor')->withKeyDown('Shift', function ($page) {
     $page->click('#item-1')->click('#item-5');
 });
 ```
@@ -105,7 +105,7 @@ $this->visit('/editor')->withKeyDown('Shift', function ($page) {
 Interact within iframes:
 
 ```php
-$this->visit('/embed')->withinIframe('#payment-frame', function ($iframe) {
+visit('/embed')->withinIframe('#payment-frame', function ($iframe) {
     $iframe->type('card-number', '4242424242424242')->press('Pay');
 });
 ```
@@ -113,106 +113,106 @@ $this->visit('/embed')->withinIframe('#payment-frame', function ($iframe) {
 Press and wait for async operations:
 
 ```php
-$this->visit('/form')->pressAndWaitFor('Submit', 2)->assertSee('Submitted');
+visit('/form')->pressAndWaitFor('Submit', 2)->assertSee('Submitted');
 ```
 
 ### Content Assertions
 
 ```php
-$this->visit('/')->assertSee('Welcome');
-$this->visit('/')->assertDontSee('Error');
-$this->visit('/')->assertSeeIn('.alert', 'Success');
-$this->visit('/')->assertDontSeeIn('.alert', 'Warning');
-$this->visit('/')->assertCount('.product-card', 5);
-$this->visit('/')->assertSeeLink('Documentation');
-$this->visit('/')->assertDontSeeLink('Admin');
-$this->visit('/')->assertTitle('Home — My App');
-$this->visit('/')->assertTitleContains('Home');
-$this->visit('/')->assertSourceHas('<meta name="description"');
-$this->visit('/')->assertSourceMissing('<div class="debug"');
+visit('/')->assertSee('Welcome');
+visit('/')->assertDontSee('Error');
+visit('/')->assertSeeIn('.alert', 'Success');
+visit('/')->assertDontSeeIn('.alert', 'Warning');
+visit('/')->assertCount('.product-card', 5);
+visit('/')->assertSeeLink('Documentation');
+visit('/')->assertDontSeeLink('Admin');
+visit('/')->assertTitle('Home — My App');
+visit('/')->assertTitleContains('Home');
+visit('/')->assertSourceHas('<meta name="description"');
+visit('/')->assertSourceMissing('<div class="debug"');
 ```
 
 ### Element State Assertions
 
 ```php
-$this->visit('/')->assertVisible('.navbar');
-$this->visit('/')->assertMissing('.loading-spinner');
-$this->visit('/')->assertPresent('input[name=email]');
-$this->visit('/')->assertNotPresent('.modal');
-$this->visit('/form')->assertEnabled('submit');
-$this->visit('/form')->assertDisabled('delete');
-$this->visit('/form')->assertButtonEnabled('Save');
-$this->visit('/form')->assertButtonDisabled('Delete');
+visit('/')->assertVisible('.navbar');
+visit('/')->assertMissing('.loading-spinner');
+visit('/')->assertPresent('input[name=email]');
+visit('/')->assertNotPresent('.modal');
+visit('/form')->assertEnabled('submit');
+visit('/form')->assertDisabled('delete');
+visit('/form')->assertButtonEnabled('Save');
+visit('/form')->assertButtonDisabled('Delete');
 ```
 
 ### Form Assertions
 
 ```php
-$this->visit('/settings')->assertValue('name', 'John Doe');
-$this->visit('/settings')->assertValueIsNot('name', '');
-$this->visit('/settings')->assertChecked('notifications');
-$this->visit('/settings')->assertNotChecked('marketing');
-$this->visit('/settings')->assertIndeterminate('select-all');
-$this->visit('/form')->assertRadioSelected('plan', 'pro');
-$this->visit('/form')->assertRadioNotSelected('plan', 'free');
-$this->visit('/form')->assertSelected('country', 'US');
-$this->visit('/form')->assertNotSelected('country', 'UK');
+visit('/settings')->assertValue('name', 'John Doe');
+visit('/settings')->assertValueIsNot('name', '');
+visit('/settings')->assertChecked('notifications');
+visit('/settings')->assertNotChecked('marketing');
+visit('/settings')->assertIndeterminate('select-all');
+visit('/form')->assertRadioSelected('plan', 'pro');
+visit('/form')->assertRadioNotSelected('plan', 'free');
+visit('/form')->assertSelected('country', 'US');
+visit('/form')->assertNotSelected('country', 'UK');
 ```
 
 ### URL Assertions
 
 ```php
-$this->visit('/dashboard')->assertUrlIs('http://localhost/dashboard');
-$this->visit('/dashboard')->assertPathIs('/dashboard');
-$this->visit('/dashboard')->assertPathIsNot('/login');
-$this->visit('/docs/install')->assertPathBeginsWith('/docs');
-$this->visit('/docs/install')->assertPathEndsWith('/install');
-$this->visit('/docs/install')->assertPathContains('docs');
-$this->visit('/dashboard')->assertSchemeIs('http');
-$this->visit('/dashboard')->assertHostIs('localhost');
-$this->visit('/search?q=pest')->assertQueryStringHas('q');
-$this->visit('/search')->assertQueryStringMissing('q');
-$this->visit('/page#section')->assertFragmentIs('section');
-$this->visit('/page#section-one')->assertFragmentBeginsWith('section');
+visit('/dashboard')->assertUrlIs('http://localhost/dashboard');
+visit('/dashboard')->assertPathIs('/dashboard');
+visit('/dashboard')->assertPathIsNot('/login');
+visit('/docs/install')->assertPathBeginsWith('/docs');
+visit('/docs/install')->assertPathEndsWith('/install');
+visit('/docs/install')->assertPathContains('docs');
+visit('/dashboard')->assertSchemeIs('http');
+visit('/dashboard')->assertHostIs('localhost');
+visit('/search?q=pest')->assertQueryStringHas('q');
+visit('/search')->assertQueryStringMissing('q');
+visit('/page#section')->assertFragmentIs('section');
+visit('/page#section-one')->assertFragmentBeginsWith('section');
 ```
 
 ### Attribute Assertions
 
 ```php
-$this->visit('/')->assertAttribute('.logo', 'alt', 'My App');
-$this->visit('/')->assertAttributeMissing('.input', 'disabled');
-$this->visit('/')->assertAttributeContains('.btn', 'class', 'primary');
-$this->visit('/')->assertAttributeDoesntContain('.btn', 'class', 'hidden');
-$this->visit('/')->assertDataAttribute('.card', 'id', '42');
-$this->visit('/')->assertAriaAttribute('.menu', 'expanded', 'true');
+visit('/')->assertAttribute('.logo', 'alt', 'My App');
+visit('/')->assertAttributeMissing('.input', 'disabled');
+visit('/')->assertAttributeContains('.btn', 'class', 'primary');
+visit('/')->assertAttributeDoesntContain('.btn', 'class', 'hidden');
+visit('/')->assertDataAttribute('.card', 'id', '42');
+visit('/')->assertAriaAttribute('.menu', 'expanded', 'true');
 ```
 
 ### Quality & Accessibility
 
 ```php
-$this->visit('/')->assertNoJavaScriptErrors();
-$this->visit('/')->assertNoConsoleLogs();
-$this->visit('/')->assertNoSmoke();
-$this->visit('/')->assertNoAccessibilityIssues();
-$this->visit('/')->assertScript('document.title', 'My App');
+visit('/')->assertNoJavaScriptErrors();
+visit('/')->assertNoConsoleLogs();
+visit('/')->assertNoSmoke();
+visit('/')->assertNoAccessibilityIssues();
+visit('/')->assertScript('document.title', 'My App');
 ```
 
 ### Data Retrieval
 
 ```php
-$text = $this->visit('/')->text('.heading');
-$href = $this->visit('/')->attribute('.link', 'href');
-$value = $this->visit('/form')->value('email');
-$html = $this->visit('/')->content();
-$url = $this->visit('/redirect')->url();
-$count = $this->visit('/')->script('document.querySelectorAll(".item").length');
+$text = visit('/')->text('.heading');
+$href = visit('/')->attribute('.link', 'href');
+$value = visit('/form')->value('email');
+$html = visit('/')->content();
+$url = visit('/redirect')->url();
+$count = visit('/')->script('document.querySelectorAll(".item").length');
 ```
 
 ### Waiting
 
 ```php
-$this->visit('/')->wait(2); // Wait 2 seconds
-$this->visit('/form')->pressAndWaitFor('Submit', 2); // Press and wait
+visit('/')->wait(2); // Wait 2 seconds
+visit('/form')->pressAndWaitFor('Submit', 2); // Press and wait
 ```
 
 Configure default timeout in `Pest.php`:
@@ -245,16 +245,16 @@ Override via CLI: `./vendor/bin/pest --browser firefox`.
 Configure locale, timezone, and user agent:
 
 ```php
-$this->visit('/')->withLocale('fr-FR')->assertSee('Bienvenue');
-$this->visit('/')->withTimezone('America/New_York');
-$this->visit('/')->withUserAgent('Googlebot');
-$this->visit('/')->withHost('subdomain.localhost');
+visit('/')->withLocale('fr-FR')->assertSee('Bienvenue');
+visit('/')->withTimezone('America/New_York');
+visit('/')->withUserAgent('Googlebot');
+visit('/')->withHost('subdomain.localhost');
 ```
 
 Geolocation:
 
 ```php
-$this->visit('/nearby')->geolocation(40.7128, -74.0060)->assertSee('New York');
+visit('/nearby')->geolocation(40.7128, -74.0060)->assertSee('New York');
 ```
 
 ### Debugging
@@ -272,7 +272,7 @@ $this->visit('/nearby')->geolocation(40.7128, -74.0060)->assertSee('New York');
 
 ```php
 Mail::fake();
-$this->visit('/contact')
+visit('/contact')
     ->type('email', 'test@example.com')
     ->type('message', 'Hello')
     ->press('Send')
@@ -282,7 +282,7 @@ Mail::assertSent(ContactForm::class);
 
 ```php
 Notification::fake();
-$this->visit('/register')
+visit('/register')
     ->type('name', 'John')
     ->type('email', 'john@example.com')
     ->type('password', 'password')
@@ -292,7 +292,7 @@ Notification::assertSentTo(User::first(), WelcomeNotification::class);
 ```
 
 ```php
-$this->visit('/checkout')
+visit('/checkout')
     ->type('card', '4242424242424242')
     ->press('Pay')
     ->assertSee('Transaction processed');

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -59,7 +59,7 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
     /**
      * Handles the arguments passed to the plugin.
      *
-     * @param  array<int, string>  $arguments}
+     * @param array<int, string> $arguments }
      */
     public function handleArguments(array $arguments): array
     {
@@ -93,7 +93,7 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
             $arguments = $this->popArgument('--light', $arguments);
         }
 
-        if ($this->hasArgument('--browser', $arguments)) {
+        if ($this->hasArgument('--browser', $arguments) && ! $this->hasArgument('--record', $arguments)) {
             $index = array_search('--browser', $arguments, true);
 
             if ($index === false || ! isset($arguments[$index + 1])) {
@@ -106,8 +106,8 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
 
             if (($browser = BrowserType::tryFrom($browser)) === null) {
                 throw new BrowserNotSupportedException(
-                    'The specified browser type is not supported. Supported types are: '.
-                    implode(', ', array_map(fn (BrowserType $type): string => mb_strtolower($type->name), BrowserType::cases()))
+                    'The specified browser type is not supported. Supported types are: ' .
+                    implode(', ', array_map(fn(BrowserType $type): string => mb_strtolower($type->name), BrowserType::cases()))
                 );
             }
 
@@ -152,7 +152,7 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
      */
     private function in(): string
     {
-        return TestSuite::getInstance()->rootPath.DIRECTORY_SEPARATOR.TestSuite::getInstance()->testPath;
+        return TestSuite::getInstance()->rootPath . DIRECTORY_SEPARATOR . TestSuite::getInstance()->testPath;
     }
 
     /**

--- a/src/Record.php
+++ b/src/Record.php
@@ -14,6 +14,7 @@ use Pest\Plugins\Concerns\HandleArguments;
 use Pest\TestSuite;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
 
 /**
  * @internal
@@ -24,7 +25,7 @@ final class Record implements HandlesArguments
 
     private const string OPTION = '--record';
 
-    private const string DEFAULT_TEST_ID_ATTRIBUTE = 'data-test';
+    private const string DEFAULT_TEST_ID_ATTRIBUTE = 'id';
 
     public function __construct(
         private readonly OutputInterface $output,
@@ -42,14 +43,30 @@ final class Record implements HandlesArguments
 
         $arguments = $this->popArgument(self::OPTION, $arguments);
 
-        $url = $this->popArgumentValue('--url', $arguments) ?? 'http://localhost:8000';
+        $url = $this->popArgumentValue('--url', $arguments) ?? $this->resolveAppUrl();
         $visitPath = $this->popArgumentValue('--visit', $arguments);
         $authName = $this->popArgumentValue('--acting-as', $arguments);
         $viewport = $this->popArgumentValue('--viewport', $arguments);
         $device = $this->popArgumentValue('--device', $arguments);
         $testIdAttribute = $this->popArgumentValue('--test-id-attribute', $arguments) ?? self::DEFAULT_TEST_ID_ATTRIBUTE;
+        $env = $this->popArgumentValue('--env', $arguments) ?? 'local';
 
-        $this->record($url, $visitPath, $authName, $viewport, $device, $testIdAttribute);
+        $server = $this->hasArgument('--server', $arguments);
+        if ($server) {
+            $arguments = $this->popArgument('--server', $arguments);
+        }
+
+        $migrateFresh = $this->hasArgument('--migrate-fresh', $arguments);
+        if ($migrateFresh) {
+            $arguments = $this->popArgument('--migrate-fresh', $arguments);
+        }
+
+        $seed = $this->hasArgument('--seed', $arguments);
+        if ($seed) {
+            $arguments = $this->popArgument('--seed', $arguments);
+        }
+
+        $this->record($url, $visitPath, $authName, $viewport, $device, $testIdAttribute, $server, $env, $migrateFresh, $seed);
 
         exit(0);
     }
@@ -61,6 +78,10 @@ final class Record implements HandlesArguments
         ?string $viewport,
         ?string $device,
         string $testIdAttribute,
+        bool $server = false,
+        string $env = 'local',
+        bool $migrateFresh = false,
+        bool $seed = false,
     ): void
     {
         $codegen = new Codegen;
@@ -72,6 +93,18 @@ final class Record implements HandlesArguments
 
             return;
         }
+
+        if ($migrateFresh) {
+            try {
+                $this->migrateFresh($env, $seed);
+            } catch (RuntimeException $e) {
+                $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
+
+                return;
+            }
+        }
+
+        $serverProcess = $server ? $this->startServer($url, $env) : null;
 
         $loadStorage = ! is_null($authName)
             ? $this->resolveAuthState($codegen, $url, $authName, $viewport, $testIdAttribute)
@@ -101,7 +134,7 @@ final class Record implements HandlesArguments
 
             $title = $this->prompt('Test description');
             $outputPath = $this->resolveOutputPath();
-            $code = (new TestGenerator($testIdAttribute))->generate($events, $title, $url);
+            $code = (new TestGenerator($testIdAttribute))->generate($events, $title, $url, ! is_null($authName));
 
             (new TestWriter)->write($outputPath, $code);
 
@@ -110,7 +143,56 @@ final class Record implements HandlesArguments
             $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
         } finally {
             @unlink($tmpFile);
+            $serverProcess?->stop(3);
         }
+    }
+
+    private function startServer(string $url, string $env): Process
+    {
+        $port = (int) (parse_url($url, PHP_URL_PORT) ?? 8000);
+
+        $process = new Process(['php', 'artisan', 'serve', '--port=' . $port, '--env=' . $env]);
+        $process->setTimeout(null);
+        $process->start();
+
+        $deadline = time() + 10;
+
+        while (time() < $deadline) {
+            usleep(200_000);
+            $connection = @fsockopen('127.0.0.1', $port, $errno, $errstr, 1);
+
+            if ($connection !== false) {
+                fclose($connection);
+                $this->writeLine('<fg=green>✔</> Dev server started at ' . $url);
+
+                return $process;
+            }
+        }
+
+        $this->writeLine('<fg=yellow>●</> Server may not be ready yet, proceeding...');
+
+        return $process;
+    }
+
+    private function migrateFresh(string $env, bool $seed): void
+    {
+        $this->writeLine('<fg=yellow>●</> Running migrate:fresh...');
+
+        $command = ['php', 'artisan', 'migrate:fresh', '--env=' . $env, '--force'];
+
+        if ($seed) {
+            $command[] = '--seed';
+        }
+
+        $process = new Process($command);
+        $process->setTimeout(null);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new RuntimeException('migrate:fresh failed: ' . trim($process->getErrorOutput()));
+        }
+
+        $this->writeLine('<fg=green>✔</> Database ready.');
     }
 
     private function resolveAuthState(
@@ -168,6 +250,36 @@ final class Record implements HandlesArguments
         $name = ucfirst(str_replace(['.php', 'Test.php'], '', $this->prompt('Test file name')));
 
         return $testsDir . DIRECTORY_SEPARATOR . $name . 'Test.php';
+    }
+
+    private function resolveAppUrl(): string
+    {
+        return $_ENV['APP_URL']
+            ?? $_SERVER['APP_URL']
+            ?? (getenv('APP_URL') ?: null)
+            ?? $this->readDotEnvValue('APP_URL')
+            ?? 'http://localhost:8000';
+    }
+
+    private function readDotEnvValue(string $key): ?string
+    {
+        $envFile = $this->testSuite->rootPath.DIRECTORY_SEPARATOR.'.env';
+
+        if (! file_exists($envFile)) {
+            return null;
+        }
+
+        foreach (file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            if (str_starts_with(ltrim($line), '#')) {
+                continue;
+            }
+
+            if (str_starts_with($line, $key.'=')) {
+                return trim(substr($line, strlen($key) + 1), '"\'');
+            }
+        }
+
+        return null;
     }
 
     private function prompt(string $question): string

--- a/src/Record.php
+++ b/src/Record.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser;
+
+use Pest\Browser\Recorder\Codegen;
+use Pest\Browser\Recorder\EventParser;
+use Pest\Browser\Recorder\EventSanitizer;
+use Pest\Browser\Recorder\TestGenerator;
+use Pest\Browser\Recorder\TestWriter;
+use Pest\Contracts\Plugins\HandlesArguments;
+use Pest\Plugins\Concerns\HandleArguments;
+use Pest\TestSuite;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class Record implements HandlesArguments
+{
+    use HandleArguments;
+
+    private const string OPTION = '--record';
+
+    private const string DEFAULT_TEST_ID_ATTRIBUTE = 'data-test';
+
+    public function __construct(
+        private readonly OutputInterface $output,
+        private readonly TestSuite $testSuite,
+    ) {}
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handleArguments(array $arguments): array
+    {
+        if (! $this->hasArgument(self::OPTION, $arguments)) {
+            return $arguments;
+        }
+
+        $arguments = $this->popArgument(self::OPTION, $arguments);
+
+        $url = $this->popArgumentValue('--url', $arguments) ?? 'http://localhost:8000';
+        $visitPath = $this->popArgumentValue('--visit', $arguments);
+        $authName = $this->popArgumentValue('--acting-as', $arguments);
+        $viewport = $this->popArgumentValue('--viewport', $arguments);
+        $device = $this->popArgumentValue('--device', $arguments);
+        $testIdAttribute = $this->popArgumentValue('--test-id-attribute', $arguments) ?? self::DEFAULT_TEST_ID_ATTRIBUTE;
+
+        $this->record($url, $visitPath, $authName, $viewport, $device, $testIdAttribute);
+
+        exit(0);
+    }
+
+    private function record(
+        string $url,
+        ?string $visitPath,
+        ?string $authName,
+        ?string $viewport,
+        ?string $device,
+        string $testIdAttribute,
+    ): void
+    {
+        $codegen = new Codegen;
+
+        try {
+            $codegen->checkDependencies();
+        } catch (RuntimeException $e) {
+            $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
+
+            return;
+        }
+
+        $loadStorage = ! is_null($authName)
+            ? $this->resolveAuthState($codegen, $url, $authName, $viewport, $testIdAttribute)
+            : null;
+
+        $tmpFile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pest-recording-' . getmypid() . '.jsonl';
+
+        try {
+            $this->writeLine('<fg=yellow>●</> Recorder running — close the browser to finish...');
+
+            $jsonl = $codegen->record($url, $tmpFile, $testIdAttribute, $viewport, $visitPath, $loadStorage, $device);
+
+            if ($jsonl === '') {
+                $this->writeLine('<fg=red>✗</> No recording captured.');
+
+                return;
+            }
+
+            $events = (new EventParser)->parse($jsonl);
+            $events = (new EventSanitizer($testIdAttribute))->sanitize($events);
+
+            if ($events === []) {
+                $this->writeLine('<fg=red>✗</> No mappable actions recorded.');
+
+                return;
+            }
+
+            $title = $this->prompt('Test description');
+            $outputPath = $this->resolveOutputPath();
+            $code = (new TestGenerator($testIdAttribute))->generate($events, $title, $url);
+
+            (new TestWriter)->write($outputPath, $code);
+
+            $this->writeLine(sprintf('<fg=green>✔</> Test written: %s', $outputPath));
+        } catch (RuntimeException $e) {
+            $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
+        } finally {
+            @unlink($tmpFile);
+        }
+    }
+
+    private function resolveAuthState(
+        Codegen $codegen,
+        string $url,
+        string $name,
+        ?string $viewport,
+        string $testIdAttribute,
+    ): ?string
+    {
+        $storageFile = sys_get_temp_dir()
+            . DIRECTORY_SEPARATOR
+            . 'pest-auth-' . preg_replace('/[^a-z0-9_-]/i', '-', $name) . '.json';
+
+        if (! file_exists($storageFile)) {
+            $this->writeLine(sprintf(
+                "<fg=yellow>●</> No auth state found for '%s'. Record a login sequence to save it.",
+                $name,
+            ));
+
+            try {
+                $codegen->captureAuthState($url, $storageFile, '/login', $testIdAttribute, $viewport);
+            } catch (RuntimeException $e) {
+                $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
+
+                return null;
+            }
+        }
+
+        return file_exists($storageFile) ? $storageFile : null;
+    }
+
+    private function resolveOutputPath(): string
+    {
+        $testsDir = $this->testSuite->rootPath . DIRECTORY_SEPARATOR . $this->testSuite->testPath . DIRECTORY_SEPARATOR . 'Browser';
+        $writer = new TestWriter;
+        $existing = $writer->findExistingTestFiles($testsDir);
+
+        if ($existing !== []) {
+            $choices = array_merge(
+                ['New file...'],
+                array_map(
+                    fn(string $path): string => ltrim(str_replace($testsDir, '', $path), DIRECTORY_SEPARATOR),
+                    $existing,
+                ),
+            );
+
+            $choice = $this->choose('Output file', $choices);
+
+            if ($choice !== 'New file...') {
+                return $testsDir . DIRECTORY_SEPARATOR . $choice;
+            }
+        }
+
+        $name = ucfirst(str_replace(['.php', 'Test.php'], '', $this->prompt('Test file name')));
+
+        return $testsDir . DIRECTORY_SEPARATOR . $name . 'Test.php';
+    }
+
+    private function prompt(string $question): string
+    {
+        $this->output->write("  <fg=blue>?</> {$question}: ");
+
+        $answer = fgets(STDIN);
+
+        return ($answer !== false && trim($answer) !== '') ? trim($answer) : 'Untitled';
+    }
+
+    private function choose(string $question, array $choices): string
+    {
+        $this->output->writeln("  <fg=blue>?</> {$question}:");
+
+        foreach ($choices as $index => $choice) {
+            $this->output->writeln("    [{$index}] {$choice}");
+        }
+
+        $this->output->write('  Choice: ');
+
+        $input = fgets(STDIN);
+        $index = ($input !== false && is_numeric(trim($input))) ? (int) trim($input) : 0;
+
+        return $choices[$index] ?? $choices[0];
+    }
+
+    private function writeLine(string $message): void
+    {
+        $this->output->writeln("  {$message}");
+    }
+}

--- a/src/Record.php
+++ b/src/Record.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser;
 
+use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Recorder\Codegen;
 use Pest\Browser\Recorder\EventParser;
 use Pest\Browser\Recorder\EventSanitizer;
@@ -51,6 +52,26 @@ final class Record implements HandlesArguments
         $arguments = $this->hasArgument('--user', $arguments) ? $this->popArgument('--user', $arguments) : $arguments;
         $viewport = $this->popArgumentValue('--viewport', $arguments);
         $device = $this->popArgumentValue('--device', $arguments);
+        $browserValue = $this->popArgumentValue('--browser', $arguments);
+        $browser = null;
+
+        if (! is_null($browserValue)) {
+            $browserType = BrowserType::tryFrom($browserValue);
+
+            if (is_null($browserType)) {
+                $this->writeLine(sprintf('<fg=red>✗</> Unknown browser "%s". Valid values: chrome, firefox, safari.', $browserValue));
+
+                return $arguments;
+            }
+
+            $browser = $browserType->toPlaywrightName();
+        }
+
+        $channel = $this->popArgumentValue('--channel', $arguments);
+        $lang = $this->popArgumentValue('--lang', $arguments);
+        $timezone = $this->popArgumentValue('--timezone', $arguments);
+        $colorScheme = $this->popArgumentValue('--color-scheme', $arguments);
+
         $testIdAttribute = $this->popArgumentValue('--test-id-attribute', $arguments) ?? self::DEFAULT_TEST_ID_ATTRIBUTE;
         $env = $this->popArgumentValue('--env', $arguments) ?? 'testing';
 
@@ -66,7 +87,7 @@ final class Record implements HandlesArguments
             $arguments = $this->popArgument('--seed', $arguments);
         }
 
-        $this->record($url, $visitPath, $auth, $authScript, $viewport, $device, $testIdAttribute, $env, $migrateFresh, $seed);
+        $this->record($url, $visitPath, $auth, $authScript, $viewport, $device, $browser, $channel, $lang, $timezone, $colorScheme, $testIdAttribute, $env, $migrateFresh, $seed);
 
         exit(0);
     }
@@ -78,6 +99,11 @@ final class Record implements HandlesArguments
         ?string $authScript,
         ?string $viewport,
         ?string $device,
+        ?string $browser,
+        ?string $channel,
+        ?string $lang,
+        ?string $timezone,
+        ?string $colorScheme,
         string $testIdAttribute,
         string $env = 'testing',
         bool $migrateFresh = false,
@@ -140,7 +166,7 @@ final class Record implements HandlesArguments
         try {
             $this->writeLine('<fg=yellow>●</> Recorder running — close the browser to finish...');
 
-            $jsonl = $codegen->record($url, $tmpFile, $testIdAttribute, $viewport, $visitPath, $loadStorage, $device);
+            $jsonl = $codegen->record($url, $tmpFile, $testIdAttribute, $viewport, $visitPath, $loadStorage, $device, $browser, $channel, $lang, $timezone, $colorScheme);
 
             if ($jsonl === '') {
                 $this->writeLine('<fg=red>✗</> No recording captured.');
@@ -217,9 +243,9 @@ final class Record implements HandlesArguments
         }
 
         return match (PHP_OS_FAMILY) {
-            'Linux' => preg_match('/(\d+)x(\d+)/', trim($output), $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
+            'Linux' => preg_match('/(\d+)x(\d+)/', mb_trim($output), $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
             'Darwin' => preg_match('/(\d+) x (\d+)/', $output, $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
-            'Windows' => preg_match('/(\d+)\s+(\d+)/', trim($output), $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
+            'Windows' => preg_match('/(\d+)\s+(\d+)/', mb_trim($output), $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
             default => '1920,1000',
         };
     }
@@ -239,7 +265,7 @@ final class Record implements HandlesArguments
         $process->run();
 
         if (! $process->isSuccessful()) {
-            throw new RuntimeException('migrate:fresh failed: ' . trim($process->getErrorOutput()));
+            throw new RuntimeException('migrate:fresh failed: ' . mb_trim($process->getErrorOutput()));
         }
 
         $this->writeLine('<fg=green>✔</> Database ready.');
@@ -281,10 +307,10 @@ final class Record implements HandlesArguments
         $process->run();
 
         if (! $process->isSuccessful()) {
-            throw new RuntimeException('Auth generation failed: ' . trim($process->getErrorOutput()));
+            throw new RuntimeException('Auth generation failed: ' . mb_trim($process->getErrorOutput()));
         }
 
-        $userModelClass = trim($process->getOutput());
+        $userModelClass = mb_trim($process->getOutput());
 
         return $userModelClass !== '' ? $userModelClass : null;
     }
@@ -313,7 +339,7 @@ final class Record implements HandlesArguments
             $choices = array_merge(
                 ['New file...'],
                 array_map(
-                    fn(string $path): string => ltrim(str_replace($testsDir, '', $path), DIRECTORY_SEPARATOR),
+                    fn(string $path): string => mb_ltrim(str_replace($testsDir, '', $path), DIRECTORY_SEPARATOR),
                     $existing,
                 ),
             );
@@ -336,7 +362,7 @@ final class Record implements HandlesArguments
 
         $answer = fgets(STDIN);
 
-        return ($answer !== false && trim($answer) !== '') ? trim($answer) : 'Untitled';
+        return ($answer !== false && mb_trim($answer) !== '') ? mb_trim($answer) : 'Untitled';
     }
 
     private function choose(string $question, array $choices): string
@@ -350,7 +376,7 @@ final class Record implements HandlesArguments
         $this->output->write('  Choice: ');
 
         $input = fgets(STDIN);
-        $index = ($input !== false && is_numeric(trim($input))) ? (int) trim($input) : 0;
+        $index = ($input !== false && is_numeric(mb_trim($input))) ? (int) mb_trim($input) : 0;
 
         return $choices[$index] ?? $choices[0];
     }

--- a/src/Record.php
+++ b/src/Record.php
@@ -9,6 +9,7 @@ use Pest\Browser\Recorder\EventParser;
 use Pest\Browser\Recorder\EventSanitizer;
 use Pest\Browser\Recorder\TestGenerator;
 use Pest\Browser\Recorder\TestWriter;
+use Pest\Browser\Support\Port;
 use Pest\Contracts\Plugins\HandlesArguments;
 use Pest\Plugins\Concerns\HandleArguments;
 use Pest\TestSuite;
@@ -43,43 +44,30 @@ final class Record implements HandlesArguments
 
         $arguments = $this->popArgument(self::OPTION, $arguments);
 
-        $url = $this->popArgumentValue('--url', $arguments) ?? $this->resolveAppUrl();
+        $url = $this->popArgumentValue('--url', $arguments);
         $visitPath = $this->popArgumentValue('--visit', $arguments);
         $authName = $this->popArgumentValue('--acting-as', $arguments);
         $viewport = $this->popArgumentValue('--viewport', $arguments);
         $device = $this->popArgumentValue('--device', $arguments);
         $testIdAttribute = $this->popArgumentValue('--test-id-attribute', $arguments) ?? self::DEFAULT_TEST_ID_ATTRIBUTE;
-        $env = $this->popArgumentValue('--env', $arguments) ?? 'local';
-
-        $server = $this->hasArgument('--server', $arguments);
-        if ($server) {
-            $arguments = $this->popArgument('--server', $arguments);
-        }
+        $env = $this->popArgumentValue('--env', $arguments) ?? 'testing';
 
         $migrateFresh = $this->hasArgument('--migrate-fresh', $arguments);
-        if ($migrateFresh) {
-            $arguments = $this->popArgument('--migrate-fresh', $arguments);
-        }
-
         $seed = $this->hasArgument('--seed', $arguments);
-        if ($seed) {
-            $arguments = $this->popArgument('--seed', $arguments);
-        }
 
-        $this->record($url, $visitPath, $authName, $viewport, $device, $testIdAttribute, $server, $env, $migrateFresh, $seed);
+        $this->record($url, $visitPath, $authName, $viewport, $device, $testIdAttribute, $env, $migrateFresh, $seed);
 
         exit(0);
     }
 
     private function record(
-        string $url,
+        ?string $url,
         ?string $visitPath,
         ?string $authName,
         ?string $viewport,
         ?string $device,
         string $testIdAttribute,
-        bool $server = false,
-        string $env = 'local',
+        string $env = 'testing',
         bool $migrateFresh = false,
         bool $seed = false,
     ): void
@@ -104,11 +92,29 @@ final class Record implements HandlesArguments
             }
         }
 
-        $serverProcess = $server ? $this->startServer($url, $env) : null;
+        if (is_null($viewport) && is_null($device)) {
+            $viewport = $this->detectScreenResolution();
+        }
 
-        $loadStorage = ! is_null($authName)
-            ? $this->resolveAuthState($codegen, $url, $authName, $viewport, $testIdAttribute)
-            : null;
+        $serverProcess = null;
+
+        if (is_null($url)) {
+            $port = Port::find();
+            $url = sprintf('http://127.0.0.1:%d', $port);
+            $serverProcess = $this->startServer($url, $env);
+        }
+
+        $loadStorage = null;
+
+        if (! is_null($authName)) {
+            $loadStorage = $this->resolveAuthState($url, $authName, $env);
+
+            if (is_null($loadStorage)) {
+                $this->writeLine('<fg=red>✗</> Auth state generation failed.');
+
+                return;
+            }
+        }
 
         $tmpFile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pest-recording-' . getmypid() . '.jsonl';
 
@@ -174,6 +180,27 @@ final class Record implements HandlesArguments
         return $process;
     }
 
+    private function detectScreenResolution(): string
+    {
+        $output = match (PHP_OS_FAMILY) {
+            'Linux' => shell_exec('xrandr --current 2>/dev/null | grep -m1 " connected" | grep -oP "\d+x\d+"'),
+            'Darwin' => shell_exec('system_profiler SPDisplaysDataType 2>/dev/null | grep -m1 "Resolution"'),
+            'Windows' => shell_exec('wmic desktopmonitor get screenwidth,screenheight 2>nul'),
+            default => null,
+        };
+
+        if ($output === null || $output === '') {
+            return '1920,1000';
+        }
+
+        return match (PHP_OS_FAMILY) {
+            'Linux' => preg_match('/(\d+)x(\d+)/', trim($output), $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
+            'Darwin' => preg_match('/(\d+) x (\d+)/', $output, $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
+            'Windows' => preg_match('/(\d+)\s+(\d+)/', trim($output), $m) ? $m[2] . ',' . ((int) $m[1] - 80) : '1920,1000',
+            default => '1920,1000',
+        };
+    }
+
     private function migrateFresh(string $env, bool $seed): void
     {
         $this->writeLine('<fg=yellow>●</> Running migrate:fresh...');
@@ -195,34 +222,94 @@ final class Record implements HandlesArguments
         $this->writeLine('<fg=green>✔</> Database ready.');
     }
 
-    private function resolveAuthState(
-        Codegen $codegen,
-        string $url,
-        string $name,
-        ?string $viewport,
-        string $testIdAttribute,
-    ): ?string
+    private function resolveAuthState(string $url, string $name, string $env): ?string
     {
         $storageFile = sys_get_temp_dir()
             . DIRECTORY_SEPARATOR
             . 'pest-auth-' . preg_replace('/[^a-z0-9_-]/i', '-', $name) . '.json';
 
-        if (! file_exists($storageFile)) {
-            $this->writeLine(sprintf(
-                "<fg=yellow>●</> No auth state found for '%s'. Record a login sequence to save it.",
-                $name,
-            ));
+        $this->writeLine(sprintf("<fg=yellow>●</> Generating auth state for '%s'...", $name));
 
-            try {
-                $codegen->captureAuthState($url, $storageFile, '/login', $testIdAttribute, $viewport);
-            } catch (RuntimeException $e) {
-                $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
+        try {
+            $this->generateAuthState($url, $storageFile, $env);
+        } catch (RuntimeException $e) {
+            $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
 
-                return null;
-            }
+            return null;
         }
 
-        return file_exists($storageFile) ? $storageFile : null;
+        $this->writeLine('<fg=green>✔</> Auth state ready.');
+
+        return $storageFile;
+    }
+
+    private function generateAuthState(string $url, string $storageFile, string $env): void
+    {
+        $rootPath = addslashes($this->testSuite->rootPath);
+        $host = parse_url($url, PHP_URL_HOST) ?? '127.0.0.1';
+        $cookieName = addslashes(preg_replace('/[^a-z0-9_\-]/i', '_', basename($rootPath)) . '_session');
+
+        $script = <<<PHP
+        <?php
+        define('LARAVEL_START', microtime(true));
+        require '{$rootPath}/vendor/autoload.php';
+        \$app = require_once '{$rootPath}/bootstrap/app.php';
+        \$kernel = \$app->make(\Illuminate\Contracts\Console\Kernel::class);
+        \$kernel->bootstrap();
+
+        \$manager = app('session');
+        \$store = \$manager->driver();
+        \$store->setId(\Illuminate\Support\Str::random(40));
+        \$store->start();
+
+        \$user = \App\Models\User::factory()->create();
+        app('auth')->guard()->setUser(\$user);
+        \$store->put(app('auth')->guard()->getName(), \$user->getAuthIdentifier());
+        \$store->put('password_hash_' . app('auth')->getDefaultDriver(), \$user->getAuthPassword());
+        \$store->save();
+
+        \$sessionId = \$store->getId();
+        \$cookieName = config('session.cookie');
+        \$encrypter = app('encrypter');
+        \$prefix = \Illuminate\Cookie\CookieValuePrefix::create(\$cookieName, \$encrypter->getKey());
+        \$encrypted = \$encrypter->encrypt(\$prefix . \$sessionId, false);
+
+        echo json_encode([
+            'cookies' => [[
+                'name'     => \$cookieName,
+                'value'    => \$encrypted,
+                'domain'   => '{$host}',
+                'path'     => '/',
+                'expires'  => -1,
+                'httpOnly' => true,
+                'secure'   => false,
+                'sameSite' => 'Lax',
+            ]],
+            'origins' => [],
+        ]);
+        PHP;
+
+        $tmpScript = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pest-auth-gen-' . getmypid() . '.php';
+        file_put_contents($tmpScript, $script);
+
+        $process = new Process(['php', $tmpScript]);
+        $process->setTimeout(30);
+        $process->setEnv(['APP_ENV' => $env]);
+        $process->run();
+
+        @unlink($tmpScript);
+
+        if (! $process->isSuccessful()) {
+            throw new RuntimeException('Auth generation failed: ' . trim($process->getErrorOutput()));
+        }
+
+        $output = trim($process->getOutput());
+
+        if ($output === '' || json_decode($output) === null) {
+            throw new RuntimeException('Auth generation returned invalid output.');
+        }
+
+        file_put_contents($storageFile, $output);
     }
 
     private function resolveOutputPath(): string
@@ -250,36 +337,6 @@ final class Record implements HandlesArguments
         $name = ucfirst(str_replace(['.php', 'Test.php'], '', $this->prompt('Test file name')));
 
         return $testsDir . DIRECTORY_SEPARATOR . $name . 'Test.php';
-    }
-
-    private function resolveAppUrl(): string
-    {
-        return $_ENV['APP_URL']
-            ?? $_SERVER['APP_URL']
-            ?? (getenv('APP_URL') ?: null)
-            ?? $this->readDotEnvValue('APP_URL')
-            ?? 'http://localhost:8000';
-    }
-
-    private function readDotEnvValue(string $key): ?string
-    {
-        $envFile = $this->testSuite->rootPath.DIRECTORY_SEPARATOR.'.env';
-
-        if (! file_exists($envFile)) {
-            return null;
-        }
-
-        foreach (file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
-            if (str_starts_with(ltrim($line), '#')) {
-                continue;
-            }
-
-            if (str_starts_with($line, $key.'=')) {
-                return trim(substr($line, strlen($key) + 1), '"\'');
-            }
-        }
-
-        return null;
     }
 
     private function prompt(string $question): string

--- a/src/Record.php
+++ b/src/Record.php
@@ -46,16 +46,27 @@ final class Record implements HandlesArguments
 
         $url = $this->popArgumentValue('--url', $arguments);
         $visitPath = $this->popArgumentValue('--visit', $arguments);
-        $authName = $this->popArgumentValue('--acting-as', $arguments);
+        $auth = $this->hasArgument('--auth', $arguments) || $this->hasArgument('--user', $arguments);
+        $arguments = $this->hasArgument('--auth', $arguments) ? $this->popArgument('--auth', $arguments) : $arguments;
+        $arguments = $this->hasArgument('--user', $arguments) ? $this->popArgument('--user', $arguments) : $arguments;
         $viewport = $this->popArgumentValue('--viewport', $arguments);
         $device = $this->popArgumentValue('--device', $arguments);
         $testIdAttribute = $this->popArgumentValue('--test-id-attribute', $arguments) ?? self::DEFAULT_TEST_ID_ATTRIBUTE;
         $env = $this->popArgumentValue('--env', $arguments) ?? 'testing';
 
-        $migrateFresh = $this->hasArgument('--migrate-fresh', $arguments);
-        $seed = $this->hasArgument('--seed', $arguments);
+        $authScript = $this->popArgumentValue('--auth-script', $arguments);
 
-        $this->record($url, $visitPath, $authName, $viewport, $device, $testIdAttribute, $env, $migrateFresh, $seed);
+        $migrateFresh = $this->hasArgument('--migrate-fresh', $arguments);
+        if ($migrateFresh) {
+            $arguments = $this->popArgument('--migrate-fresh', $arguments);
+        }
+
+        $seed = $this->hasArgument('--seed', $arguments);
+        if ($seed) {
+            $arguments = $this->popArgument('--seed', $arguments);
+        }
+
+        $this->record($url, $visitPath, $auth, $authScript, $viewport, $device, $testIdAttribute, $env, $migrateFresh, $seed);
 
         exit(0);
     }
@@ -63,7 +74,8 @@ final class Record implements HandlesArguments
     private function record(
         ?string $url,
         ?string $visitPath,
-        ?string $authName,
+        bool $auth,
+        ?string $authScript,
         ?string $viewport,
         ?string $device,
         string $testIdAttribute,
@@ -80,6 +92,10 @@ final class Record implements HandlesArguments
             $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
 
             return;
+        }
+
+        if ($seed && ! $migrateFresh) {
+            $this->writeLine('<fg=yellow>⚠</> --seed has no effect without --migrate-fresh.');
         }
 
         if ($migrateFresh) {
@@ -105,15 +121,18 @@ final class Record implements HandlesArguments
         }
 
         $loadStorage = null;
+        $userModelClass = null;
 
-        if (! is_null($authName)) {
-            $loadStorage = $this->resolveAuthState($url, $authName, $env);
+        if ($auth) {
+            $auth = $this->resolveAuthState($url, $env, $authScript);
 
-            if (is_null($loadStorage)) {
+            if (is_null($auth)) {
                 $this->writeLine('<fg=red>✗</> Auth state generation failed.');
 
                 return;
             }
+
+            [$loadStorage, $userModelClass] = $auth;
         }
 
         $tmpFile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pest-recording-' . getmypid() . '.jsonl';
@@ -138,17 +157,21 @@ final class Record implements HandlesArguments
                 return;
             }
 
+            $writer = new TestWriter;
             $title = $this->prompt('Test description');
-            $outputPath = $this->resolveOutputPath();
-            $code = (new TestGenerator($testIdAttribute))->generate($events, $title, $url, ! is_null($authName));
+            $outputPath = $this->resolveOutputPath($writer);
+            $code = (new TestGenerator($testIdAttribute))->generate($events, $title, $url, $userModelClass);
 
-            (new TestWriter)->write($outputPath, $code);
+            $writer->write($outputPath, $code, ! is_null($userModelClass));
 
             $this->writeLine(sprintf('<fg=green>✔</> Test written: %s', $outputPath));
         } catch (RuntimeException $e) {
             $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
         } finally {
             @unlink($tmpFile);
+            if (! is_null($loadStorage)) {
+                @unlink($loadStorage);
+            }
             $serverProcess?->stop(3);
         }
     }
@@ -175,9 +198,9 @@ final class Record implements HandlesArguments
             }
         }
 
-        $this->writeLine('<fg=yellow>●</> Server may not be ready yet, proceeding...');
+        $process->stop(3);
 
-        return $process;
+        throw new RuntimeException('Dev server failed to start within 10 seconds.');
     }
 
     private function detectScreenResolution(): string
@@ -196,7 +219,7 @@ final class Record implements HandlesArguments
         return match (PHP_OS_FAMILY) {
             'Linux' => preg_match('/(\d+)x(\d+)/', trim($output), $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
             'Darwin' => preg_match('/(\d+) x (\d+)/', $output, $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
-            'Windows' => preg_match('/(\d+)\s+(\d+)/', trim($output), $m) ? $m[2] . ',' . ((int) $m[1] - 80) : '1920,1000',
+            'Windows' => preg_match('/(\d+)\s+(\d+)/', trim($output), $m) ? $m[1] . ',' . ((int) $m[2] - 80) : '1920,1000',
             default => '1920,1000',
         };
     }
@@ -222,16 +245,19 @@ final class Record implements HandlesArguments
         $this->writeLine('<fg=green>✔</> Database ready.');
     }
 
-    private function resolveAuthState(string $url, string $name, string $env): ?string
+    /**
+     * @return array{string, ?string}|null
+     */
+    private function resolveAuthState(string $url, string $env, ?string $authScript): ?array
     {
         $storageFile = sys_get_temp_dir()
             . DIRECTORY_SEPARATOR
-            . 'pest-auth-' . preg_replace('/[^a-z0-9_-]/i', '-', $name) . '.json';
+            . 'pest-auth-' . getmypid() . '.json';
 
-        $this->writeLine(sprintf("<fg=yellow>●</> Generating auth state for '%s'...", $name));
+        $this->writeLine('<fg=yellow>●</> Generating auth state...');
 
         try {
-            $this->generateAuthState($url, $storageFile, $env);
+            $userModelClass = $this->generateAuthState($url, $storageFile, $env, $authScript);
         } catch (RuntimeException $e) {
             $this->writeLine('<fg=red>✗</> ' . $e->getMessage());
 
@@ -240,82 +266,47 @@ final class Record implements HandlesArguments
 
         $this->writeLine('<fg=green>✔</> Auth state ready.');
 
-        return $storageFile;
+        return [$storageFile, $userModelClass];
     }
 
-    private function generateAuthState(string $url, string $storageFile, string $env): void
+    private function generateAuthState(string $url, string $storageFile, string $env, ?string $authScript): ?string
     {
-        $rootPath = addslashes($this->testSuite->rootPath);
-        $host = parse_url($url, PHP_URL_HOST) ?? '127.0.0.1';
-        $cookieName = addslashes(preg_replace('/[^a-z0-9_\-]/i', '_', basename($rootPath)) . '_session');
+        $host = preg_replace('/[^a-zA-Z0-9._\-\[\]:]/', '', parse_url($url, PHP_URL_HOST) ?? '127.0.0.1');
 
-        $script = <<<PHP
-        <?php
-        define('LARAVEL_START', microtime(true));
-        require '{$rootPath}/vendor/autoload.php';
-        \$app = require_once '{$rootPath}/bootstrap/app.php';
-        \$kernel = \$app->make(\Illuminate\Contracts\Console\Kernel::class);
-        \$kernel->bootstrap();
+        $scriptPath = $this->resolveAuthScriptPath($authScript);
 
-        \$manager = app('session');
-        \$store = \$manager->driver();
-        \$store->setId(\Illuminate\Support\Str::random(40));
-        \$store->start();
-
-        \$user = \App\Models\User::factory()->create();
-        app('auth')->guard()->setUser(\$user);
-        \$store->put(app('auth')->guard()->getName(), \$user->getAuthIdentifier());
-        \$store->put('password_hash_' . app('auth')->getDefaultDriver(), \$user->getAuthPassword());
-        \$store->save();
-
-        \$sessionId = \$store->getId();
-        \$cookieName = config('session.cookie');
-        \$encrypter = app('encrypter');
-        \$prefix = \Illuminate\Cookie\CookieValuePrefix::create(\$cookieName, \$encrypter->getKey());
-        \$encrypted = \$encrypter->encrypt(\$prefix . \$sessionId, false);
-
-        echo json_encode([
-            'cookies' => [[
-                'name'     => \$cookieName,
-                'value'    => \$encrypted,
-                'domain'   => '{$host}',
-                'path'     => '/',
-                'expires'  => -1,
-                'httpOnly' => true,
-                'secure'   => false,
-                'sameSite' => 'Lax',
-            ]],
-            'origins' => [],
-        ]);
-        PHP;
-
-        $tmpScript = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pest-auth-gen-' . getmypid() . '.php';
-        file_put_contents($tmpScript, $script);
-
-        $process = new Process(['php', $tmpScript]);
+        $process = new Process(['php', $scriptPath, $this->testSuite->rootPath, $host, $storageFile]);
         $process->setTimeout(30);
         $process->setEnv(['APP_ENV' => $env]);
         $process->run();
-
-        @unlink($tmpScript);
 
         if (! $process->isSuccessful()) {
             throw new RuntimeException('Auth generation failed: ' . trim($process->getErrorOutput()));
         }
 
-        $output = trim($process->getOutput());
+        $userModelClass = trim($process->getOutput());
 
-        if ($output === '' || json_decode($output) === null) {
-            throw new RuntimeException('Auth generation returned invalid output.');
-        }
-
-        file_put_contents($storageFile, $output);
+        return $userModelClass !== '' ? $userModelClass : null;
     }
 
-    private function resolveOutputPath(): string
+    private function resolveAuthScriptPath(?string $customScript): string
+    {
+        if (! is_null($customScript)) {
+            return $customScript;
+        }
+
+        if (! file_exists($this->testSuite->rootPath . DIRECTORY_SEPARATOR . 'bootstrap' . DIRECTORY_SEPARATOR . 'app.php')) {
+            throw new RuntimeException(
+                '--auth requires a Laravel application. For other frameworks, provide a custom bootstrap script with --auth-script=path/to/auth.php',
+            );
+        }
+
+        return __DIR__ . DIRECTORY_SEPARATOR . 'Recorder' . DIRECTORY_SEPARATOR . 'Laravel' . DIRECTORY_SEPARATOR . 'auth-gen.php';
+    }
+
+    private function resolveOutputPath(TestWriter $writer): string
     {
         $testsDir = $this->testSuite->rootPath . DIRECTORY_SEPARATOR . $this->testSuite->testPath . DIRECTORY_SEPARATOR . 'Browser';
-        $writer = new TestWriter;
         $existing = $writer->findExistingTestFiles($testsDir);
 
         if ($existing !== []) {

--- a/src/Recorder/Codegen.php
+++ b/src/Recorder/Codegen.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Recorder;
+
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+final class Codegen
+{
+    public function checkDependencies(): void
+    {
+        $process = new Process(['npx', 'playwright', '--version']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $stderr = trim($process->getErrorOutput());
+            $hint = $stderr !== '' ? "\n{$stderr}" : '';
+
+            throw new RuntimeException(
+                'Playwright not found. Run: npm install -D @playwright/test' . $hint,
+            );
+        }
+    }
+
+    public function record(
+        string $url,
+        string $outputFile,
+        string $testIdAttribute,
+        ?string $viewport = null,
+        ?string $visitPath = null,
+        ?string $loadStorage = null,
+        ?string $device = null,
+    ): string
+    {
+        $command = $this->buildCommand(
+            url: $url,
+            outputFile: $outputFile,
+            testIdAttribute: $testIdAttribute,
+            viewport: $viewport,
+            visitPath: $visitPath,
+            saveStorage: null,
+            loadStorage: $loadStorage,
+            device: $device,
+        );
+
+        $process = (new Process($command))->setTimeout(null);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $this->throwFromStderr($process->getErrorOutput());
+        }
+
+        if (! file_exists($outputFile)) {
+            return '';
+        }
+
+        $content = file_get_contents($outputFile);
+
+        return is_string($content) ? $content : '';
+    }
+
+    public function captureAuthState(
+        string $url,
+        string $storageFile,
+        string $loginPath,
+        string $testIdAttribute,
+        ?string $viewport = null,
+    ): void
+    {
+        $dir = dirname($storageFile);
+
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $tmpOutput = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pest-auth-capture-' . getmypid() . '.jsonl';
+
+        $command = $this->buildCommand(
+            url: $url,
+            outputFile: $tmpOutput,
+            testIdAttribute: $testIdAttribute,
+            viewport: $viewport,
+            visitPath: $loginPath,
+            saveStorage: $storageFile,
+        );
+
+        (new Process($command))->setTimeout(null)->run();
+
+        @unlink($tmpOutput);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildCommand(
+        string $url,
+        string $outputFile,
+        string $testIdAttribute,
+        ?string $viewport,
+        ?string $visitPath,
+        ?string $saveStorage,
+        ?string $loadStorage = null,
+        ?string $device = null,
+    ): array
+    {
+        $command = [
+            'npx', 'playwright', 'codegen',
+            '--target=jsonl',
+            '--test-id-attribute=' . $testIdAttribute,
+            '--output=' . $outputFile,
+        ];
+
+        if (! is_null($device)) {
+            $command[] = '--device=' . $device;
+        } else if (! is_null($viewport)) {
+            $command[] = '--viewport-size=' . $viewport;
+        }
+
+        if (! is_null($saveStorage)) {
+            $command[] = '--save-storage=' . $saveStorage;
+        }
+
+        if (! is_null($loadStorage)) {
+            $command[] = '--load-storage=' . $loadStorage;
+        }
+
+        $command[] = ! is_null($visitPath)
+            ? rtrim($url, '/') . '/' . ltrim($visitPath, '/')
+            : $url;
+
+        return $command;
+    }
+
+    private function throwFromStderr(string $stderr): never
+    {
+        $stderr = trim($stderr);
+
+        if (str_contains($stderr, "Executable doesn't exist")) {
+            throw new RuntimeException('Playwright browsers not installed. Run: npx playwright install');
+        }
+
+        throw new RuntimeException($stderr !== '' ? $stderr : 'Recording failed unexpectedly.');
+    }
+}

--- a/src/Recorder/Codegen.php
+++ b/src/Recorder/Codegen.php
@@ -32,6 +32,11 @@ final class Codegen
         ?string $visitPath = null,
         ?string $loadStorage = null,
         ?string $device = null,
+        ?string $browser = null,
+        ?string $channel = null,
+        ?string $lang = null,
+        ?string $timezone = null,
+        ?string $colorScheme = null,
     ): string
     {
         $command = $this->buildCommand(
@@ -42,6 +47,11 @@ final class Codegen
             visitPath: $visitPath,
             loadStorage: $loadStorage,
             device: $device,
+            browser: $browser,
+            channel: $channel,
+            lang: $lang,
+            timezone: $timezone,
+            colorScheme: $colorScheme,
         );
 
         $process = (new Process($command))->setTimeout(null);
@@ -71,6 +81,11 @@ final class Codegen
         ?string $visitPath,
         ?string $loadStorage = null,
         ?string $device = null,
+        ?string $browser = null,
+        ?string $channel = null,
+        ?string $lang = null,
+        ?string $timezone = null,
+        ?string $colorScheme = null,
     ): array
     {
         $command = [
@@ -79,6 +94,26 @@ final class Codegen
             '--test-id-attribute=' . $testIdAttribute,
             '--output=' . $outputFile,
         ];
+
+        if (! is_null($browser)) {
+            $command[] = '--browser=' . $browser;
+        }
+
+        if (! is_null($channel)) {
+            $command[] = '--channel=' . $channel;
+        }
+
+        if (! is_null($lang)) {
+            $command[] = '--lang=' . $lang;
+        }
+
+        if (! is_null($timezone)) {
+            $command[] = '--timezone=' . $timezone;
+        }
+
+        if (! is_null($colorScheme)) {
+            $command[] = '--color-scheme=' . $colorScheme;
+        }
 
         $flag = match (true) {
             ! is_null($device) => '--device=' . $device,

--- a/src/Recorder/Codegen.php
+++ b/src/Recorder/Codegen.php
@@ -40,7 +40,6 @@ final class Codegen
             testIdAttribute: $testIdAttribute,
             viewport: $viewport,
             visitPath: $visitPath,
-            saveStorage: null,
             loadStorage: $loadStorage,
             device: $device,
         );
@@ -61,36 +60,6 @@ final class Codegen
         return is_string($content) ? $content : '';
     }
 
-    public function captureAuthState(
-        string $url,
-        string $storageFile,
-        string $loginPath,
-        string $testIdAttribute,
-        ?string $viewport = null,
-    ): void
-    {
-        $dir = dirname($storageFile);
-
-        if (! is_dir($dir)) {
-            mkdir($dir, 0755, true);
-        }
-
-        $tmpOutput = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pest-auth-capture-' . getmypid() . '.jsonl';
-
-        $command = $this->buildCommand(
-            url: $url,
-            outputFile: $tmpOutput,
-            testIdAttribute: $testIdAttribute,
-            viewport: $viewport,
-            visitPath: $loginPath,
-            saveStorage: $storageFile,
-        );
-
-        (new Process($command))->setTimeout(null)->run();
-
-        @unlink($tmpOutput);
-    }
-
     /**
      * @return string[]
      */
@@ -100,7 +69,6 @@ final class Codegen
         string $testIdAttribute,
         ?string $viewport,
         ?string $visitPath,
-        ?string $saveStorage,
         ?string $loadStorage = null,
         ?string $device = null,
     ): array
@@ -112,14 +80,14 @@ final class Codegen
             '--output=' . $outputFile,
         ];
 
-        if (! is_null($device)) {
-            $command[] = '--device=' . $device;
-        } else if (! is_null($viewport)) {
-            $command[] = '--viewport-size=' . $viewport;
-        }
+        $flag = match (true) {
+            ! is_null($device) => '--device=' . $device,
+            ! is_null($viewport) => '--viewport-size=' . $viewport,
+            default => null,
+        };
 
-        if (! is_null($saveStorage)) {
-            $command[] = '--save-storage=' . $saveStorage;
+        if (! is_null($flag)) {
+            $command[] = $flag;
         }
 
         if (! is_null($loadStorage)) {

--- a/src/Recorder/EventParser.php
+++ b/src/Recorder/EventParser.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Recorder;
+
+final class EventParser
+{
+    /**
+     * @return RecordedEvent[]
+     */
+    public function parse(string $jsonlContent): array
+    {
+        $events = [];
+
+        foreach (explode("\n", $jsonlContent) as $line) {
+            $line = trim($line);
+
+            if ($line === '') {
+                continue;
+            }
+
+            $data = json_decode($line, true);
+
+            if (! is_array($data)) {
+                continue;
+            }
+
+            $event = RecordedEvent::fromRaw($data);
+
+            if (! is_null($event)) {
+                $events[] = $event;
+            }
+        }
+
+        return $events;
+    }
+}

--- a/src/Recorder/EventSanitizer.php
+++ b/src/Recorder/EventSanitizer.php
@@ -90,24 +90,31 @@ final class EventSanitizer
      */
     private function deduplicateFills(array $events): array
     {
-        $lastFillIndex = [];
-        $result = [];
+        $lastIndex = [];
 
-        foreach ($events as $event) {
+        foreach ($events as $index => $event) {
             if ($event->type === 'fill') {
                 $selector = $this->resolveSelector($event);
-
-                if (! is_null($selector) && isset($lastFillIndex[$selector])) {
-                    unset($result[$lastFillIndex[$selector]]);
+                if (! is_null($selector)) {
+                    $lastIndex[$selector] = $index;
                 }
+            }
+        }
 
-                $lastFillIndex[$selector ?? ''] = count($result);
+        $result = [];
+
+        foreach ($events as $index => $event) {
+            if ($event->type === 'fill') {
+                $selector = $this->resolveSelector($event);
+                if (! is_null($selector) && $lastIndex[$selector] !== $index) {
+                    continue;
+                }
             }
 
             $result[] = $event;
         }
 
-        return array_values($result);
+        return $result;
     }
 
     private function resolveSelector(RecordedEvent $event): ?string

--- a/src/Recorder/EventSanitizer.php
+++ b/src/Recorder/EventSanitizer.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Recorder;
+
+final class EventSanitizer
+{
+    private const array SUPPORTED_TYPES = [
+        'navigate',
+        'click',
+        'fill',
+        'selectOption',
+        'check',
+        'uncheck',
+        'assertVisible',
+        'assertText',
+    ];
+
+    public function __construct(
+        private readonly string $testIdAttribute,
+    ) {}
+
+    /**
+     * @param RecordedEvent[] $events
+     * @return RecordedEvent[]
+     */
+    public function sanitize(array $events): array
+    {
+        $events = $this->dropUnsupported($events);
+        $events = $this->dropRedundantClicks($events);
+        $events = $this->deduplicateFills($events);
+
+        return array_values($events);
+    }
+
+    /**
+     * @param RecordedEvent[] $events
+     * @return RecordedEvent[]
+     */
+    private function dropUnsupported(array $events): array
+    {
+        return array_values(array_filter($events, function (RecordedEvent $event): bool {
+            if (! in_array($event->type, self::SUPPORTED_TYPES, true)) {
+                return false;
+            }
+
+            if ($event->type === 'navigate') {
+                return is_string($event->url);
+            }
+
+            if (is_null($event->locator)) {
+                return false;
+            }
+
+            return ! is_null(Locator::fromArray($event->locator)->toSelector($this->testIdAttribute));
+        }));
+    }
+
+    /**
+     * @param RecordedEvent[] $events
+     * @return RecordedEvent[]
+     */
+    private function dropRedundantClicks(array $events): array
+    {
+        $result = [];
+
+        foreach ($events as $index => $event) {
+            if ($event->type === 'click') {
+                $next = $events[$index + 1] ?? null;
+
+                if (
+                    ! is_null($next)
+                    && $next->type === 'fill'
+                    && $this->resolveSelector($event) === $this->resolveSelector($next)
+                ) {
+                    continue;
+                }
+            }
+
+            $result[] = $event;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param RecordedEvent[] $events
+     * @return RecordedEvent[]
+     */
+    private function deduplicateFills(array $events): array
+    {
+        $lastFillIndex = [];
+        $result = [];
+
+        foreach ($events as $event) {
+            if ($event->type === 'fill') {
+                $selector = $this->resolveSelector($event);
+
+                if (! is_null($selector) && isset($lastFillIndex[$selector])) {
+                    unset($result[$lastFillIndex[$selector]]);
+                }
+
+                $lastFillIndex[$selector ?? ''] = count($result);
+            }
+
+            $result[] = $event;
+        }
+
+        return array_values($result);
+    }
+
+    private function resolveSelector(RecordedEvent $event): ?string
+    {
+        if (is_null($event->locator)) {
+            return null;
+        }
+
+        return Locator::fromArray($event->locator)->toSelector($this->testIdAttribute);
+    }
+}

--- a/src/Recorder/EventSanitizer.php
+++ b/src/Recorder/EventSanitizer.php
@@ -49,6 +49,10 @@ final class EventSanitizer
                 return is_string($event->url);
             }
 
+            if ($event->type === 'assertText') {
+                return $event->text !== null && $event->text !== '';
+            }
+
             if (is_null($event->locator)) {
                 return false;
             }
@@ -90,23 +94,36 @@ final class EventSanitizer
      */
     private function deduplicateFills(array $events): array
     {
+        $pageIndex = 0;
         $lastIndex = [];
 
         foreach ($events as $index => $event) {
+            if ($event->type === 'navigate') {
+                $pageIndex++;
+                continue;
+            }
+
             if ($event->type === 'fill') {
                 $selector = $this->resolveSelector($event);
                 if (! is_null($selector)) {
-                    $lastIndex[$selector] = $index;
+                    $lastIndex[$pageIndex][$selector] = $index;
                 }
             }
         }
 
+        $pageIndex = 0;
         $result = [];
 
         foreach ($events as $index => $event) {
+            if ($event->type === 'navigate') {
+                $pageIndex++;
+                $result[] = $event;
+                continue;
+            }
+
             if ($event->type === 'fill') {
                 $selector = $this->resolveSelector($event);
-                if (! is_null($selector) && $lastIndex[$selector] !== $index) {
+                if (! is_null($selector) && ($lastIndex[$pageIndex][$selector] ?? null) !== $index) {
                     continue;
                 }
             }

--- a/src/Recorder/Laravel/auth-gen.php
+++ b/src/Recorder/Laravel/auth-gen.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Support\Str;
+
+define('LARAVEL_START', microtime(true));
+
+[$rootPath, $host, $storageFile] = array_slice($argv, 1, 3);
+
+require $rootPath . '/vendor/autoload.php';
+
+$app = require_once $rootPath . '/bootstrap/app.php';
+$kernel = $app->make(Kernel::class);
+$kernel->bootstrap();
+
+$userModel = config('auth.providers.users.model', User::class);
+
+$manager = app('session');
+$store = $manager->driver();
+$store->setId(Str::random(40));
+$store->start();
+
+$user = $userModel::factory()->create();
+app('auth')->guard()->setUser($user);
+$store->put(app('auth')->guard()->getName(), $user->getAuthIdentifier());
+$store->put('password_hash_' . app('auth')->getDefaultDriver(), $user->getAuthPassword());
+$store->save();
+
+$sessionId = $store->getId();
+$cookieName = config('session.cookie');
+$encrypter = app('encrypter');
+$prefix = CookieValuePrefix::create($cookieName, $encrypter->getKey());
+$encrypted = $encrypter->encrypt($prefix . $sessionId, false);
+
+file_put_contents($storageFile, json_encode([
+    'cookies' => [[
+        'name' => $cookieName,
+        'value' => $encrypted,
+        'domain' => $host,
+        'path' => '/',
+        'expires' => -1,
+        'httpOnly' => true,
+        'secure' => false,
+        'sameSite' => 'Lax',
+    ]],
+    'origins' => [],
+]));
+
+echo $userModel;

--- a/src/Recorder/Locator.php
+++ b/src/Recorder/Locator.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Recorder;
+
+final readonly class Locator
+{
+    private function __construct(
+        private string $kind,
+        private string $body,
+        private array $options,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            kind: $data['kind'] ?? 'default',
+            body: $data['body'] ?? '',
+            options: $data['options'] ?? [],
+        );
+    }
+
+    public function toSelector(string $testIdAttribute): ?string
+    {
+        if ($this->kind === 'test-id' && $this->body !== '') {
+            return match ($testIdAttribute) {
+                'data-test' => '@' . $this->body,
+                'data-testid' => '@' . $this->body,
+                'id' => '#' . $this->body,
+                default => sprintf('[%s="%s"]', $testIdAttribute, $this->body),
+            };
+        }
+
+        if ($this->kind === 'role') {
+            return $this->resolveRoleSelector();
+        }
+
+        if ($this->kind === 'text' && $this->body !== '') {
+            return $this->body;
+        }
+
+        if (in_array($this->kind, ['css', 'default'], true) && $this->body !== '') {
+            return $this->body;
+        }
+
+        return null;
+    }
+
+    private function resolveRoleSelector(): ?string
+    {
+        $name = trim($this->options['name'] ?? '');
+
+        if ($name === '') {
+            return null;
+        }
+
+        return match ($this->body) {
+            'button', 'link', 'menuitem', 'tab', 'option' => $name,
+            'textbox', 'searchbox', 'combobox' => sprintf('[aria-label="%s"]', $name),
+            'checkbox', 'radio' => $name,
+            default => null,
+        };
+    }
+}

--- a/src/Recorder/Locator.php
+++ b/src/Recorder/Locator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Recorder;
 
+use Pest\Browser\Support\Selector;
+
 final readonly class Locator
 {
     private function __construct(
@@ -56,9 +58,8 @@ final readonly class Locator
         }
 
         return match ($this->body) {
-            'button', 'link', 'menuitem', 'tab', 'option' => $name,
-            'textbox', 'searchbox', 'combobox' => sprintf('[aria-label="%s"]', $name),
-            'checkbox', 'radio' => $name,
+            'button', 'link', 'menuitem', 'tab', 'option', 'checkbox', 'radio' => $name,
+            'textbox', 'searchbox', 'combobox' => Selector::getByLabelSelector($name, true),
             default => null,
         };
     }

--- a/src/Recorder/RecordedEvent.php
+++ b/src/Recorder/RecordedEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Recorder;
+
+final readonly class RecordedEvent
+{
+    public function __construct(
+        public string $type,
+        public ?string $url = null,
+        public ?array $locator = null,
+        public ?string $text = null,
+        public ?string $key = null,
+        public ?string $selectValue = null,
+    ) {}
+
+    public static function fromRaw(array $data): ?self
+    {
+        $type = $data['name'] ?? null;
+
+        if (! is_string($type)) {
+            return null;
+        }
+
+        $selectValue = null;
+
+        if (isset($data['options'])) {
+            $option = $data['options'][0] ?? null;
+            $selectValue = is_array($option)
+                ? ($option['value'] ?? $option['label'] ?? null)
+                : (is_string($option) ? $option : null);
+        }
+
+        return new self(
+            type: $type,
+            url: $data['url'] ?? null,
+            locator: $data['locator'] ?? null,
+            text: $data['text'] ?? $data['value'] ?? null,
+            key: $data['key'] ?? null,
+            selectValue: $selectValue,
+        );
+    }
+}

--- a/src/Recorder/TestGenerator.php
+++ b/src/Recorder/TestGenerator.php
@@ -13,13 +13,13 @@ final class TestGenerator
     /**
      * @param RecordedEvent[] $events
      */
-    public function generate(array $events, string $title, string $baseUrl, bool $actingAs = false): string
+    public function generate(array $events, string $title, string $baseUrl, ?string $userModelClass = null): string
     {
         $pages = $this->groupByNavigation($events, $baseUrl);
         $body = $this->renderBody($pages);
 
-        if ($actingAs) {
-            $body = "    \$this->actingAs(\\App\\Models\\User::factory()->create());\n\n" . $body;
+        if (! is_null($userModelClass)) {
+            $body = "    \$this->actingAs(\\{$userModelClass}::factory()->create());\n\n" . $body;
         }
 
         $escapedTitle = str_replace("'", "\\'", $title);

--- a/src/Recorder/TestGenerator.php
+++ b/src/Recorder/TestGenerator.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Recorder;
+
+final class TestGenerator
+{
+    public function __construct(
+        private readonly string $testIdAttribute,
+    ) {}
+
+    /**
+     * @param RecordedEvent[] $events
+     */
+    public function generate(array $events, string $title, string $baseUrl): string
+    {
+        $pages = $this->groupByNavigation($events, $baseUrl);
+        $body = $this->renderBody($pages);
+
+        $escapedTitle = str_replace("'", "\\'", $title);
+
+        return sprintf("it('%s', function (): void {\n%s\n});", $escapedTitle, $body);
+    }
+
+    /**
+     * @param RecordedEvent[] $events
+     * @return array<int, array{path: string, events: RecordedEvent[]}>
+     */
+    private function groupByNavigation(array $events, string $baseUrl): array
+    {
+        $pages = [];
+        $current = null;
+
+        foreach ($events as $event) {
+            if ($event->type === 'navigate') {
+                if (! is_null($current)) {
+                    $pages[] = $current;
+                }
+
+                $current = [
+                    'path' => $this->toPath($event->url ?? '/', $baseUrl),
+                    'events' => [],
+                ];
+
+                continue;
+            }
+
+            if (is_null($current)) {
+                $current = ['path' => '/', 'events' => []];
+            }
+
+            $current['events'][] = $event;
+        }
+
+        if (! is_null($current)) {
+            $pages[] = $current;
+        }
+
+        return $pages;
+    }
+
+    /**
+     * @param array<int, array{path: string, events: RecordedEvent[]}> $pages
+     */
+    private function renderBody(array $pages): string
+    {
+        $blocks = [];
+
+        foreach ($pages as $page) {
+            $lines = [sprintf("    \$page = visit('%s');", $page['path'])];
+
+            foreach ($page['events'] as $event) {
+                $line = $this->renderAction($event);
+
+                if (! is_null($line)) {
+                    $lines[] = '    $page->' . $line . ';';
+                }
+            }
+
+            $blocks[] = implode("\n", $lines);
+        }
+
+        return implode("\n\n", $blocks);
+    }
+
+    private function renderAction(RecordedEvent $event): ?string
+    {
+        $selector = ! is_null($event->locator)
+            ? Locator::fromArray($event->locator)->toSelector($this->testIdAttribute)
+            : null;
+
+        return match ($event->type) {
+            'click' => ! is_null($selector)
+                ? sprintf("click('%s')", $this->escape($selector))
+                : null,
+
+            'fill' => ! is_null($selector)
+                ? sprintf("fill('%s', '%s')", $this->escape($selector), $this->escape($event->text ?? ''))
+                : null,
+
+            'selectOption' => ! is_null($selector)
+                ? sprintf("select('%s', '%s')", $this->escape($selector), $this->escape($event->selectValue ?? ''))
+                : null,
+
+            'check' => ! is_null($selector)
+                ? sprintf("check('%s')", $this->escape($selector))
+                : null,
+
+            'uncheck' => ! is_null($selector)
+                ? sprintf("uncheck('%s')", $this->escape($selector))
+                : null,
+
+            'assertVisible' => ! is_null($selector)
+                ? sprintf("assertVisible('%s')", $this->escape($selector))
+                : null,
+
+            'assertText' => $this->renderAssertText($event, $selector),
+
+            default => null,
+        };
+    }
+
+    private function renderAssertText(RecordedEvent $event, ?string $selector): ?string
+    {
+        $text = $event->text ?? '';
+
+        if ($text === '') {
+            return null;
+        }
+
+        if (! is_null($selector)) {
+            return sprintf("assertSeeIn('%s', '%s')", $this->escape($selector), $this->escape($text));
+        }
+
+        return sprintf("assertSee('%s')", $this->escape($text));
+    }
+
+    private function toPath(string $url, string $baseUrl): string
+    {
+        $base = rtrim($baseUrl, '/');
+
+        if (str_starts_with($url, $base)) {
+            return substr($url, strlen($base)) ?: '/';
+        }
+
+        return $url;
+    }
+
+    private function escape(string $value): string
+    {
+        return str_replace(['\\', "'"], ['\\\\', "\\'"], $value);
+    }
+}

--- a/src/Recorder/TestGenerator.php
+++ b/src/Recorder/TestGenerator.php
@@ -13,14 +13,89 @@ final class TestGenerator
     /**
      * @param RecordedEvent[] $events
      */
-    public function generate(array $events, string $title, string $baseUrl): string
+    public function generate(array $events, string $title, string $baseUrl, bool $actingAs = false): string
     {
+        if (! $actingAs) {
+            [$events, $actingAs] = $this->stripLoginSequence($events);
+        }
+
         $pages = $this->groupByNavigation($events, $baseUrl);
         $body = $this->renderBody($pages);
+
+        if ($actingAs) {
+            $body = "    \$this->actingAs(\\App\\Models\\User::factory()->create());\n\n" . $body;
+        }
 
         $escapedTitle = str_replace("'", "\\'", $title);
 
         return sprintf("it('%s', function (): void {\n%s\n});", $escapedTitle, $body);
+    }
+
+    /**
+     * Detect a login form (email + password fills) and strip it from the recorded events.
+     * Returns the cleaned event list and whether a login sequence was found.
+     *
+     * @param RecordedEvent[] $events
+     * @return array{0: RecordedEvent[], 1: bool}
+     */
+    private function stripLoginSequence(array $events): array
+    {
+        $passwordIdx = null;
+
+        foreach ($events as $i => $event) {
+            if ($event->type !== 'fill') {
+                continue;
+            }
+
+            $selector = $this->resolveSelector($event);
+
+            if ($selector !== null && str_contains(strtolower($selector), 'password')) {
+                $passwordIdx = $i;
+                break;
+            }
+        }
+
+        if ($passwordIdx === null) {
+            return [$events, false];
+        }
+
+        $emailIdx = null;
+
+        for ($i = $passwordIdx - 1; $i >= 0; $i--) {
+            if ($events[$i]->type === 'fill') {
+                $emailIdx = $i;
+                break;
+            }
+        }
+
+        $start = $emailIdx ?? $passwordIdx;
+
+        // Also remove the "Log in" link click that precedes the email field
+        if ($emailIdx !== null && $start > 0 && $events[$start - 1]->type === 'click') {
+            $start--;
+        }
+
+        // Remove up to 2 clicks after the password fill (remember-me checkbox + submit button)
+        $end = $passwordIdx;
+        $clickCount = 0;
+
+        while (isset($events[$end + 1]) && $events[$end + 1]->type === 'click' && $clickCount < 2) {
+            $end++;
+            $clickCount++;
+        }
+
+        array_splice($events, $start, $end - $start + 1);
+
+        return [$events, true];
+    }
+
+    private function resolveSelector(RecordedEvent $event): ?string
+    {
+        if ($event->locator === null) {
+            return null;
+        }
+
+        return Locator::fromArray($event->locator)->toSelector($this->testIdAttribute);
     }
 
     /**
@@ -68,15 +143,18 @@ final class TestGenerator
         $blocks = [];
 
         foreach ($pages as $page) {
-            $lines = [sprintf("    \$page = visit('%s');", $page['path'])];
+            $lines = [sprintf("    visit('%s')", $page['path'])];
 
             foreach ($page['events'] as $event) {
-                $line = $this->renderAction($event);
+                $action = $this->renderAction($event);
 
-                if (! is_null($line)) {
-                    $lines[] = '    $page->' . $line . ';';
+                if (! is_null($action)) {
+                    $lines[] = '        ->' . $action;
                 }
             }
+
+            $lastIndex = count($lines) - 1;
+            $lines[$lastIndex] .= ';';
 
             $blocks[] = implode("\n", $lines);
         }

--- a/src/Recorder/TestGenerator.php
+++ b/src/Recorder/TestGenerator.php
@@ -15,10 +15,6 @@ final class TestGenerator
      */
     public function generate(array $events, string $title, string $baseUrl, bool $actingAs = false): string
     {
-        if (! $actingAs) {
-            [$events, $actingAs] = $this->stripLoginSequence($events);
-        }
-
         $pages = $this->groupByNavigation($events, $baseUrl);
         $body = $this->renderBody($pages);
 
@@ -29,73 +25,6 @@ final class TestGenerator
         $escapedTitle = str_replace("'", "\\'", $title);
 
         return sprintf("it('%s', function (): void {\n%s\n});", $escapedTitle, $body);
-    }
-
-    /**
-     * Detect a login form (email + password fills) and strip it from the recorded events.
-     * Returns the cleaned event list and whether a login sequence was found.
-     *
-     * @param RecordedEvent[] $events
-     * @return array{0: RecordedEvent[], 1: bool}
-     */
-    private function stripLoginSequence(array $events): array
-    {
-        $passwordIdx = null;
-
-        foreach ($events as $i => $event) {
-            if ($event->type !== 'fill') {
-                continue;
-            }
-
-            $selector = $this->resolveSelector($event);
-
-            if ($selector !== null && str_contains(strtolower($selector), 'password')) {
-                $passwordIdx = $i;
-                break;
-            }
-        }
-
-        if ($passwordIdx === null) {
-            return [$events, false];
-        }
-
-        $emailIdx = null;
-
-        for ($i = $passwordIdx - 1; $i >= 0; $i--) {
-            if ($events[$i]->type === 'fill') {
-                $emailIdx = $i;
-                break;
-            }
-        }
-
-        $start = $emailIdx ?? $passwordIdx;
-
-        // Also remove the "Log in" link click that precedes the email field
-        if ($emailIdx !== null && $start > 0 && $events[$start - 1]->type === 'click') {
-            $start--;
-        }
-
-        // Remove up to 2 clicks after the password fill (remember-me checkbox + submit button)
-        $end = $passwordIdx;
-        $clickCount = 0;
-
-        while (isset($events[$end + 1]) && $events[$end + 1]->type === 'click' && $clickCount < 2) {
-            $end++;
-            $clickCount++;
-        }
-
-        array_splice($events, $start, $end - $start + 1);
-
-        return [$events, true];
-    }
-
-    private function resolveSelector(RecordedEvent $event): ?string
-    {
-        if ($event->locator === null) {
-            return null;
-        }
-
-        return Locator::fromArray($event->locator)->toSelector($this->testIdAttribute);
     }
 
     /**
@@ -193,22 +122,18 @@ final class TestGenerator
                 ? sprintf("assertVisible('%s')", $this->escape($selector))
                 : null,
 
-            'assertText' => $this->renderAssertText($event, $selector),
+            'assertText' => $this->renderAssertText($event),
 
             default => null,
         };
     }
 
-    private function renderAssertText(RecordedEvent $event, ?string $selector): ?string
+    private function renderAssertText(RecordedEvent $event): ?string
     {
         $text = $event->text ?? '';
 
         if ($text === '') {
             return null;
-        }
-
-        if (! is_null($selector)) {
-            return sprintf("assertSeeIn('%s', '%s')", $this->escape($selector), $this->escape($text));
         }
 
         return sprintf("assertSee('%s')", $this->escape($text));

--- a/src/Recorder/TestWriter.php
+++ b/src/Recorder/TestWriter.php
@@ -38,7 +38,7 @@ final class TestWriter
         return $files;
     }
 
-    public function write(string $path, string $testCode): void
+    public function write(string $path, string $testCode, bool $actingAs = false): void
     {
         if (! file_exists($path)) {
             $dir = dirname($path);
@@ -47,7 +47,9 @@ final class TestWriter
                 mkdir($dir, 0755, true);
             }
 
-            file_put_contents($path, "<?php\n\ndeclare(strict_types=1);\n\n{$testCode}\n");
+            $uses = $actingAs ? "uses(Tests\\TestCase::class);\n\n" : '';
+
+            file_put_contents($path, "<?php\n\ndeclare(strict_types=1);\n\n{$uses}{$testCode}\n");
 
             return;
         }

--- a/src/Recorder/TestWriter.php
+++ b/src/Recorder/TestWriter.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Recorder;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+final class TestWriter
+{
+    /**
+     * @return string[]
+     */
+    public function findExistingTestFiles(string $testsDirectory): array
+    {
+        if (! is_dir($testsDirectory)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($testsDirectory, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            assert($file instanceof SplFileInfo);
+
+            if ($file->isFile() && str_ends_with($file->getFilename(), 'Test.php')) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    public function write(string $path, string $testCode): void
+    {
+        if (! file_exists($path)) {
+            $dir = dirname($path);
+
+            if (! is_dir($dir)) {
+                mkdir($dir, 0755, true);
+            }
+
+            file_put_contents($path, "<?php\n\ndeclare(strict_types=1);\n\n{$testCode}\n");
+
+            return;
+        }
+
+        $existing = file_get_contents($path);
+        assert(is_string($existing));
+
+        file_put_contents($path, rtrim($existing) . "\n\n{$testCode}\n");
+    }
+}

--- a/tests/Unit/Recorder/EventSanitizerTest.php
+++ b/tests/Unit/Recorder/EventSanitizerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Pest\Browser\Recorder\EventSanitizer;
 use Pest\Browser\Recorder\RecordedEvent;
 
-function makeEvent(string $type, ?array $locator = null, ?string $url = null, ?string $text = null): RecordedEvent
+function makeRecordedEvent(string $type, ?array $locator = null, ?string $url = null, ?string $text = null): RecordedEvent
 {
     return new RecordedEvent(
         type: $type,
@@ -15,7 +15,7 @@ function makeEvent(string $type, ?array $locator = null, ?string $url = null, ?s
     );
 }
 
-function testIdLocator(string $id): array
+function makeTestIdLocator(string $id): array
 {
     return [
         'kind' => 'test-id',
@@ -24,7 +24,7 @@ function testIdLocator(string $id): array
     ];
 }
 
-function roleLocator(string $role, string $name): array
+function makeRoleLocator(string $role, string $name): array
 {
     return [
         'kind' => 'role',
@@ -39,13 +39,13 @@ function roleLocator(string $role, string $name): array
 it('keeps supported event types', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('navigate', url: 'http://localhost/'),
-        makeEvent('click', testIdLocator('btn')),
-        makeEvent('fill', testIdLocator('email')),
-        makeEvent('check', testIdLocator('remember')),
-        makeEvent('uncheck', testIdLocator('remember')),
-        makeEvent('assertVisible', testIdLocator('heading')),
-        makeEvent('assertText', testIdLocator('msg'), text: 'Hello'),
+        makeRecordedEvent('navigate', url: 'http://localhost/'),
+        makeRecordedEvent('click', makeTestIdLocator('btn')),
+        makeRecordedEvent('fill', makeTestIdLocator('email')),
+        makeRecordedEvent('check', makeTestIdLocator('remember')),
+        makeRecordedEvent('uncheck', makeTestIdLocator('remember')),
+        makeRecordedEvent('assertVisible', makeTestIdLocator('heading')),
+        makeRecordedEvent('assertText', makeTestIdLocator('msg'), text: 'Hello'),
     ];
 
     expect($sanitizer->sanitize($events))->toHaveCount(7);
@@ -54,9 +54,9 @@ it('keeps supported event types', function (): void {
 it('drops unsupported event types', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('hover', testIdLocator('btn')),
-        makeEvent('press', testIdLocator('input')),
-        makeEvent('navigate', url: 'http://localhost/'),
+        makeRecordedEvent('hover', makeTestIdLocator('btn')),
+        makeRecordedEvent('press', makeTestIdLocator('input')),
+        makeRecordedEvent('navigate', url: 'http://localhost/'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -67,8 +67,8 @@ it('drops unsupported event types', function (): void {
 it('drops navigate events without url', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('navigate'),
-        makeEvent('navigate', url: 'http://localhost/'),
+        makeRecordedEvent('navigate'),
+        makeRecordedEvent('navigate', url: 'http://localhost/'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -78,9 +78,9 @@ it('drops navigate events without url', function (): void {
 it('drops events with null locator (except navigate)', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('click'),
-        makeEvent('fill'),
-        makeEvent('navigate', url: 'http://localhost/'),
+        makeRecordedEvent('click'),
+        makeRecordedEvent('fill'),
+        makeRecordedEvent('navigate', url: 'http://localhost/'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -91,12 +91,12 @@ it('drops events with null locator (except navigate)', function (): void {
 it('drops events where locator resolves to null selector', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('click', [
+        makeRecordedEvent('click', [
             'kind' => 'unknown',
             'body' => '',
             'options' => [],
         ]),
-        makeEvent('navigate', url: 'http://localhost/'),
+        makeRecordedEvent('navigate', url: 'http://localhost/'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -107,8 +107,8 @@ it('drops events where locator resolves to null selector', function (): void {
 it('drops click when immediately followed by fill on same selector', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('click', testIdLocator('email')),
-        makeEvent('fill', testIdLocator('email'), text: 'user@example.com'),
+        makeRecordedEvent('click', makeTestIdLocator('email')),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'user@example.com'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -119,8 +119,8 @@ it('drops click when immediately followed by fill on same selector', function ()
 it('keeps click when followed by fill on different selector', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('click', testIdLocator('btn')),
-        makeEvent('fill', testIdLocator('email'), text: 'user@example.com'),
+        makeRecordedEvent('click', makeTestIdLocator('btn')),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'user@example.com'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -130,8 +130,8 @@ it('keeps click when followed by fill on different selector', function (): void 
 it('keeps click not followed by fill', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('click', roleLocator('button', 'Submit')),
-        makeEvent('navigate', url: 'http://localhost/dashboard'),
+        makeRecordedEvent('click', makeRoleLocator('button', 'Submit')),
+        makeRecordedEvent('navigate', url: 'http://localhost/dashboard'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -142,9 +142,9 @@ it('keeps click not followed by fill', function (): void {
 it('keeps only the last fill for each selector', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('fill', testIdLocator('email'), text: 'first@example.com'),
-        makeEvent('fill', testIdLocator('email'), text: 'second@example.com'),
-        makeEvent('fill', testIdLocator('email'), text: 'final@example.com'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'first@example.com'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'second@example.com'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'final@example.com'),
     ];
     $result = $sanitizer->sanitize($events);
 
@@ -155,20 +155,57 @@ it('keeps only the last fill for each selector', function (): void {
 it('keeps fills for different selectors', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('fill', testIdLocator('email'), text: 'user@example.com'),
-        makeEvent('fill', testIdLocator('password'), text: 'secret'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'user@example.com'),
+        makeRecordedEvent('fill', makeTestIdLocator('password'), text: 'secret'),
     ];
     $result = $sanitizer->sanitize($events);
 
     expect($result)->toHaveCount(2);
 });
 
+it('keeps assertText with unresolvable locator when text is non-empty', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeRecordedEvent('assertText', ['kind' => 'role', 'body' => 'main', 'options' => ['attrs' => []]], text: 'Welcome'),
+    ];
+    $result = $sanitizer->sanitize($events);
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->text)->toBe('Welcome');
+});
+
+it('keeps assertText with null locator when text is non-empty', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [makeRecordedEvent('assertText', text: 'Welcome')];
+    $result = $sanitizer->sanitize($events);
+    expect($result)->toHaveCount(1);
+});
+
+it('drops assertText when text is empty', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [makeRecordedEvent('assertText', text: '')];
+    expect($sanitizer->sanitize($events))->toHaveCount(0);
+});
+
+it('keeps fills for same selector on different pages', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeRecordedEvent('navigate', url: 'http://localhost/login'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'admin@a.com'),
+        makeRecordedEvent('navigate', url: 'http://localhost/register'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'user@b.com'),
+    ];
+    $result = $sanitizer->sanitize($events);
+    expect($result)->toHaveCount(4)
+        ->and($result[1]->text)->toBe('admin@a.com')
+        ->and($result[3]->text)->toBe('user@b.com');
+});
+
 it('preserves event order after deduplication', function (): void {
     $sanitizer = new EventSanitizer('id');
     $events = [
-        makeEvent('fill', testIdLocator('email'), text: 'first@example.com'),
-        makeEvent('fill', testIdLocator('password'), text: 'secret'),
-        makeEvent('fill', testIdLocator('email'), text: 'final@example.com'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'first@example.com'),
+        makeRecordedEvent('fill', makeTestIdLocator('password'), text: 'secret'),
+        makeRecordedEvent('fill', makeTestIdLocator('email'), text: 'final@example.com'),
     ];
     $result = $sanitizer->sanitize($events);
 

--- a/tests/Unit/Recorder/EventSanitizerTest.php
+++ b/tests/Unit/Recorder/EventSanitizerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Recorder\EventSanitizer;
+use Pest\Browser\Recorder\RecordedEvent;
+
+function makeEvent(string $type, ?array $locator = null, ?string $url = null, ?string $text = null): RecordedEvent
+{
+    return new RecordedEvent(
+        type: $type,
+        url: $url,
+        locator: $locator,
+        text: $text,
+    );
+}
+
+function testIdLocator(string $id): array
+{
+    return [
+        'kind' => 'test-id',
+        'body' => $id,
+        'options' => [],
+    ];
+}
+
+function roleLocator(string $role, string $name): array
+{
+    return [
+        'kind' => 'role',
+        'body' => $role,
+        'options' => [
+            'name' => $name,
+        ],
+    ];
+}
+
+// dropUnsupported
+it('keeps supported event types', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('navigate', url: 'http://localhost/'),
+        makeEvent('click', testIdLocator('btn')),
+        makeEvent('fill', testIdLocator('email')),
+        makeEvent('check', testIdLocator('remember')),
+        makeEvent('uncheck', testIdLocator('remember')),
+        makeEvent('assertVisible', testIdLocator('heading')),
+        makeEvent('assertText', testIdLocator('msg'), text: 'Hello'),
+    ];
+
+    expect($sanitizer->sanitize($events))->toHaveCount(7);
+});
+
+it('drops unsupported event types', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('hover', testIdLocator('btn')),
+        makeEvent('press', testIdLocator('input')),
+        makeEvent('navigate', url: 'http://localhost/'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->type)->toBe('navigate');
+});
+
+it('drops navigate events without url', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('navigate'),
+        makeEvent('navigate', url: 'http://localhost/'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(1);
+});
+
+it('drops events with null locator (except navigate)', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('click'),
+        makeEvent('fill'),
+        makeEvent('navigate', url: 'http://localhost/'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->type)->toBe('navigate');
+});
+
+it('drops events where locator resolves to null selector', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('click', [
+            'kind' => 'unknown',
+            'body' => '',
+            'options' => [],
+        ]),
+        makeEvent('navigate', url: 'http://localhost/'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(1);
+});
+
+// dropRedundantClicks
+it('drops click when immediately followed by fill on same selector', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('click', testIdLocator('email')),
+        makeEvent('fill', testIdLocator('email'), text: 'user@example.com'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->type)->toBe('fill');
+});
+
+it('keeps click when followed by fill on different selector', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('click', testIdLocator('btn')),
+        makeEvent('fill', testIdLocator('email'), text: 'user@example.com'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(2);
+});
+
+it('keeps click not followed by fill', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('click', roleLocator('button', 'Submit')),
+        makeEvent('navigate', url: 'http://localhost/dashboard'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(2);
+});
+
+// deduplicateFills
+it('keeps only the last fill for each selector', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('fill', testIdLocator('email'), text: 'first@example.com'),
+        makeEvent('fill', testIdLocator('email'), text: 'second@example.com'),
+        makeEvent('fill', testIdLocator('email'), text: 'final@example.com'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->text)->toBe('final@example.com');
+});
+
+it('keeps fills for different selectors', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('fill', testIdLocator('email'), text: 'user@example.com'),
+        makeEvent('fill', testIdLocator('password'), text: 'secret'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(2);
+});
+
+it('preserves event order after deduplication', function (): void {
+    $sanitizer = new EventSanitizer('id');
+    $events = [
+        makeEvent('fill', testIdLocator('email'), text: 'first@example.com'),
+        makeEvent('fill', testIdLocator('password'), text: 'secret'),
+        makeEvent('fill', testIdLocator('email'), text: 'final@example.com'),
+    ];
+    $result = $sanitizer->sanitize($events);
+
+    expect($result)->toHaveCount(2)
+        ->and($result[0]->text)->toBe('secret')
+        ->and($result[1]->text)->toBe('final@example.com');
+});

--- a/tests/Unit/Recorder/LocatorTest.php
+++ b/tests/Unit/Recorder/LocatorTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Recorder\Locator;
+
+// test-id kind
+it('resolves test-id with id attribute to hash selector', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'test-id',
+        'body' => 'submit-btn',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('#submit-btn');
+});
+
+it('resolves test-id with data-test attribute to @ selector', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'test-id',
+        'body' => 'submit-btn',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('data-test'))->toBe('@submit-btn');
+});
+
+it('resolves test-id with data-testid attribute to @ selector', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'test-id',
+        'body' => 'submit-btn',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('data-testid'))->toBe('@submit-btn');
+});
+
+it('resolves test-id with custom attribute to attribute selector', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'test-id',
+        'body' => 'submit-btn',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('data-cy'))->toBe('[data-cy="submit-btn"]');
+});
+
+it('returns null for test-id with empty body', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'test-id',
+        'body' => '',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('id'))->toBeNull();
+});
+
+// role kind — clickable elements use name directly
+it('resolves role=button to name', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'button',
+        'options' => ['name' => 'Submit'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('Submit');
+});
+
+it('resolves role=link to name', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'link',
+        'options' => ['name' => 'Dashboard'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('Dashboard');
+});
+
+it('resolves role=menuitem to name', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'menuitem',
+        'options' => ['name' => 'Settings'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('Settings');
+});
+
+it('resolves role=checkbox to name', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'checkbox',
+        'options' => ['name' => 'Remember me'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('Remember me');
+});
+
+// role kind — input elements use label selector
+it('resolves role=textbox to label selector', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'textbox',
+        'options' => ['name' => 'Email address'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('internal:label="Email address"s');
+});
+
+it('resolves role=searchbox to label selector', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'searchbox',
+        'options' => ['name' => 'Search'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('internal:label="Search"s');
+});
+
+it('resolves role=combobox to label selector', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'combobox',
+        'options' => ['name' => 'Country'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('internal:label="Country"s');
+});
+
+it('returns null for role with empty name', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'button',
+        'options' => ['name' => ''],
+    ]);
+
+    expect($locator->toSelector('id'))->toBeNull();
+});
+
+it('returns null for unhandled role body', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'role',
+        'body' => 'grid',
+        'options' => ['name' => 'Data'],
+    ]);
+
+    expect($locator->toSelector('id'))->toBeNull();
+});
+
+// text / css / default kinds
+it('resolves text kind to body', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'text',
+        'body' => 'Click here',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('Click here');
+});
+
+it('resolves css kind to body', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'css',
+        'body' => '.btn-primary',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('.btn-primary');
+});
+
+it('resolves default kind to body', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'default',
+        'body' => 'input[type=email]',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('id'))->toBe('input[type=email]');
+});
+
+it('returns null for unknown kind', function (): void {
+    $locator = Locator::fromArray([
+        'kind' => 'label',
+        'body' => 'Email',
+        'options' => [],
+    ]);
+
+    expect($locator->toSelector('id'))->toBeNull();
+});
+
+it('uses defaults when array keys are missing', function (): void {
+    $locator = Locator::fromArray([]);
+
+    expect($locator->toSelector('id'))->toBeNull();
+});

--- a/tests/Unit/Recorder/TestGeneratorTest.php
+++ b/tests/Unit/Recorder/TestGeneratorTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 use Pest\Browser\Recorder\RecordedEvent;
 use Pest\Browser\Recorder\TestGenerator;
 
-function navigate(string $url): RecordedEvent
+function navigateEvent(string $url): RecordedEvent
 {
     return new RecordedEvent(type: 'navigate', url: $url);
 }
 
-function click(string $name): RecordedEvent
+function clickEvent(string $name): RecordedEvent
 {
     return new RecordedEvent(
         type: 'click',
@@ -22,7 +22,7 @@ function click(string $name): RecordedEvent
     );
 }
 
-function fill(string $id, string $value): RecordedEvent
+function fillEvent(string $id, string $value): RecordedEvent
 {
     return new RecordedEvent(
         type: 'fill',
@@ -35,24 +35,24 @@ function fill(string $id, string $value): RecordedEvent
     );
 }
 
-function assertText(string $text): RecordedEvent
+function assertTextEvent(string $text): RecordedEvent
 {
     return new RecordedEvent(type: 'assertText', text: $text);
 }
 
 // actingAs
-it('injects actingAs when actingAs=true', function (): void {
+it('injects actingAs with resolved model class', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), fill('email', 'test@example.com')];
-    $code = $generator->generate($events, 'can do something', 'http://localhost', true);
+    $events = [navigateEvent('http://localhost/'), fillEvent('email', 'test@example.com')];
+    $code = $generator->generate($events, 'can do something', 'http://localhost', 'App\\Models\\User');
 
     expect($code)->toContain('$this->actingAs(\App\Models\User::factory()->create())');
 });
 
-it('does not inject actingAs when actingAs=false', function (): void {
+it('does not inject actingAs when userModelClass is null', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), fill('email', 'test@example.com')];
-    $code = $generator->generate($events, 'can do something', 'http://localhost', false);
+    $events = [navigateEvent('http://localhost/'), fillEvent('email', 'test@example.com')];
+    $code = $generator->generate($events, 'can do something', 'http://localhost');
 
     expect($code)->not->toContain('actingAs');
 });
@@ -60,7 +60,7 @@ it('does not inject actingAs when actingAs=false', function (): void {
 // test structure
 it('wraps output in it() closure', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/')];
+    $events = [navigateEvent('http://localhost/')];
     $code = $generator->generate($events, 'can visit home', 'http://localhost');
 
     expect($code)->toStartWith("it('can visit home', function (): void {");
@@ -68,7 +68,7 @@ it('wraps output in it() closure', function (): void {
 
 it('escapes single quotes in title', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/')];
+    $events = [navigateEvent('http://localhost/')];
     $code = $generator->generate($events, "can't login", 'http://localhost');
 
     expect($code)->toContain("it('can\\'t login'");
@@ -78,10 +78,10 @@ it('escapes single quotes in title', function (): void {
 it('groups events into visit() blocks per page', function (): void {
     $generator = new TestGenerator('id');
     $events = [
-        navigate('http://localhost/'),
-        click('Submit'),
-        navigate('http://localhost/dashboard'),
-        click('Settings'),
+        navigateEvent('http://localhost/'),
+        clickEvent('Submit'),
+        navigateEvent('http://localhost/dashboard'),
+        clickEvent('Settings'),
     ];
     $code = $generator->generate($events, 'can navigate', 'http://localhost');
 
@@ -92,7 +92,7 @@ it('groups events into visit() blocks per page', function (): void {
 
 it('strips base url from path', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost:8000/dashboard')];
+    $events = [navigateEvent('http://localhost:8000/dashboard')];
     $code = $generator->generate($events, 'test', 'http://localhost:8000');
 
     expect($code)->toContain("visit('/dashboard')");
@@ -100,7 +100,7 @@ it('strips base url from path', function (): void {
 
 it('uses / when url matches base exactly', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/')];
+    $events = [navigateEvent('http://localhost/')];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
     expect($code)->toContain("visit('/')");
@@ -109,7 +109,7 @@ it('uses / when url matches base exactly', function (): void {
 // action rendering
 it('renders click action', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), click('Log in')];
+    $events = [navigateEvent('http://localhost/'), clickEvent('Log in')];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
     expect($code)->toContain("->click('Log in')");
@@ -117,7 +117,7 @@ it('renders click action', function (): void {
 
 it('renders fill action with id selector', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), fill('email', 'user@example.com')];
+    $events = [navigateEvent('http://localhost/'), fillEvent('email', 'user@example.com')];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
     expect($code)->toContain("->fill('#email', 'user@example.com')");
@@ -125,7 +125,7 @@ it('renders fill action with id selector', function (): void {
 
 it('renders assertText as assertSee without selector', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), assertText('These credentials do not match')];
+    $events = [navigateEvent('http://localhost/'), assertTextEvent('These credentials do not match')];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
     expect($code)
@@ -135,7 +135,7 @@ it('renders assertText as assertSee without selector', function (): void {
 
 it('skips assertText with empty text', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), assertText('')];
+    $events = [navigateEvent('http://localhost/'), assertTextEvent('')];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
     expect($code)->not->toContain('assertSee');
@@ -144,7 +144,7 @@ it('skips assertText with empty text', function (): void {
 // escaping
 it('escapes single quotes in fill value', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), fill('name', "O'Brien")];
+    $events = [navigateEvent('http://localhost/'), fillEvent('name', "O'Brien")];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
     expect($code)->toContain("->fill('#name', 'O\\'Brien')");
@@ -152,7 +152,7 @@ it('escapes single quotes in fill value', function (): void {
 
 it('escapes backslashes in fill value', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/'), fill('path', 'C:\\Users')];
+    $events = [navigateEvent('http://localhost/'), fillEvent('path', 'C:\\Users')];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
     expect($code)->toContain("->fill('#path', 'C:\\\\Users')");
@@ -162,8 +162,8 @@ it('escapes backslashes in fill value', function (): void {
 it('separates multiple pages with blank line', function (): void {
     $generator = new TestGenerator('id');
     $events = [
-        navigate('http://localhost/'),
-        navigate('http://localhost/dashboard'),
+        navigateEvent('http://localhost/'),
+        navigateEvent('http://localhost/dashboard'),
     ];
     $code = $generator->generate($events, 'test', 'http://localhost');
 
@@ -171,10 +171,10 @@ it('separates multiple pages with blank line', function (): void {
 });
 
 // actingAs placed before first visit
-it('places actingAs before visit when actingAs=true', function (): void {
+it('places actingAs before visit when userModelClass is set', function (): void {
     $generator = new TestGenerator('id');
-    $events = [navigate('http://localhost/dashboard')];
-    $code = $generator->generate($events, 'test', 'http://localhost', true);
+    $events = [navigateEvent('http://localhost/dashboard')];
+    $code = $generator->generate($events, 'test', 'http://localhost', 'App\\Models\\User');
     $actingAsPos = strpos($code, 'actingAs');
     $visitPos = strpos($code, 'visit(');
 

--- a/tests/Unit/Recorder/TestGeneratorTest.php
+++ b/tests/Unit/Recorder/TestGeneratorTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Recorder\RecordedEvent;
+use Pest\Browser\Recorder\TestGenerator;
+
+function navigate(string $url): RecordedEvent
+{
+    return new RecordedEvent(type: 'navigate', url: $url);
+}
+
+function click(string $name): RecordedEvent
+{
+    return new RecordedEvent(
+        type: 'click',
+        locator: [
+            'kind' => 'role',
+            'body' => 'button',
+            'options' => ['name' => $name],
+        ],
+    );
+}
+
+function fill(string $id, string $value): RecordedEvent
+{
+    return new RecordedEvent(
+        type: 'fill',
+        locator: [
+            'kind' => 'test-id',
+            'body' => $id,
+            'options' => [],
+        ],
+        text: $value,
+    );
+}
+
+function assertText(string $text): RecordedEvent
+{
+    return new RecordedEvent(type: 'assertText', text: $text);
+}
+
+// actingAs
+it('injects actingAs when actingAs=true', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), fill('email', 'test@example.com')];
+    $code = $generator->generate($events, 'can do something', 'http://localhost', true);
+
+    expect($code)->toContain('$this->actingAs(\App\Models\User::factory()->create())');
+});
+
+it('does not inject actingAs when actingAs=false', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), fill('email', 'test@example.com')];
+    $code = $generator->generate($events, 'can do something', 'http://localhost', false);
+
+    expect($code)->not->toContain('actingAs');
+});
+
+// test structure
+it('wraps output in it() closure', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/')];
+    $code = $generator->generate($events, 'can visit home', 'http://localhost');
+
+    expect($code)->toStartWith("it('can visit home', function (): void {");
+});
+
+it('escapes single quotes in title', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/')];
+    $code = $generator->generate($events, "can't login", 'http://localhost');
+
+    expect($code)->toContain("it('can\\'t login'");
+});
+
+// navigation grouping
+it('groups events into visit() blocks per page', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [
+        navigate('http://localhost/'),
+        click('Submit'),
+        navigate('http://localhost/dashboard'),
+        click('Settings'),
+    ];
+    $code = $generator->generate($events, 'can navigate', 'http://localhost');
+
+    expect($code)
+        ->toContain("visit('/')")
+        ->toContain("visit('/dashboard')");
+});
+
+it('strips base url from path', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost:8000/dashboard')];
+    $code = $generator->generate($events, 'test', 'http://localhost:8000');
+
+    expect($code)->toContain("visit('/dashboard')");
+});
+
+it('uses / when url matches base exactly', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/')];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)->toContain("visit('/')");
+});
+
+// action rendering
+it('renders click action', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), click('Log in')];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)->toContain("->click('Log in')");
+});
+
+it('renders fill action with id selector', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), fill('email', 'user@example.com')];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)->toContain("->fill('#email', 'user@example.com')");
+});
+
+it('renders assertText as assertSee without selector', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), assertText('These credentials do not match')];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)
+        ->toContain("->assertSee('These credentials do not match')")
+        ->not->toContain('assertSeeIn');
+});
+
+it('skips assertText with empty text', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), assertText('')];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)->not->toContain('assertSee');
+});
+
+// escaping
+it('escapes single quotes in fill value', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), fill('name', "O'Brien")];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)->toContain("->fill('#name', 'O\\'Brien')");
+});
+
+it('escapes backslashes in fill value', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/'), fill('path', 'C:\\Users')];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)->toContain("->fill('#path', 'C:\\\\Users')");
+});
+
+// multiple pages separated by blank line
+it('separates multiple pages with blank line', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [
+        navigate('http://localhost/'),
+        navigate('http://localhost/dashboard'),
+    ];
+    $code = $generator->generate($events, 'test', 'http://localhost');
+
+    expect($code)->toContain("\n\n");
+});
+
+// actingAs placed before first visit
+it('places actingAs before visit when actingAs=true', function (): void {
+    $generator = new TestGenerator('id');
+    $events = [navigate('http://localhost/dashboard')];
+    $code = $generator->generate($events, 'test', 'http://localhost', true);
+    $actingAsPos = strpos($code, 'actingAs');
+    $visitPos = strpos($code, 'visit(');
+
+    expect($actingAsPos)->toBeLessThan($visitPos);
+});


### PR DESCRIPTION
**As more code (and tests) gets written by AI, (browser)tests matter more than ever. 
Not just as a safety net, but as the source of truth.** 

`vendor/bin/pest --record` (or `php artisan test --record`) opens a real browser, lets you click through your app, fill and save forms, close the browser, give the test a name and Pest writes a ready-to-run test to tests/Browser/. 

```bash
vendor/bin/pest --record --visit=/checkout
vendor/bin/pest --record --auth --migrate-fresh --seed --visit=/dashboard
vendor/bin/pest --record --url=https://pestphp.com
```

This implementation is based on my POC https://github.com/ComfyCodersBV/laravel-pest-recorder which I talked about with Nuno at Laracon EU.

https://github.com/user-attachments/assets/6c39b3e7-89aa-4131-92b7-3ed8400f5859


What's in here:
- Full record flow: auto-starts Laravel test server, opens Playwright recorder, you can navigate, fill forms, make assertions.
- Event sanitizer: deduplicates fills, removes noise, cleans up navigations
- Code generator: maps Playwright events to Pest Browser format
- Auth support: `--auth` or `--user` bootstraps a factory user with a session cookie; generated test uses actingAs(). Built in auth for Laravel included, manual override option possible for other frameworks or extended authentication.
- RECORDING.md usage guide
- Most original options of `playwright codegen` supported & more like the `--url=...` flag.