### PR TITLE
feat: allow passing options to click() and press()

### DIFF
--- a/src/Api/Concerns/InteractsWithElements.php
+++ b/src/Api/Concerns/InteractsWithElements.php
@@ -13,10 +13,12 @@ trait InteractsWithElements
 {
     /**
      * Click the link with the given text.
+     *
+     * @param  array<string, mixed>|null  $options
      */
-    public function click(string $text): self
+    public function click(string $text, ?array $options = null): self
     {
-        $this->guessLocator($text)->click();
+        $this->guessLocator($text)->click($options);
 
         return $this;
     }
@@ -187,10 +189,12 @@ trait InteractsWithElements
 
     /**
      * Press the button with the given text or name.
+     *
+     * @param  array<string, mixed>|null  $options
      */
-    public function press(string $button): self
+    public function press(string $button, ?array $options = null): self
     {
-        return $this->click($button);
+        return $this->click($button, $options);
     }
 
     /**

--- a/tests/Browser/Webpage/ClickTest.php
+++ b/tests/Browser/Webpage/ClickTest.php
@@ -73,3 +73,19 @@ it('can click elements via exact match css selectors', function (string $selecto
     '[name$="test"]',
     'button[name="test"]',
 ]);
+
+it('forwards options to the underlying click', function (): void {
+    Route::get('/', fn (): string => '
+        <button oncontextmenu="event.preventDefault(); document.getElementById(\'result\').textContent = \'Right Clicked\'">Menu</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/');
+
+    // A left click would never fire the contextmenu handler, so this proves the
+    // `button` option reaches the underlying Playwright locator. The motivating
+    // use case is passing `noWaitAfter` for clicks that trigger a navigation.
+    $page->click('Menu', ['button' => 'right']);
+
+    expect($page->text('#result'))->toBe('Right Clicked');
+});

--- a/tests/Browser/Webpage/PressTest.php
+++ b/tests/Browser/Webpage/PressTest.php
@@ -91,3 +91,16 @@ it('may press an input button by data test attribute', function (): void {
 
     expect($page->text('#result'))->toBe('Input Button Pressed');
 });
+
+it('forwards options to the underlying press', function (): void {
+    Route::get('/', fn (): string => '
+        <button oncontextmenu="event.preventDefault(); document.getElementById(\'result\').textContent = \'Right Pressed\'">Submit</button>
+        <div id="result"></div>
+    ');
+
+    $page = visit('/');
+
+    $page->press('Submit', ['button' => 'right']);
+
+    expect($page->text('#result'))->toBe('Right Pressed');
+});


### PR DESCRIPTION
## Description

`click()` and `press()` currently call the underlying Playwright locator with no options, so there's no way to pass locator options such as `noWaitAfter`, `timeout`, `position`, or `button`.

This adds an optional `?array $options = null` parameter to both, forwarded straight through to the locator's `click()`:

```php
$page->press('Submit', ['noWaitAfter' => true])
    ->assertPathIs('/next-page');
```

## Motivation

The main driver is `noWaitAfter` for actions that trigger a navigation. Today a `click()`/`press()` that navigates can hang until the timeout on pages whose load doesn't settle quickly (e.g. Livewire/SPA pages that fire a request after the `load` event) — see pestphp/pest#1511. `noWaitAfter` lets the action dispatch without blocking on the navigation to settle; a following `assertPathIs`/`assertSee` (still retried) then confirms the result. This is a narrow, opt-in option rather than a change to the global retry behavior.

## Tests

Added forwarding tests for both `click` and `press` — they pass `['button' => 'right']` and assert a `contextmenu` handler fired, which a plain click would not trigger, proving the option reaches the locator. Existing click/press tests are unchanged.

- `composer lint` (pint + rector), `phpstan`, and 100% type-coverage pass
- browser tests pass
