### PR TITLE
Flush `scoped()` container bindings between requests in `LaravelHttpServer`

### DIFF
--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -273,6 +273,10 @@ final class LaravelHttpServer implements HttpServer
 
         $debug = config('app.debug');
 
+        // This server reuses one container across a test's requests, so scoped() bindings must be
+        // released per request (as FPM and Octane do) — otherwise they leak like singletons.
+        app()->forgetScopedInstances();
+
         try {
             config(['app.debug' => false]);
 

--- a/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
+++ b/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
@@ -36,3 +36,17 @@ it('includes server variables set in the test', function (): void {
     visit('/server-variables')
         ->assertSee('"test-server-key":"test value"');
 });
+
+it('flushes scoped container bindings between requests', function (): void {
+    // A scoped() binding is released only by Application::forgetScopedInstances(). Since this
+    // server reuses one container across a test's requests, it must flush per request — otherwise
+    // the instance resolved in the first request leaks into the second (and would behave like a
+    // singleton), unlike FPM or Octane. Each request renders the resolved object's id; they differ.
+    app()->scoped('scoped-probe', fn (): object => new stdClass);
+    Route::get('/scoped-probe', fn (): string => spl_object_hash(app('scoped-probe')));
+
+    $first = visit('/scoped-probe')->content();
+    $second = visit('/scoped-probe')->content();
+
+    expect($first)->not->toBe($second);
+});


### PR DESCRIPTION
## Problem

`LaravelHttpServer` serves every request of a browser test from one long-lived container — it calls `$kernel->handle()` / `$kernel->terminate()` per request, but never `$app->forgetScopedInstances()`. Since `scoped()` bindings are only released by that call, a `scoped()` service resolved in one request survives into the next and behaves like a `singleton()`.

Every other Laravel runtime releases them per unit of work:

- **FPM** builds a fresh container per request;
- **Octane** flushes scoped instances between requests;
- even the framework's **queue worker** does it between jobs (`Illuminate\Queue\QueueServiceProvider` calls `$app->forgetScopedInstances()`).

The in-process test server is the only place where a `scoped()` service leaks — so browser tests exercise a lifetime that exists in no production runtime.

## Impact

Symptoms look like flaky, order-dependent tests rather than a container issue, and bite hardest right after an auth change mid-test (login, logout, impersonation): the request after taking an impersonation can resolve the *previous* user's cached, request-scoped context service and act on the wrong user/team. The failure is silent and only surfaces once an app registers a `scoped()` binding.

## Change

Flush scoped instances at the start of each request, before `$kernel->handle()`, mirroring Octane:

```php
app()->forgetScopedInstances();
```

One line, no API change, and a no-op for apps without `scoped()` bindings.

## Test

Added to `tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php`: register a `scoped()` binding, `visit()` a route that renders the resolved object's hash twice, assert the two differ. Fails on `4.x` without the change (same instance returned), passes with it.

---

Targeted at `4.x`; if `5.x` already flushes here, this is only needed for the 4.x line.
