### PR TITLE
Allow attaching multiple files to an input with `attach`

### DIFF
--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -176,7 +176,7 @@ trait InteractsWithElements
     }
 
     /**
-     * Attach the given file to the field.
+     * Attach the given files to the field.
      */
     public function attach(string $field, string|array $path): self
     {

--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -178,7 +178,7 @@ trait InteractsWithElements
     /**
      * Attach the given file to the field.
      */
-    public function attach(string $field, string $path): self
+    public function attach(string $field, string|array $path): self
     {
         $this->guessLocator($field)->setInputFiles($path);
 

--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -177,6 +177,8 @@ trait InteractsWithElements
 
     /**
      * Attach the given files to the field.
+     *
+     * @param  string|array<string>  $path
      */
     public function attach(string $field, string|array $path): self
     {

--- a/src/Playwright/Locator.php
+++ b/src/Playwright/Locator.php
@@ -651,6 +651,8 @@ final readonly class Locator
 
     /**
      * Set input files for a file input element.
+     *
+     * @param  string|array<string>  $path
      */
     public function setInputFiles(string|array $path): void
     {

--- a/src/Playwright/Locator.php
+++ b/src/Playwright/Locator.php
@@ -652,9 +652,9 @@ final readonly class Locator
     /**
      * Set input files for a file input element.
      */
-    public function setInputFiles(string $path): void
+    public function setInputFiles(string|array $path): void
     {
-        $params = ['localPaths' => [$path]];
+        $params = ['localPaths' => is_array($path) ? $path : [$path]];
         $response = $this->sendMessage('setInputFiles', $params);
 
         $this->processVoidResponse($response);

--- a/tests/Browser/Webpage/AttachTest.php
+++ b/tests/Browser/Webpage/AttachTest.php
@@ -47,3 +47,33 @@ it('may attach a file to a file input using an id selector', function (): void {
     // Clean up
     unlink($tempFile);
 });
+
+it('may attach multiple files to a file input', function (): void {
+    Route::get('/', fn (): string => '
+        <form>
+            <input type="file" id="avatar" name="avatar" multiple>
+        </form>
+    ');
+
+    $page = visit('/');
+
+    // Create temporary files
+    $tempFiles = [
+        tempnam(sys_get_temp_dir(), 'test'),
+        tempnam(sys_get_temp_dir(), 'test'),
+    ];
+    file_put_contents($tempFiles[0], 'test content 1');
+    file_put_contents($tempFiles[1], 'test content 2');
+
+    $page->attach('avatar', $tempFiles);
+
+    // Check that the files are attached
+    $fileNames = array_map(fn ($file) => basename($file), $tempFiles);
+    expect($page->script('() => document.querySelector("input[name=avatar]").files.length'))->toBe(count($tempFiles));
+    expect($page->script('() => document.querySelector("input[name=avatar]").files.map(file => file.name)'))->toBe($fileNames);
+
+    // Clean up
+    foreach ($tempFiles as $tempFile) {
+        unlink($tempFile);
+    }
+});


### PR DESCRIPTION
I was testing a multi file upload and realized that Playwright supports multiple files, this plugin is just only exposing it as a single file. 

The change is straight forward, just a non breaking contract change and a manual array wrap. 