### PR TITLE
feat: add slow-motion support to ease debugging

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -86,6 +86,16 @@ final readonly class Configuration
     }
 
     /**
+     * Slows down each browser action by the given number of milliseconds.
+     */
+    public function slowMo(int $milliseconds = Playwright::DEFAULT_SLOW_MO): self
+    {
+        Playwright::setSlowMo($milliseconds);
+
+        return $this;
+    }
+
+    /**
      * Sets the browsers userAgent.
      */
     public function userAgent(string $userAgent): self

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -53,6 +53,7 @@ final class Client
 
             $launchOptions = json_encode([
                 'headless' => Playwright::isHeadless(),
+                'slowMo' => Playwright::slowMo(),
                 'ignoreHTTPSErrors' => true,
                 'bypassCSP' => true,
             ]);

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -13,6 +13,12 @@ use Pest\Browser\Enums\ColorScheme;
 final class Playwright
 {
     /**
+     * The default slow-motion delay, in milliseconds, used when `--slow-mo` is
+     * passed without a value.
+     */
+    public const int DEFAULT_SLOW_MO = 500;
+
+    /**
      * Browser types
      *
      * @var array<string, BrowserFactory>
@@ -48,6 +54,11 @@ final class Playwright
      * The timeout in milliseconds.
      */
     private static int $timeout = 5_000;
+
+    /**
+     * The delay, in milliseconds, applied before each browser action.
+     */
+    private static int $slowMo = 0;
 
     /**
      * The default userAgent.
@@ -129,6 +140,22 @@ final class Playwright
     public static function timeout(): int
     {
         return self::$timeout;
+    }
+
+    /**
+     * Set the delay, in milliseconds, applied before each browser action.
+     */
+    public static function setSlowMo(int $milliseconds): void
+    {
+        self::$slowMo = $milliseconds;
+    }
+
+    /**
+     * Get the delay, in milliseconds, applied before each browser action.
+     */
+    public static function slowMo(): int
+    {
+        return self::$slowMo;
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -118,6 +118,24 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
             $arguments = array_values($arguments);
         }
 
+        if ($this->hasArgument('--slow-mo', $arguments)) {
+            $index = array_search('--slow-mo', $arguments, true);
+
+            // `--slow-mo` may be passed bare (uses a sensible default) or with an
+            // explicit millisecond value: `--slow-mo 250`.
+            if ($index !== false && isset($arguments[$index + 1]) && is_numeric($arguments[$index + 1])) {
+                Playwright::setSlowMo((int) $arguments[$index + 1]);
+
+                unset($arguments[$index], $arguments[$index + 1]);
+            } else {
+                Playwright::setSlowMo(Playwright::DEFAULT_SLOW_MO);
+
+                unset($arguments[$index]);
+            }
+
+            $arguments = array_values($arguments);
+        }
+
         $this->validateNonSupportedParallelFeatures();
 
         return $arguments;

--- a/tests/Unit/Configuration/SlowMoConfigurationTest.php
+++ b/tests/Unit/Configuration/SlowMoConfigurationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Configuration;
+use Pest\Browser\Playwright\Playwright;
+
+beforeEach(function (): void {
+    // Reset Playwright state before each test
+    Playwright::setSlowMo(0);
+});
+
+it('defaults slow motion to zero', function (): void {
+    expect(Playwright::slowMo())->toBe(0);
+});
+
+it('can set slow motion via configuration', function (): void {
+    $config = new Configuration();
+
+    $result = $config->slowMo(250);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::slowMo())->toBe(250);
+});
+
+it('uses a sensible default when no value is given', function (): void {
+    $config = new Configuration();
+
+    $config->slowMo();
+
+    expect(Playwright::slowMo())->toBe(Playwright::DEFAULT_SLOW_MO);
+});
+
+it('follows fluent interface pattern', function (): void {
+    $config = new Configuration();
+
+    $result = $config
+        ->slowMo(500)
+        ->timeout(10000);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::slowMo())->toBe(500);
+});
+
+it('stores slow motion in Playwright global state', function (): void {
+    expect(Playwright::slowMo())->toBe(0);
+
+    Playwright::setSlowMo(1000);
+
+    expect(Playwright::slowMo())->toBe(1000);
+});


### PR DESCRIPTION
## Why / Background

When you run the browser tests with `--debug` it goes a bit too fast for you to really see what is going on or where things break. Playwright supports this with their --slow-mo option that adds a delay between each action so that you can follow what is happening in the browser. There is no way to pass that down to playwright through this plugin, and that is what this PR adds. 

## What

Adds an optional delay before each browser action, mapped to Playwright's slowMo launch option:

- CLI: `--slow-mo` (defaults to 500ms) or `--slow-mo <ms>` for an explicit delay
- Config: `pest()->browser()->slowMo()` / `->slowMo($ms)`

slowMo defaults to 0 (no delay), so the launch options are unchanged when unused.

