### PR TITLE
Add playwright routes support

### DIFF
--- a/src/Api/Concerns/HasRoutes.php
+++ b/src/Api/Concerns/HasRoutes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Pest\Browser\Api\Webpage;
+use Pest\Browser\Playwright\Route;
+
+/**
+ * @mixin Webpage
+ */
+trait HasRoutes
+{
+    /**
+     * @param  callable(Route): bool  $handler
+     */
+    public function route(
+        string $pattern,
+        callable $handler,
+    ): void {
+        $this->page->context()->setNetworkInterceptionPatterns([
+            'patterns' => [
+                [
+                    'glob' => $pattern,
+                ],
+            ],
+        ]);
+        Route::registerRouteHandler($pattern, $handler);
+    }
+}

--- a/src/Api/Concerns/HasRoutes.php
+++ b/src/Api/Concerns/HasRoutes.php
@@ -19,6 +19,7 @@ trait HasRoutes
         string $pattern,
         callable $handler,
     ): void {
+        Route::registerRouteHandler($pattern, $handler);
         $this->page->context()->setNetworkInterceptionPatterns([
             'patterns' => [
                 [
@@ -26,6 +27,5 @@ trait HasRoutes
                 ],
             ],
         ]);
-        Route::registerRouteHandler($pattern, $handler);
     }
 }

--- a/src/Api/From.php
+++ b/src/Api/From.php
@@ -23,7 +23,7 @@ final readonly class From
         private Device $device,
         private string $url,
         private array $options,
-        private readonly array $routes,
+        private array $routes,
     ) {
         //
     }

--- a/src/Api/From.php
+++ b/src/Api/From.php
@@ -23,6 +23,7 @@ final readonly class From
         private Device $device,
         private string $url,
         private array $options,
+        private readonly array $routes,
     ) {
         //
     }
@@ -141,6 +142,7 @@ final readonly class From
             $this->device,
             $this->url,
             $this->options,
+            $this->routes,
         ))
             ->geolocation($city->geolocation()['latitude'], $city->geolocation()['longitude'])
             ->withTimezone($city->timezone())

--- a/src/Api/On.php
+++ b/src/Api/On.php
@@ -22,6 +22,7 @@ final readonly class On
         private Device $device,
         private string $url,
         private array $options,
+        private readonly array $routes,
     ) {
         //
     }
@@ -39,6 +40,7 @@ final readonly class On
             $this->device,
             $this->url,
             $this->options,
+            $this->routes,
         ))->{$name}(...$arguments);
     }
 
@@ -52,6 +54,7 @@ final readonly class On
             Device::DESKTOP,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -65,6 +68,7 @@ final readonly class On
             Device::MOBILE,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -78,6 +82,7 @@ final readonly class On
             Device::MACBOOK_16,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -91,6 +96,7 @@ final readonly class On
             Device::MACBOOK_14,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -104,6 +110,7 @@ final readonly class On
             Device::MACBOOK_AIR,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -117,6 +124,7 @@ final readonly class On
             Device::IPHONE_15_PRO,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -130,6 +138,7 @@ final readonly class On
             Device::IPHONE_15,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -143,6 +152,7 @@ final readonly class On
             Device::IPHONE_14_PRO,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -156,6 +166,7 @@ final readonly class On
             Device::IPHONE_SE,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -169,6 +180,7 @@ final readonly class On
             Device::IPAD_PRO,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -182,6 +194,7 @@ final readonly class On
             Device::IPAD_MINI,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -195,6 +208,7 @@ final readonly class On
             Device::PIXEL_8,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -208,6 +222,7 @@ final readonly class On
             Device::PIXEL_7,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -221,6 +236,7 @@ final readonly class On
             Device::PIXEL_6A,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -234,6 +250,7 @@ final readonly class On
             Device::GALAXY_S24_ULTRA,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -247,6 +264,7 @@ final readonly class On
             Device::GALAXY_S23,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -260,6 +278,7 @@ final readonly class On
             Device::GALAXY_S22,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -273,6 +292,7 @@ final readonly class On
             Device::GALAXY_NOTE_20,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -286,6 +306,7 @@ final readonly class On
             Device::GALAXY_TAB_S8,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -299,6 +320,7 @@ final readonly class On
             Device::SURFACE_PRO_9,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -312,6 +334,7 @@ final readonly class On
             Device::SURFACE_LAPTOP_5,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -325,6 +348,7 @@ final readonly class On
             Device::ONEPLUS_11,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -337,7 +361,8 @@ final readonly class On
             $this->browserType,
             Device::XIAOMI_13,
             $this->url,
-            $this->options
+            $this->options,
+            $this->routes,
         );
     }
 
@@ -351,6 +376,7 @@ final readonly class On
             Device::HUAWEI_P50,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 }

--- a/src/Api/On.php
+++ b/src/Api/On.php
@@ -22,7 +22,7 @@ final readonly class On
         private Device $device,
         private string $url,
         private array $options,
-        private readonly array $routes,
+        private array $routes,
     ) {
         //
     }

--- a/src/Api/PendingAwaitablePage.php
+++ b/src/Api/PendingAwaitablePage.php
@@ -31,6 +31,7 @@ final class PendingAwaitablePage
         private readonly Device $device,
         private readonly string $url,
         private readonly array $options,
+        private readonly array $routes = [],
     ) {
         //
     }
@@ -49,6 +50,23 @@ final class PendingAwaitablePage
     }
 
     /**
+     * @param  callable(Route): bool  $handler
+     */
+    public function withRoute(string $pattern, callable $handler): self
+    {
+        return new self(
+            $this->browserType,
+            $this->device,
+            $this->url,
+            $this->options,
+            [
+                ...$this->routes,
+                $pattern => $handler,
+            ],
+        );
+    }
+
+    /**
      * Sets the color scheme to dark mode.
      */
     public function inDarkMode(): self
@@ -56,7 +74,7 @@ final class PendingAwaitablePage
         return new self($this->browserType, $this->device, $this->url, [
             'colorScheme' => ColorScheme::DARK->value,
             ...$this->options,
-        ]);
+        ], $this->routes);
     }
 
     /**
@@ -67,7 +85,7 @@ final class PendingAwaitablePage
         return new self($this->browserType, $this->device, $this->url, [
             'colorScheme' => ColorScheme::LIGHT->value,
             ...$this->options,
-        ]);
+        ], $this->routes);
     }
 
     /**
@@ -80,6 +98,7 @@ final class PendingAwaitablePage
             $this->device,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -93,6 +112,7 @@ final class PendingAwaitablePage
             $this->device,
             $this->url,
             $this->options,
+            $this->routes,
         );
     }
 
@@ -104,7 +124,7 @@ final class PendingAwaitablePage
         return new self($this->browserType, $this->device, $this->url, [
             'locale' => $locale,
             ...$this->options,
-        ]);
+        ], $this->routes);
     }
 
     /**
@@ -115,7 +135,7 @@ final class PendingAwaitablePage
         return new self($this->browserType, $this->device, $this->url, [
             'userAgent' => $userAgent,
             ...$this->options,
-        ]);
+        ], $this->routes);
     }
 
     /**
@@ -126,7 +146,7 @@ final class PendingAwaitablePage
         return new self($this->browserType, $this->device, $this->url, [
             'host' => $host,
             ...$this->options,
-        ]);
+        ], $this->routes);
     }
 
     /**
@@ -137,7 +157,7 @@ final class PendingAwaitablePage
         return new self($this->browserType, $this->device, $this->url, [
             'timezoneId' => $timezone,
             ...$this->options,
-        ]);
+        ], $this->routes);
     }
 
     /**
@@ -151,7 +171,7 @@ final class PendingAwaitablePage
             'geolocation' => $geolocation,
             'permissions' => ['geolocation'],
             ...$this->options,
-        ]);
+        ], $this->routes);
     }
 
     /**
@@ -184,10 +204,18 @@ final class PendingAwaitablePage
 
         $url = ComputeUrl::from($this->url);
 
-        return new AwaitableWebpage(
-            $context->newPage()->goto($url, $options),
+        $awaitableWebPage = new AwaitableWebpage(
+            $context->newPage(),
             $url,
         );
+
+        foreach ($this->routes as $pattern => $handler) {
+            $awaitableWebPage->route($pattern, $handler);
+        }
+
+        $awaitableWebPage->page()->goto($url, $options);
+
+        return $awaitableWebPage;
     }
 
     /**

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -11,7 +11,8 @@ use Pest\Browser\Support\GuessLocator;
 
 final readonly class Webpage
 {
-    use Concerns\HasWaitCapabilities,
+    use Concerns\HasRoutes,
+        Concerns\HasWaitCapabilities,
         Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
         Concerns\InteractsWithScreen,

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -101,6 +101,22 @@ final class Client
                 throw new ExpectationFailedException($message);
             }
 
+            if (
+                isset($response['method']) && $response['method'] === '__create__'
+                && isset($response['params']['type'])
+            ) {
+                if ($response['params']['type'] === 'Request') {
+                    Request::register(Request::fromArray($response['params']));
+
+                    continue;
+                }
+                if ($response['params']['type'] === 'Route') {
+                    Route::handle(Route::fromArray($response['params']));
+
+                    continue;
+                }
+            }
+
             yield $response;
 
             if (
@@ -110,6 +126,30 @@ final class Client
                 break;
             }
         }
+    }
+
+    /**
+     * Executes a method on the Playwright instance without expecting a response.
+     * Useful for nested execute calls which should not consume the outer loops messages.
+     *
+     * @param  array<string, mixed>  $params
+     * @param  array<string, mixed>  $meta
+     */
+    public function executeWithoutResponse(string $guid, string $method, array $params = [], array $meta = []): void
+    {
+        assert($this->websocketConnection instanceof WebsocketConnection, 'WebSocket client is not connected.');
+
+        $requestId = uniqid();
+
+        $requestJson = (string) json_encode([
+            'id' => $requestId,
+            'guid' => $guid,
+            'method' => $method,
+            'params' => ['timeout' => $this->timeout, ...$params],
+            'metadata' => $meta,
+        ]);
+
+        $this->websocketConnection->sendText($requestJson);
     }
 
     /**

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -61,6 +61,16 @@ final class Context
     }
 
     /**
+     * Sets network interception patterns
+     */
+    public function setNetworkInterceptionPatterns($options): void
+    {
+        $response = $this->sendMessage('setNetworkInterceptionPatterns', $options);
+
+        $this->processVoidResponse($response);
+    }
+
+    /**
      * Closes the browser context.
      */
     public function close(): void

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -63,7 +63,7 @@ final class Context
     /**
      * Sets network interception patterns
      */
-    public function setNetworkInterceptionPatterns($options): void
+    public function setNetworkInterceptionPatterns(array $options): void
     {
         $response = $this->sendMessage('setNetworkInterceptionPatterns', $options);
 

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -192,12 +192,12 @@ final class Playwright
      */
     public static function reset(): void
     {
-        Request::reset();
-        Route::reset();
-
         foreach (self::$browserTypes as $browserType) {
             $browserType->reset();
         }
+
+        Request::reset();
+        Route::reset();
     }
 
     /**

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -192,6 +192,9 @@ final class Playwright
      */
     public static function reset(): void
     {
+        Request::reset();
+        Route::reset();
+
         foreach (self::$browserTypes as $browserType) {
             $browserType->reset();
         }

--- a/src/Playwright/Request.php
+++ b/src/Playwright/Request.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Playwright;
+
+final class Request
+{
+    /**
+     * All requests indexed by guid
+     *
+     * @var array<string, Request>
+     * */
+    private static array $requests = [];
+
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function __construct(
+        public string $guid,
+        public string $frameGuid,
+        public string $url,
+        public string $resourceType,
+        public string $method,
+        public array $headers,
+        public bool $isNavigationRequest,
+    ) {}
+
+    public static function fromArray(array $params): self
+    {
+        $headers = [];
+        foreach ($params['initializer']['headers'] as $header) {
+            $headers[$header['name']] = $header['value'];
+        }
+
+        return new self(
+            $params['guid'],
+            frameGuid: $params['initializer']['frame']['guid'],
+            url: $params['initializer']['url'],
+            resourceType: $params['initializer']['resourceType'],
+            method: $params['initializer']['method'],
+            headers: $headers,
+            isNavigationRequest: $params['initializer']['isNavigationRequest'],
+        );
+    }
+
+    public static function register(self $request): void
+    {
+        self::$requests[$request->guid] = $request;
+    }
+
+    public static function get(string $guid): self
+    {
+        return self::$requests[$guid];
+    }
+
+    public static function reset(): void
+    {
+        self::$requests = [];
+    }
+
+    public function header(string $name): ?string
+    {
+        return $this->headers[$name] ?? null;
+    }
+
+    public function hasHeader(string $name): bool
+    {
+        return isset($this->headers[$name]);
+    }
+}

--- a/src/Playwright/Route.php
+++ b/src/Playwright/Route.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Playwright;
+
+use RuntimeException;
+
+final class Route
+{
+    use Concerns\InteractsWithPlaywright;
+
+    /**
+     * All requests indexed by guid
+     *
+     * @var array<string, callable(Route)>
+     * */
+    private static array $handlers = [];
+
+    public function __construct(
+        private readonly string $guid,
+        private readonly Request $request
+    ) {}
+
+    public static function fromArray(array $params): self
+    {
+        return new self($params['guid'], Request::get($params['initializer']['request']['guid']));
+    }
+
+    /**
+     * @param  callable(Route): bool  $handler
+     */
+    public static function registerRouteHandler(string $pattern, callable $handler): void
+    {
+        self::$handlers[self::regexFromPattern($pattern)] = $handler;
+    }
+
+    public static function handle(self $route): void
+    {
+        foreach (self::$handlers as $regex => $handler) {
+            if (preg_match($regex, $route->request()->url) === 1) {
+                $handler($route);
+
+                return;
+            }
+        }
+        throw new RuntimeException(
+            sprintf('No route handler matched "%s".', $route->request()->url)
+        );
+    }
+
+    public static function regexFromPattern(string $pattern): string
+    {
+        // Escape regex characters.
+        $regex = preg_quote($pattern, '/');
+
+        // Replace escaped globs with regex equivalents.
+        $regex = str_replace('\*\*', '.*', $regex);      // ** => anything
+        $regex = str_replace('\*', '[^\/]*', $regex);     // * => anything except /
+
+        return '/^'.$regex.'$/';
+    }
+
+    public static function reset(): void
+    {
+        self::$handlers = [];
+    }
+
+    public function request(): Request
+    {
+        return $this->request;
+    }
+
+    public function continue(array $params = ['isFallback' => true]): void
+    {
+        // Since this is called nested withing execute we don't want it to consume an actual response
+        Client::instance()->executeWithoutResponse($this->guid, 'continue', $params);
+    }
+
+    public function abort(array $params = []): void
+    {
+        // Since this is called nested withing execute we don't want it to consume an actual response
+        Client::instance()->executeWithoutResponse($this->guid, 'abort', $params);
+    }
+
+    public function fulfill(array $params = []): void
+    {
+        // Since this is called nested withing execute we don't want it to consume an actual response
+        Client::instance()->executeWithoutResponse($this->guid, 'fulfill', $params);
+    }
+}

--- a/tests/Browser/Webpage/RoutesTest.php
+++ b/tests/Browser/Webpage/RoutesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Pest\Browser\Playwright\Route as PlaywrightRoute;
+
+it('may continue a request', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            fetch("/message")
+                .then(response => response.text())
+                .then(message => document.body.textContent = message)
+                .catch(() => document.body.textContent = "aborted");
+        </script>
+    ');
+
+    Route::get('/message', fn (): string => 'continued');
+
+    $page = visit('/')->withRoute('**/message', fn (PlaywrightRoute $route) => $route->continue());
+
+    $page->assertSee('continued');
+    $page->assertDontSee('aborted');
+    $page->assertDontSee('fulfilled');
+});
+
+it('may abort a request', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            fetch("/message")
+                .then(response => response.text())
+                .then(message => document.body.textContent = message)
+                .catch(() => document.body.textContent = "aborted");
+        </script>
+    ');
+
+    Route::get('/message', fn (): string => 'continued');
+
+    $page = visit('/')->withRoute('**/message', fn (PlaywrightRoute $route) => $route->abort());
+
+    $page->assertDontSee('continued');
+    $page->assertSee('aborted');
+    $page->assertDontSee('fulfilled');
+});
+
+it('may fulfill a request', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            fetch("/message")
+                .then(response => response.text())
+                .then(message => document.body.textContent = message)
+                .catch(() => document.body.textContent = "aborted");
+        </script>
+    ');
+
+    Route::get('/message', fn (): string => 'continued');
+
+    $page = visit('/')->withRoute('**/message', fn (PlaywrightRoute $route) => $route->fulfill([
+        'status' => 200,
+        'body' => 'fulfilled',
+    ]));
+
+    $page->assertDontSee('continued');
+    $page->assertDontSee('aborted');
+    $page->assertSee('fulfilled');
+});


### PR DESCRIPTION
This pull request adds routes to pest-plugin-browser with minimal changes to the current code. Use with

`visit('/')->withRoute('**/message', fn (PlaywrightRoute $route) => $route->continue());`

or

`$page->route('**/*', fn (PlaywrightRoute $route) => $route->abort());`

Currently supported methods are continue, abort and fulfill