### PR TITLE
Add configurable screenshot directory

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,7 @@ namespace Pest\Browser;
 use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Enums\ColorScheme;
 use Pest\Browser\Playwright\Playwright;
+use Pest\Browser\Support\Screenshot;
 
 /**
  * @internal
@@ -91,6 +92,16 @@ final readonly class Configuration
     public function userAgent(string $userAgent): self
     {
         Playwright::setUserAgent($userAgent);
+
+        return $this;
+    }
+
+    /**
+     * Sets the screenshots directory.
+     */
+    public function screenshots(string $dir): self
+    {
+        Screenshot::useDirectory($dir);
 
         return $this;
     }

--- a/src/Support/Screenshot.php
+++ b/src/Support/Screenshot.php
@@ -12,10 +12,27 @@ use Pest\TestSuite;
 final class Screenshot
 {
     /**
+     * The path to the screenshots' directory.
+     */
+    private static ?string $dir = null;
+
+    /**
+     * Set the path to the screenshots' directory.
+     */
+    public static function useDirectory(string $dir): void
+    {
+        self::$dir = $dir;
+    }
+
+    /**
      * Return the path to the screenshots' directory.
      */
     public static function dir(): string
     {
+        if (self::$dir !== null) {
+            return self::$dir;
+        }
+
         return TestSuite::getInstance()->rootPath
             .'/tests/Browser/Screenshots';
     }

--- a/tests/Unit/Configuration/HostConfigurationTest.php
+++ b/tests/Unit/Configuration/HostConfigurationTest.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 
 use Pest\Browser\Configuration;
 use Pest\Browser\Playwright\Playwright;
+use Pest\Browser\Support\Screenshot;
+
+function resetConfigurationScreenshotDir(): void
+{
+    $property = new ReflectionProperty(Screenshot::class, 'dir');
+    $property->setValue(null, null);
+}
 
 beforeEach(function (): void {
     // Reset Playwright state before each test
     Playwright::setHost(null);
+    resetConfigurationScreenshotDir();
+});
+
+afterEach(function (): void {
+    resetConfigurationScreenshotDir();
 });
 
 it('can set host via configuration', function (): void {
@@ -29,6 +41,16 @@ it('follows fluent interface pattern', function (): void {
 
     expect($result)->toBeInstanceOf(Configuration::class);
     expect(Playwright::host())->toBe('app.localhost');
+});
+
+it('can set screenshots directory via configuration', function (): void {
+    $config = new Configuration();
+    $dir = sys_get_temp_dir().'/pest-browser-configuration-'.uniqid('', true);
+
+    $result = $config->screenshots($dir);
+
+    expect($result)->toBeInstanceOf(Configuration::class)
+        ->and(Screenshot::dir())->toBe($dir);
 });
 
 it('stores host in Playwright global state', function (): void {

--- a/tests/Unit/Support/ScreenshotTest.php
+++ b/tests/Unit/Support/ScreenshotTest.php
@@ -3,6 +3,70 @@
 declare(strict_types=1);
 
 use Pest\Browser\Support\Screenshot;
+use Pest\TestSuite;
+
+function resetScreenshotDir(): void
+{
+    $property = new ReflectionProperty(Screenshot::class, 'dir');
+    $property->setValue(null, null);
+}
+
+function screenshotTestDir(string $name): string
+{
+    return sys_get_temp_dir().'/pest-browser-'.$name.'-'.uniqid('', true);
+}
+
+beforeEach(function (): void {
+    resetScreenshotDir();
+});
+
+afterEach(function (): void {
+    Screenshot::cleanup();
+    resetScreenshotDir();
+});
+
+it('uses the default screenshots directory', function (): void {
+    expect(Screenshot::dir())->toBe(TestSuite::getInstance()->rootPath.'/tests/Browser/Screenshots');
+});
+
+it('uses a configured screenshots directory', function (): void {
+    $dir = screenshotTestDir('configured');
+
+    Screenshot::useDirectory($dir);
+
+    expect(Screenshot::dir())->toBe($dir);
+});
+
+it('builds screenshot paths from the configured directory', function (): void {
+    $dir = screenshotTestDir('path');
+
+    Screenshot::useDirectory($dir);
+
+    expect(Screenshot::path('foo'))->toBe($dir.'/foo.png');
+});
+
+it('cleans up only the configured screenshots directory', function (): void {
+    $parent = screenshotTestDir('cleanup');
+    $dir = $parent.'/Screenshots';
+    $sharedFile = $parent.'/shared.txt';
+
+    mkdir($dir.'/Sliders', 0755, true);
+    mkdir($dir.'/ImageDiffView', 0755, true);
+    file_put_contents($dir.'/screenshot.png', 'screenshot');
+    file_put_contents($dir.'/Sliders/slider.png', 'slider');
+    file_put_contents($dir.'/ImageDiffView/diff.html', 'diff');
+    file_put_contents($sharedFile, 'shared');
+
+    Screenshot::useDirectory($dir);
+    Screenshot::cleanup();
+
+    expect(is_dir($dir))->toBeFalse()
+        ->and(is_dir($parent))->toBeTrue()
+        ->and(file_exists($sharedFile))->toBeTrue();
+
+    @unlink($sharedFile);
+    @rmdir($parent);
+});
 
 it('places screenshots under tests/Browser/screenshots', function (): void {
     Screenshot::save('asdf', 'test-screenshot.png');


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Allow browser screenshots to be written to a custom directory.

The default location is unchanged, but projects can now configure the screenshot path with `pest()->browser()->screenshots($dir)`.

This is useful when running more than one test process at the same time, for example when multiple AI agents are running browser tests and would otherwise overwrite each other's screenshots.

Usage:

```php
$someId = "xyz";

$screenshotDirectory = dirname(__DIR__) . '/tests/Browser/Screenshots/' . $someId;

pest()->browser()->screenshots($screenshotDirectory);
```

### Related:

- Resolves pestphp/pest#1724