### PR TITLE
Parse multipart/form-data and forward uploaded files in LaravelHttpServer

### DIFF
--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -25,6 +25,7 @@ use Pest\Browser\Execution;
 use Pest\Browser\GlobalState;
 use Pest\Browser\Playwright\Playwright;
 use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\MimeTypes;
 use Throwable;
 
@@ -241,8 +242,14 @@ final class LaravelHttpServer implements HttpServer
         $method = mb_strtoupper($request->getMethod());
         $rawBody = (string) $request->getBody();
         $parameters = [];
-        if ($method !== 'GET' && str_starts_with(mb_strtolower($contentType), 'application/x-www-form-urlencoded')) {
-            parse_str($rawBody, $parameters);
+        $files = [];
+        if ($method !== 'GET') {
+            $lcContentType = mb_strtolower($contentType);
+            if (str_starts_with($lcContentType, 'application/x-www-form-urlencoded')) {
+                parse_str($rawBody, $parameters);
+            } elseif (str_starts_with($lcContentType, 'multipart/form-data')) {
+                [$parameters, $files] = $this->parseMultipartBody($rawBody, $contentType);
+            }
         }
         $cookies = array_map(fn (RequestCookie $cookie): string => urldecode($cookie->getValue()), $request->getCookies());
         $cookies = array_merge($cookies, test()->prepareCookiesForRequest()); // @phpstan-ignore-line
@@ -254,7 +261,7 @@ final class LaravelHttpServer implements HttpServer
             $method,
             $parameters,
             $cookies,
-            [], // @TODO files...
+            $files,
             $serverVariables,
             $rawBody
         );
@@ -310,6 +317,163 @@ final class LaravelHttpServer implements HttpServer
             $response->headers->all(), // @phpstan-ignore-line
             $content,
         );
+    }
+
+    /**
+     * Parse a `multipart/form-data` body into ($parameters, $files) suitable
+     * for `Symfony\Component\HttpFoundation\Request::create()`.
+     *
+     * Byte-safe — uses string functions (not `mb_*`) so binary uploads
+     * (.xlsx, .zip, images, PDFs) survive without UTF-8 corruption. Each
+     * file part is written to a temp file in `sys_get_temp_dir()` and
+     * wrapped in a Symfony `UploadedFile` constructed with `$test = true`
+     * to bypass `is_uploaded_file()` (which only returns true for real
+     * SAPI uploads).
+     *
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+     *         [0] parameters (non-file form fields), [1] files (UploadedFile
+     *         instances keyed by field name).
+     */
+    private function parseMultipartBody(string $body, string $contentType): array
+    {
+        if (preg_match('/boundary="?([^";\s]+)"?/i', $contentType, $matches) !== 1) {
+            return [[], []];
+        }
+        $boundary = '--'.$matches[1];
+
+        // Split byte-safe; first chunk is empty (preamble before first boundary).
+        $parts = explode("\r\n".$boundary, "\r\n".$body);
+        array_shift($parts);
+
+        $parameters = [];
+        $files = [];
+
+        foreach ($parts as $part) {
+            // Closing boundary is "--{boundary}--"; the leading "--" remains
+            // at the start of $part after split — skip it.
+            if (str_starts_with($part, '--')) {
+                continue;
+            }
+            // Strip leading "\r\n" left by the split.
+            if (str_starts_with($part, "\r\n")) {
+                $part = substr($part, 2);
+            }
+
+            $headerEnd = strpos($part, "\r\n\r\n");
+            if ($headerEnd === false) {
+                continue;
+            }
+            $headerSection = substr($part, 0, $headerEnd);
+            $content = substr($part, $headerEnd + 4);
+
+            // Trailing "\r\n" precedes the next boundary delimiter.
+            if (str_ends_with($content, "\r\n")) {
+                $content = substr($content, 0, -2);
+            }
+
+            $headers = [];
+            foreach (explode("\r\n", $headerSection) as $line) {
+                $colonPos = strpos($line, ':');
+                if ($colonPos === false) {
+                    continue;
+                }
+                $name = strtolower(trim(substr($line, 0, $colonPos)));
+                $value = trim(substr($line, $colonPos + 1));
+                $headers[$name] = $value;
+            }
+
+            $disposition = $headers['content-disposition'] ?? '';
+            if (preg_match('/name="([^"]+)"/', $disposition, $nameMatch) !== 1) {
+                continue;
+            }
+            $fieldName = $nameMatch[1];
+
+            if (preg_match('/filename="([^"]*)"/', $disposition, $filenameMatch) === 1) {
+                $filename = $filenameMatch[1];
+                if ($filename === '') {
+                    // Empty `<input type="file">` with no selection.
+                    continue;
+                }
+                $mimeType = $headers['content-type'] ?? 'application/octet-stream';
+
+                $tmpPath = tempnam(sys_get_temp_dir(), 'pest_browser_upload_');
+                if ($tmpPath === false) {
+                    continue;
+                }
+                file_put_contents($tmpPath, $content);
+
+                $uploadedFile = new UploadedFile(
+                    $tmpPath,
+                    $filename,
+                    $mimeType,
+                    UPLOAD_ERR_OK,
+                    test: true,
+                );
+
+                $this->assignParsedValue($files, $fieldName, $uploadedFile);
+            } else {
+                $this->assignParsedValue($parameters, $fieldName, $content);
+            }
+        }
+
+        return [$parameters, $files];
+    }
+
+    /**
+     * Assign a parsed multipart value into the target array, honoring
+     * PHP's bracket notation for nested fields (e.g. `tags[]`, `user[name]`,
+     * `files[0]`). Delegates to `parse_str()` via `http_build_query()` so
+     * the same nesting semantics PHP applies to `$_POST`/`$_FILES` apply
+     * here.
+     *
+     * @param  array<string, mixed>  $target
+     */
+    private function assignParsedValue(array &$target, string $fieldName, mixed $value): void
+    {
+        if (! str_contains($fieldName, '[')) {
+            $target[$fieldName] = $value;
+
+            return;
+        }
+
+        // For files we cannot round-trip through http_build_query() — encode
+        // a placeholder, parse the structure, then walk the parsed tree and
+        // replace the placeholder leaf with the UploadedFile instance.
+        $placeholder = '__pest_browser_placeholder_'.spl_object_id((object) []).'__';
+        $encoded = http_build_query([$fieldName => $value instanceof UploadedFile ? $placeholder : $value]);
+        $decoded = [];
+        parse_str($encoded, $decoded);
+
+        if ($value instanceof UploadedFile) {
+            $this->replacePlaceholderLeaf($decoded, $placeholder, $value);
+        }
+
+        $target = array_replace_recursive($target, $decoded);
+    }
+
+    /**
+     * Walk an array recursively, replacing the first leaf string equal to
+     * `$placeholder` with `$replacement`. Used to inject `UploadedFile`
+     * instances into the structure produced by `parse_str()` (which only
+     * preserves scalars).
+     *
+     * @param  array<int|string, mixed>  $array
+     */
+    private function replacePlaceholderLeaf(array &$array, string $placeholder, mixed $replacement): bool
+    {
+        foreach ($array as $key => &$value) {
+            if (is_array($value)) {
+                if ($this->replacePlaceholderLeaf($value, $placeholder, $replacement)) {
+                    return true;
+                }
+            } elseif ($value === $placeholder) {
+                $array[$key] = $replacement;
+
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Browser/Webpage/AttachServerSideTest.php
+++ b/tests/Browser/Webpage/AttachServerSideTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Pest\Browser\Playwright\Playwright;
+
+// The defaults in tests/Pest.php (2000ms) are too short for round-trips
+// that include form submit + server-side file processing on slower CI.
+beforeEach(fn () => Playwright::setTimeout(10000));
+afterEach(fn () => Playwright::setTimeout(2000));
+
+it('forwards a single uploaded file to the Laravel request', function (): void {
+    Route::post('/upload', function (Request $request): string {
+        $file = $request->file('avatar');
+        if ($file === null) {
+            return 'NO_FILE';
+        }
+
+        return sprintf(
+            '%s|%s|%d|%s',
+            $file->getClientOriginalName(),
+            $file->getClientMimeType(),
+            $file->getSize(),
+            $file->getContent(),
+        );
+    })->withoutMiddleware([ValidateCsrfToken::class]);
+
+    Route::get('/form', fn (): string => '
+        <form id="upload-form" method="POST" action="/upload" enctype="multipart/form-data">
+            <input type="file" id="avatar" name="avatar">
+        </form>
+        <div id="result"></div>
+        <script>
+            document.getElementById("upload-form").addEventListener("submit", async (e) => {
+                e.preventDefault();
+                const fd = new FormData(e.target);
+                const res = await fetch(e.target.action, { method: "POST", body: fd });
+                document.getElementById("result").textContent = await res.text();
+            });
+        </script>
+        <button id="submit" onclick="document.getElementById(\'upload-form\').dispatchEvent(new Event(\'submit\'))">Send</button>
+    ');
+
+    $tempFile = tempnam(sys_get_temp_dir(), 'pest_upload_');
+    file_put_contents($tempFile, 'hello, server');
+
+    // Note: client mime type comes from the browser (FormData picks a guess
+    // based on the file extension, which is none for tempnam). Assert
+    // separately on name + size + raw content; the MIME-type assertion is
+    // skipped because it is environment-dependent.
+    visit('/form')
+        ->attach('#avatar', $tempFile)
+        ->click('#submit')
+        ->assertSee(basename($tempFile))
+        ->assertSee('13') // bytes of "hello, server"
+        ->assertSee('hello, server');
+
+    unlink($tempFile);
+});
+
+it('preserves binary file content (no UTF-8 corruption)', function (): void {
+    Route::post('/upload-binary', function (Request $request): string {
+        $file = $request->file('payload');
+        if ($file === null) {
+            return 'NO_FILE';
+        }
+
+        return bin2hex($file->getContent());
+    })->withoutMiddleware([ValidateCsrfToken::class]);
+
+    Route::get('/form-binary', fn (): string => '
+        <form id="upload-form" method="POST" action="/upload-binary" enctype="multipart/form-data">
+            <input type="file" id="payload" name="payload">
+        </form>
+        <div id="result"></div>
+        <script>
+            document.getElementById("upload-form").addEventListener("submit", async (e) => {
+                e.preventDefault();
+                const fd = new FormData(e.target);
+                const res = await fetch(e.target.action, { method: "POST", body: fd });
+                document.getElementById("result").textContent = await res.text();
+            });
+        </script>
+        <button id="submit" onclick="document.getElementById(\'upload-form\').dispatchEvent(new Event(\'submit\'))">Send</button>
+    ');
+
+    // Bytes that would corrupt under mb_* string operations: 0xFF, 0xFE,
+    // 0xC0 (invalid UTF-8 lead byte), 0x00 (null), 0x0A (LF), 0x0D (CR).
+    $binary = "\xFF\xFE\xC0\x00\x0A\x0D\x80\x81";
+    $expectedHex = bin2hex($binary);
+
+    $tempFile = tempnam(sys_get_temp_dir(), 'pest_binary_');
+    file_put_contents($tempFile, $binary);
+
+    visit('/form-binary')
+        ->attach('#payload', $tempFile)
+        ->click('#submit')
+        ->assertSee($expectedHex);
+
+    unlink($tempFile);
+});
+
+it('mixes file and non-file fields in the same multipart request', function (): void {
+    Route::post('/upload-mixed', function (Request $request): string {
+        $file = $request->file('avatar');
+        $note = $request->input('note');
+
+        return sprintf(
+            'file=%s note=%s',
+            $file !== null ? $file->getClientOriginalName() : 'NULL',
+            $note ?? 'NULL',
+        );
+    })->withoutMiddleware([ValidateCsrfToken::class]);
+
+    Route::get('/form-mixed', fn (): string => '
+        <form id="upload-form" method="POST" action="/upload-mixed" enctype="multipart/form-data">
+            <input type="text" id="note" name="note" value="">
+            <input type="file" id="avatar" name="avatar">
+        </form>
+        <div id="result"></div>
+        <script>
+            document.getElementById("upload-form").addEventListener("submit", async (e) => {
+                e.preventDefault();
+                const fd = new FormData(e.target);
+                const res = await fetch(e.target.action, { method: "POST", body: fd });
+                document.getElementById("result").textContent = await res.text();
+            });
+        </script>
+        <button id="submit" onclick="document.getElementById(\'upload-form\').dispatchEvent(new Event(\'submit\'))">Send</button>
+    ');
+
+    $tempFile = tempnam(sys_get_temp_dir(), 'pest_mixed_');
+    file_put_contents($tempFile, 'x');
+
+    visit('/form-mixed')
+        ->fill('#note', 'remember-me')
+        ->attach('#avatar', $tempFile)
+        ->click('#submit')
+        ->assertSee('remember-me')
+        ->assertSee(basename($tempFile));
+
+    unlink($tempFile);
+});


### PR DESCRIPTION
## Summary

`LaravelHttpServer::handleRequest()` was passing `[]` to the `$files` argument of `Symfony\Component\HttpFoundation\Request::create()` with a `// @TODO files...` placeholder. This means: any browser test that drives a real `<input type=file>` through Playwright (`$page->attach(...)`) has the file written to the input and the `change` event fires correctly, **but the Laravel kernel never sees the file** — `$request->file('avatar')` returns null and `$request->allFiles()` is empty.

The existing `tests/Browser/Webpage/AttachTest.php` only asserts on `document.querySelector("input[name=avatar]").files[0].name` (client-side DOM), which masked the gap: from a contributor's POV the API looks complete because the test passes, but no real Laravel upload pipeline can actually be exercised end-to-end.

## What this PR does

1. **Implements `parseMultipartBody()`** in `LaravelHttpServer`. It is invoked when the request `Content-Type` starts with `multipart/form-data`. The parser:
   - Extracts the boundary from the Content-Type header.
   - Splits the body **byte-safe** (plain `explode`/`substr`/`strpos`, never `mb_*`) so binary uploads — .xlsx, .zip, images, PDFs — survive without UTF-8 corruption.
   - For each part, parses `Content-Disposition` to extract the field name and optional `filename=`.
   - File parts are written to `tempnam(sys_get_temp_dir(), 'pest_browser_upload_')` and wrapped in `Symfony\Component\HttpFoundation\File\UploadedFile` constructed with `$test: true` — Symfony then skips `is_uploaded_file()`, which only returns true for real SAPI uploads.
   - Non-file parts populate `$parameters` (so `$request->input('note')` works alongside `$request->file('avatar')`).
   - Bracket notation (`tags[]`, `user[name]`, `files[0]`) is honored by delegating to `parse_str()` via `http_build_query()`; `UploadedFile` instances are injected into the parsed structure after the round-trip (since `parse_str()` only preserves scalars).

2. **Wires the result into `Request::create()`** — replaces the `[], // @TODO files...` call site with the parsed `$files` array. `multipart/form-data` is now a recognized branch alongside the existing `application/x-www-form-urlencoded` parsing.

3. **Adds `tests/Browser/Webpage/AttachServerSideTest.php`** — three tests that close the gap:
   - `forwards a single uploaded file to the Laravel request` — name + size + raw content visible server-side after `attach() + submit`.
   - `preserves binary file content (no UTF-8 corruption)` — bytes including `0xFF`, `0xFE`, `0xC0`, `0x00`, `0x0A`, `0x0D` survive intact; regression guard against any future `mb_*` usage in the parser.
   - `mixes file and non-file fields in the same multipart request` — `$request->file('avatar')` and `$request->input('note')` both populated from the same POST.

   These tests use `fetch()` for the form submit because they need to display the server's response in the same page (for `assertSee` to work); the underlying multipart upload pipeline is identical to a native form submit.

## Real-world motivation

Filament v4 FileUpload (which wraps FilePond) + Livewire's batch upload pipeline could not be tested with this plugin because Livewire's `_finishUpload($name, $tmpPath = [], false)` received an empty array and threw `Undefined array key 0` in `WithFileUploads.php:49`. After investigation, the FilePond JS bridge correctly POSTs the multipart payload — the server just dropped the file before the Laravel kernel ran. This patch makes that pipeline testable end-to-end.

## Test plan

- [x] `vendor/bin/pest tests/Browser/Webpage/AttachServerSideTest.php` — 3 new tests pass.
- [x] `vendor/bin/pest tests/Browser/Webpage/AttachTest.php` — existing tests still pass (no regression).
- [x] `vendor/bin/pest tests/Browser/` — full suite: 239 passed, 1 skipped (platform-specific, unrelated), 0 failed.
- [ ] CI on this PR.

## Notes

- The temp files written under `sys_get_temp_dir()` are not actively cleaned up by this patch. Symfony's `UploadedFile` is constructed in test mode (`$test: true`) so move/store operations work normally; the OS reclaims `/tmp` on reboot, and individual test runs are short-lived. If you'd prefer explicit cleanup tied to the request lifecycle, happy to add it.
- `parseMultipartBody()` aims for correctness with the common shapes (`name`, `name[]`, `name[key]`, `name[0]`) rather than the exhaustive RFC 7578 surface (e.g. `multipart/mixed` for arrays). Same scope as PHP's built-in SAPI parser for `$_FILES`. Happy to extend if needed.