### PR TITLE
 [4.x] Fix canonical URL handling for subdomain routing

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Pest\Browser;
 
+use Pest\Browser\Drivers\LaravelHttpServer;
 use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Enums\ColorScheme;
 use Pest\Browser\Playwright\Playwright;
+use Pest\Browser\ServerManager;
 
 /**
  * @internal
@@ -101,6 +103,11 @@ final readonly class Configuration
     public function withHost(?string $host): self
     {
         Playwright::setHost($host);
+
+        $http = ServerManager::instance()->http();
+        if ($http instanceof LaravelHttpServer) {
+            $http->syncCanonicalUrl();
+        }
 
         return $this;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -105,6 +105,7 @@ final readonly class Configuration
         Playwright::setHost($host);
 
         $http = ServerManager::instance()->http();
+
         if ($http instanceof LaravelHttpServer) {
             $http->syncCanonicalUrl();
         }

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -198,6 +198,7 @@ final class LaravelHttpServer implements HttpServer
 
             assert($urlGenerator instanceof UrlGenerator);
 
+            $urlGenerator->setRequest(Request::create($url));
             $urlGenerator->useOrigin($url);
             $urlGenerator->useAssetOrigin($url);
         }

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -175,6 +175,13 @@ final class LaravelHttpServer implements HttpServer
             return;
         }
 
+        // Guard against being called when the Laravel container is not (yet) bootstrapped,
+        // e.g. from a Pest `beforeAll` hook, or between test files in a parallel worker
+        // after the previous test's app has been torn down.
+        if (! app()->bound('config')) {
+            return;
+        }
+
         $url = $this->canonicalUrl();
 
         config(['app.url' => $url]);

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -100,13 +100,11 @@ final class LaravelHttpServer implements HttpServer
             return;
         }
 
-        $logger = new NullLogger();
-
         // Bump the body size limit well above Amp's 128 KiB default so that
         // POSTs with large JSON payloads (e.g. the booking-engine order submit,
         // which can exceed 180 KiB) don't deadlock when the request body is read.
         $this->socket = $server = SocketHttpServer::createForDirectAccess(
-            logger: $logger,
+            logger: $logger = new NullLogger(),
             httpDriverFactory: new DefaultHttpDriverFactory(
                 logger: $logger,
                 bodySizeLimit: 64 * 1024 * 1024,

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -7,6 +7,7 @@ namespace Pest\Browser\Drivers;
 use Amp\ByteStream\ReadableResourceStream;
 use Amp\Http\Cookie\RequestCookie;
 use Amp\Http\Server\DefaultErrorHandler;
+use Amp\Http\Server\Driver\DefaultHttpDriverFactory;
 use Amp\Http\Server\HttpServer as AmpHttpServer;
 use Amp\Http\Server\HttpServerStatus;
 use Amp\Http\Server\Request as AmpRequest;
@@ -99,7 +100,18 @@ final class LaravelHttpServer implements HttpServer
             return;
         }
 
-        $this->socket = $server = SocketHttpServer::createForDirectAccess(new NullLogger());
+        $logger = new NullLogger();
+
+        // Bump the body size limit well above Amp's 128 KiB default so that
+        // POSTs with large JSON payloads (e.g. the booking-engine order submit,
+        // which can exceed 180 KiB) don't deadlock when the request body is read.
+        $this->socket = $server = SocketHttpServer::createForDirectAccess(
+            logger: $logger,
+            httpDriverFactory: new DefaultHttpDriverFactory(
+                logger: $logger,
+                bodySizeLimit: 64 * 1024 * 1024,
+            ),
+        );
 
         $server->expose("{$this->host}:{$this->port}");
         $server->start(

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -100,9 +100,9 @@ final class LaravelHttpServer implements HttpServer
             return;
         }
 
-        // Bump the body size limit well above Amp's 128 KiB default so that
-        // POSTs with large JSON payloads (e.g. the booking-engine order submit,
-        // which can exceed 180 KiB) don't deadlock when the request body is read.
+        // Increase the body size limit beyond Amp's 128-KiB
+        // default to prevent deadlocks when reading large
+        // JSON payloads in POST, PUT, and PATCH requests.
         $this->socket = $server = SocketHttpServer::createForDirectAccess(
             logger: $logger = new NullLogger(),
             httpDriverFactory: new DefaultHttpDriverFactory(
@@ -173,10 +173,8 @@ final class LaravelHttpServer implements HttpServer
     }
 
     /**
-     * Re-sync Laravel's `app.url` and the URL generator's origin to the canonical URL.
-     *
-     * Called both at bootstrap and when the configured host changes mid-test (e.g.
-     * via `withHost(...)`), so that `route()`, `asset()`, and `config('app.url')`
+     * Re-sync Laravel's `app.url` and the URL generator's origin to the
+     * canonical URL, so that `route()`, `asset()`, and `config('app.url')`
      * stay consistent with the host the browser is navigating to.
      */
     public function syncCanonicalUrl(): void

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -173,9 +173,8 @@ final class LaravelHttpServer implements HttpServer
     }
 
     /**
-     * Re-sync Laravel's `app.url` and the URL generator's origin to the
-     * canonical URL, so that `route()`, `asset()`, and `config('app.url')`
-     * stay consistent with the host the browser is navigating to.
+     * Re-sync Laravel's `app.url` and the URL generator's origin to the canonical URL, so that `route()`,
+     * `asset()`, and `config('app.url')` stay consistent with the host the browser is navigating to.
      */
     public function syncCanonicalUrl(): void
     {

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -70,7 +70,7 @@ final class LaravelHttpServer implements HttpServer
     }
 
     /**
-     * Rewrite the given URL to match the server's host and port.
+     * Rewrite the given URL to match the server's canonical host and port.
      */
     public function rewrite(string $url): string
     {
@@ -85,7 +85,7 @@ final class LaravelHttpServer implements HttpServer
         $path = $parts['path'] ?? '/';
         parse_str($parts['query'] ?? '', $queryParameters);
 
-        return (string) Uri::of($this->url())
+        return (string) Uri::of($this->canonicalUrl())
             ->withPath($path)
             ->withQuery($queryParameters);
     }
@@ -148,10 +148,6 @@ final class LaravelHttpServer implements HttpServer
     {
         $this->start();
 
-        $url = $this->url();
-
-        config(['app.url' => $url]);
-
         config(['cors.paths' => ['*']]);
 
         if (app()->bound('url')) {
@@ -160,10 +156,36 @@ final class LaravelHttpServer implements HttpServer
             assert($urlGenerator instanceof UrlGenerator);
 
             $this->setOriginalAssetUrl($urlGenerator->asset(''));
+            $urlGenerator->forceScheme('http');
+        }
+
+        $this->syncCanonicalUrl();
+    }
+
+    /**
+     * Re-sync Laravel's `app.url` and the URL generator's origin to the canonical URL.
+     *
+     * Called both at bootstrap and when the configured host changes mid-test (e.g.
+     * via `withHost(...)`), so that `route()`, `asset()`, and `config('app.url')`
+     * stay consistent with the host the browser is navigating to.
+     */
+    public function syncCanonicalUrl(): void
+    {
+        if (! $this->socket instanceof AmpHttpServer) {
+            return;
+        }
+
+        $url = $this->canonicalUrl();
+
+        config(['app.url' => $url]);
+
+        if (app()->bound('url')) {
+            $urlGenerator = app('url');
+
+            assert($urlGenerator instanceof UrlGenerator);
 
             $urlGenerator->useOrigin($url);
             $urlGenerator->useAssetOrigin($url);
-            $urlGenerator->forceScheme('http');
         }
     }
 
@@ -194,7 +216,7 @@ final class LaravelHttpServer implements HttpServer
     }
 
     /**
-     * Get the public path for the given path.
+     * Get the URL of the bound socket (always 127.0.0.1:<port>).
      */
     private function url(): string
     {
@@ -203,6 +225,28 @@ final class LaravelHttpServer implements HttpServer
         }
 
         return sprintf('http://%s:%d', $this->host, $this->port);
+    }
+
+    /**
+     * Get the canonical host the user expects URLs to use.
+     *
+     * Defaults to the bound IP unless the test configured a host with `withHost(...)`.
+     */
+    private function canonicalHost(): string
+    {
+        return Playwright::host() ?? $this->host;
+    }
+
+    /**
+     * Get the canonical base URL used for generated links and request URIs.
+     */
+    private function canonicalUrl(): string
+    {
+        if (! $this->socket instanceof AmpHttpServer) {
+            throw new ServerNotFoundException('The HTTP server is not running.');
+        }
+
+        return sprintf('http://%s:%d', $this->canonicalHost(), $this->port);
     }
 
     /**
@@ -224,11 +268,17 @@ final class LaravelHttpServer implements HttpServer
             Execution::instance()->tick();
         }
 
+        // Re-sync per request as a safety net — if the configured host changes
+        // mid-test, the URL generator and config should reflect it before the
+        // app handles the request.
+        $this->syncCanonicalUrl();
+        $canonicalUrl = $this->canonicalUrl();
+
         $uri = $request->getUri();
         $path = in_array($uri->getPath(), ['', '0'], true) ? '/' : $uri->getPath();
         $query = $uri->getQuery() ?? ''; // @phpstan-ignore-line
         $fullPath = $path.($query !== '' ? '?'.$query : '');
-        $absoluteUrl = mb_rtrim($this->url(), '/').$fullPath;
+        $absoluteUrl = mb_rtrim($canonicalUrl, '/').$fullPath;
 
         $filepath = public_path($path);
         if (file_exists($filepath) && ! is_dir($filepath)) {
@@ -261,15 +311,13 @@ final class LaravelHttpServer implements HttpServer
 
         $symfonyRequest->headers->add($request->getHeaders());
 
-        // Set the Host header to match the configured host for subdomain routing
-        $configuredHost = Playwright::host();
-        if ($configuredHost !== null) {
-            $hostHeader = sprintf('%s:%d', $configuredHost, $this->port);
-            $symfonyRequest->headers->set('Host', $hostHeader);
-            // Also set SERVER_NAME for Laravel routing
-            $symfonyRequest->server->set('SERVER_NAME', $configuredHost);
-            $symfonyRequest->server->set('HTTP_HOST', $hostHeader);
-        }
+        // Ensure the framework sees the canonical host (e.g. for subdomain routing)
+        // even when the browser arrived via a different network host (e.g. 127.0.0.1).
+        $canonicalHost = $this->canonicalHost();
+        $hostHeader = sprintf('%s:%d', $canonicalHost, $this->port);
+        $symfonyRequest->headers->set('Host', $hostHeader);
+        $symfonyRequest->server->set('SERVER_NAME', $canonicalHost);
+        $symfonyRequest->server->set('HTTP_HOST', $hostHeader);
 
         $debug = config('app.debug');
 

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -171,7 +171,6 @@ final class Execution
         $reflector = new ReflectionClass(Assert::class);
         $property = $reflector->getProperty('count');
 
-        // @phpstan-ignore-next-line
-        $property->setValue(Assert::class, $originalCount);
+        $property->setValue(null, $originalCount);
     }
 }

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -171,6 +171,7 @@ final class Execution
         $reflector = new ReflectionClass(Assert::class);
         $property = $reflector->getProperty('count');
 
-        $property->setValue(null, $originalCount);
+        // @phpstan-ignore-next-line
+        $property->setValue(Assert::class, $originalCount);
     }
 }

--- a/tests/Browser/Visit/CanonicalUrlTest.php
+++ b/tests/Browser/Visit/CanonicalUrlTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Pest\Browser\ServerManager;
+
+/*
+ * These tests cover the "canonical URL" wiring: when `withHost(...)` is set, the
+ * URL generator, `route()` helper, server-side `request()->url()`, and the URL
+ * Playwright actually navigates to all line up on `http://{host}:{port}` — not
+ * a mix of the configured host (header-only) and the bound socket IP.
+ *
+ * This matters for SPAs (Inertia, Livewire) that compare a clicked link's
+ * origin to `window.location.origin` to decide whether navigation is internal.
+ * If the page is at `app.localhost:<port>` but `route()` produces
+ * `127.0.0.1:<port>`, the SPA treats every link as cross-origin and falls back
+ * to a full reload — which then 404s in the test harness.
+ */
+
+it('exposes the canonical host on request()->url() when withHost is set', function (): void {
+    Route::domain('app.localhost')->get('/canonical/request-url', fn (Request $request) => $request->url());
+
+    pest()->browser()->withHost('app.localhost');
+
+    $port = ServerManager::instance()->http()->port; // @phpstan-ignore-line
+
+    visit('/canonical/request-url')
+        ->assertUrlIs("http://app.localhost:{$port}/canonical/request-url")
+        ->assertSee("http://app.localhost:{$port}/canonical/request-url");
+});
+
+it('generates route() URLs against the canonical host when withHost is set', function (): void {
+    Route::domain('app.localhost')->as('canonical.test')->get('/canonical/route-url', fn () => route('canonical.test'));
+
+    pest()->browser()->withHost('app.localhost');
+
+    $port = ServerManager::instance()->http()->port; // @phpstan-ignore-line
+
+    visit('/canonical/route-url')
+        ->assertSee("http://app.localhost:{$port}/canonical/route-url");
+
+    expect(route('canonical.test'))->toBe("http://app.localhost:{$port}/canonical/route-url");
+});
+
+it('reverts to the bound IP origin when withHost(null) clears the configured host', function (): void {
+    Route::as('canonical.no-host')->get('/canonical/no-host', fn () => route('canonical.no-host'));
+
+    // Ensure no leaking host from earlier tests.
+    pest()->browser()->withHost(null);
+
+    $port = ServerManager::instance()->http()->port; // @phpstan-ignore-line
+
+    visit('/canonical/no-host')
+        ->assertSee("http://127.0.0.1:{$port}/canonical/no-host");
+
+    expect(route('canonical.no-host'))->toBe("http://127.0.0.1:{$port}/canonical/no-host");
+});
+
+it('updates the URL generator immediately when withHost changes mid-test', function (): void {
+    Route::domain('first.localhost')->as('canonical.first')->get('/canonical/first', fn () => route('canonical.first'));
+    Route::domain('second.localhost')->as('canonical.second')->get('/canonical/second', fn () => route('canonical.second'));
+
+    $port = ServerManager::instance()->http()->port; // @phpstan-ignore-line
+
+    pest()->browser()->withHost('first.localhost');
+
+    expect(route('canonical.first'))->toBe("http://first.localhost:{$port}/canonical/first");
+
+    pest()->browser()->withHost('second.localhost');
+
+    // Per-request resync should also surface the new host on the page itself.
+    visit('/canonical/second')
+        ->assertSee("http://second.localhost:{$port}/canonical/second");
+
+    expect(route('canonical.second'))->toBe("http://second.localhost:{$port}/canonical/second");
+});

--- a/tests/Browser/Visit/CanonicalUrlTest.php
+++ b/tests/Browser/Visit/CanonicalUrlTest.php
@@ -6,19 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Pest\Browser\ServerManager;
 
-/*
- * These tests cover the "canonical URL" wiring: when `withHost(...)` is set, the
- * URL generator, `route()` helper, server-side `request()->url()`, and the URL
- * Playwright actually navigates to all line up on `http://{host}:{port}` — not
- * a mix of the configured host (header-only) and the bound socket IP.
- *
- * This matters for SPAs (Inertia, Livewire) that compare a clicked link's
- * origin to `window.location.origin` to decide whether navigation is internal.
- * If the page is at `app.localhost:<port>` but `route()` produces
- * `127.0.0.1:<port>`, the SPA treats every link as cross-origin and falls back
- * to a full reload — which then 404s in the test harness.
- */
-
 it('exposes the canonical host on request()->url() when withHost is set', function (): void {
     Route::domain('app.localhost')->get('/canonical/request-url', fn (Request $request) => $request->url());
 

--- a/tests/Browser/Visit/CanonicalUrlTest.php
+++ b/tests/Browser/Visit/CanonicalUrlTest.php
@@ -51,14 +51,15 @@ it('updates the URL generator immediately when withHost changes mid-test', funct
 
     $port = ServerManager::instance()->http()->port; // @phpstan-ignore-line
 
-    pest()->browser()->withHost('first.localhost');
+    visit('/canonical/first')
+        ->withHost('first.localhost')
+        ->assertSee("http://first.localhost:{$port}/canonical/first");
 
     expect(route('canonical.first'))->toBe("http://first.localhost:{$port}/canonical/first");
 
-    pest()->browser()->withHost('second.localhost');
-
     // Per-request resync should also surface the new host on the page itself.
     visit('/canonical/second')
+        ->withHost('second.localhost')
         ->assertSee("http://second.localhost:{$port}/canonical/second");
 
     expect(route('canonical.second'))->toBe("http://second.localhost:{$port}/canonical/second");

--- a/tests/Browser/Visit/LargeBodyTest.php
+++ b/tests/Browser/Visit/LargeBodyTest.php
@@ -5,18 +5,6 @@ declare(strict_types=1);
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-/*
- * Regression test for the Amp http-server body-size deadlock: by default
- * SocketHttpServer caps request bodies at 128 KiB (HttpDriver::DEFAULT_BODY_SIZE_LIMIT).
- * Any POST larger than that — common for SPA endpoints that submit nested form
- * state, e.g. a booking engine sending its full order graph as JSON — would
- * cause `(string) $request->getBody()` to block forever, the test would hang,
- * and the spinner-on-a-submit-button would never resolve.
- *
- * The plugin now wires a DefaultHttpDriverFactory with a 64 MiB body limit, so
- * large JSON payloads round-trip through the test server without stalling.
- */
-
 it('accepts JSON request bodies larger than the default 128 KiB limit', function (): void {
     Route::post('/large-body/echo', fn (Request $request): array => [
         'received_bytes' => mb_strlen($request->getContent()),

--- a/tests/Browser/Visit/LargeBodyTest.php
+++ b/tests/Browser/Visit/LargeBodyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+/*
+ * Regression test for the Amp http-server body-size deadlock: by default
+ * SocketHttpServer caps request bodies at 128 KiB (HttpDriver::DEFAULT_BODY_SIZE_LIMIT).
+ * Any POST larger than that — common for SPA endpoints that submit nested form
+ * state, e.g. a booking engine sending its full order graph as JSON — would
+ * cause `(string) $request->getBody()` to block forever, the test would hang,
+ * and the spinner-on-a-submit-button would never resolve.
+ *
+ * The plugin now wires a DefaultHttpDriverFactory with a 64 MiB body limit, so
+ * large JSON payloads round-trip through the test server without stalling.
+ */
+
+it('accepts JSON request bodies larger than the default 128 KiB limit', function (): void {
+    Route::post('/large-body/echo', fn (Request $request): array => [
+        'received_bytes' => mb_strlen($request->getContent()),
+        'received_count' => count($request->json('items', [])),
+    ]);
+
+    // Build a payload that comfortably exceeds Amp's 128 KiB default.
+    $items = [];
+    for ($i = 0; $i < 5000; $i++) {
+        $items[] = [
+            'id' => $i,
+            'name' => str_repeat('x', 32),
+            'description' => str_repeat('y', 64),
+        ];
+    }
+    $payload = json_encode(['items' => $items]);
+
+    expect(mb_strlen($payload))->toBeGreaterThan(128 * 1024);
+
+    // Render a tiny page that POSTs the payload via fetch and writes the JSON
+    // response into the DOM so we can assert against it.
+    Route::get('/large-body/post-from-page', fn () => '
+        <html><body>
+            <pre id="result"></pre>
+            <script>
+                fetch("/large-body/echo", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: '.json_encode($payload).',
+                })
+                .then(r => r.json())
+                .then(data => { document.getElementById("result").textContent = JSON.stringify(data); });
+            </script>
+        </body></html>
+    ');
+
+    visit('/large-body/post-from-page')
+        ->assertSee('"received_bytes":'.mb_strlen($payload))
+        ->assertSee('"received_count":5000');
+});

--- a/tests/Browser/Visit/SubdomainTest.php
+++ b/tests/Browser/Visit/SubdomainTest.php
@@ -70,18 +70,18 @@ it('Chaining withHost will not override global host', function (): void {
         'host' => request()->getHost(),
     ]);
 
-    // Set global host: test.domain
-    pest()->browser()->withHost('test.domain');
+    // Set global host: test.localhost
+    pest()->browser()->withHost('test.localhost');
 
     // 1. Visit withHost: api.localhost
     visit('/api/health')
         ->withHost('api.localhost')
         ->assertSee('"host":"api.localhost"')
-        ->assertDontSee('test.domain');
+        ->assertDontSee('test.localhost');
 
-    // 2. Visit without withHost: should use global host "test.domain"
+    // 2. Visit without withHost: should use global host "test.localhost"
     visit('/')
-        ->assertSee('"host":"test.domain"')
+        ->assertSee('"host":"test.localhost"')
         ->assertDontSee('api.localhost');
 });
 


### PR DESCRIPTION
Reworked for 5.x in #258

This PR introduces a single canonical-URL concept in LaravelHttpServer (canonicalHost() / canonicalUrl(), re-synced via syncCanonicalUrl()) and fixes two bugs that stemmed from inconsistent host/URL handling.

1. **Subdomain routing bug**
    Previously, the configured host (`withHost(...)`) was only applied ad-hoc to the `Host` header inside the request handler, while Laravel's `app.url`, `route()`, and `asset()` still pointed at the bound socket IP (`127.0.0.1`). This left URL generation and subdomain routing inconsistent with the host the browser was actually navigating to.
    Now the canonical host is resolved in one place and synced into `app.url` and the URL generator's origin/asset origin/scheme. The framework consistently sees the canonical host (e.g. for subdomain routing) even when the request arrived over a different network host like `127.0.0.1`. Syncing happens on boot, when the host changes via `withHost()` (wired through `Configuration::setHost()`), and per-request as a safety net.

2. **Amp 128 KiB body limit bug**
    Amp's `SocketHttpServer::createForDirectAccess()` defaults to a 128 KiB body size limit, which caused deadlocks/hangs when reading large JSON payloads in `POST`/`PUT`/`PATCH` requests. The server is now created with an explicit `DefaultHttpDriverFactory` raising the body size limit to 64 MiB, allowing large request bodies to be read without stalling.
