### PR TITLE
fix: attach() is broken with Playwright 1.61.0 and above

### DIFF
--- a/src/Exceptions/FileNotReadableException.php
+++ b/src/Exceptions/FileNotReadableException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Exceptions;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class FileNotReadableException extends RuntimeException
+{
+    //
+}

--- a/src/Exceptions/FileTooLargeException.php
+++ b/src/Exceptions/FileTooLargeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Exceptions;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class FileTooLargeException extends RuntimeException
+{
+    //
+}

--- a/src/Playwright/Locator.php
+++ b/src/Playwright/Locator.php
@@ -6,6 +6,7 @@ namespace Pest\Browser\Playwright;
 
 use Generator;
 use Pest\Browser\Playwright\Concerns\InteractsWithPlaywright;
+use Pest\Browser\Support\FilePayload;
 use Pest\Browser\Support\Selector;
 use RuntimeException;
 
@@ -651,10 +652,13 @@ final readonly class Locator
 
     /**
      * Set input files for a file input element.
+     *
+     * The file is sent by value rather than by path, as Playwright 1.61.0
+     * and above reject `localPaths` for websocket clients.
      */
     public function setInputFiles(string $path): void
     {
-        $params = ['localPaths' => [$path]];
+        $params = ['payloads' => [FilePayload::fromPath($path)->toArray()]];
         $response = $this->sendMessage('setInputFiles', $params);
 
         $this->processVoidResponse($response);

--- a/src/Support/FilePayload.php
+++ b/src/Support/FilePayload.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Support;
+
+use Pest\Browser\Exceptions\FileNotReadableException;
+use Pest\Browser\Exceptions\FileTooLargeException;
+use Symfony\Component\Mime\MimeTypes;
+
+/**
+ * A file to be uploaded, expressed as an inline Playwright payload.
+ *
+ * Playwright 1.61.0 and above refuse `localPaths` unless the client is
+ * collocated with the server, a flag only set by the in-process and stdio
+ * drivers — never by `run-server`. As this plugin always connects over a
+ * websocket, files are sent by value instead of by path.
+ *
+ * @internal
+ */
+final readonly class FilePayload
+{
+    /**
+     * The largest buffer Playwright accepts for an inline payload.
+     */
+    private const int MAX_SIZE_IN_BYTES = 50 * 1024 * 1024;
+
+    /**
+     * The MIME type used when the extension cannot be mapped to a known type.
+     */
+    private const string FALLBACK_MIME_TYPE = 'application/octet-stream';
+
+    /**
+     * Creates a new file payload instance.
+     */
+    private function __construct(
+        private string $name,
+        private string $mimeType,
+        private string $contents,
+    ) {
+        //
+    }
+
+    /**
+     * Create a payload from the file at the given path.
+     */
+    public static function fromPath(string $path): self
+    {
+        if (! is_file($path) || ! is_readable($path)) {
+            throw new FileNotReadableException("The file [{$path}] does not exist or is not readable.");
+        }
+
+        $size = filesize($path);
+
+        if ($size === false) {
+            throw new FileNotReadableException("The size of the file [{$path}] could not be determined.");
+        }
+
+        if ($size > self::MAX_SIZE_IN_BYTES) {
+            throw new FileTooLargeException(
+                "The file [{$path}] exceeds the maximum upload size of 50 MB supported by Playwright."
+            );
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            throw new FileNotReadableException("The file [{$path}] could not be read.");
+        }
+
+        return new self(basename($path), self::guessMimeType($path), $contents);
+    }
+
+    /**
+     * Return the payload in the shape expected by the Playwright protocol.
+     *
+     * The `buffer` field is typed as binary by the protocol, which is
+     * base64 over the JSON channel.
+     *
+     * @return array{name: string, mimeType: string, buffer: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'mimeType' => $this->mimeType,
+            'buffer' => base64_encode($this->contents),
+        ];
+    }
+
+    /**
+     * Guess the MIME type of the file from its extension.
+     */
+    private static function guessMimeType(string $path): string
+    {
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+
+        if ($extension === '') {
+            return self::FALLBACK_MIME_TYPE;
+        }
+
+        $mimeTypes = (new MimeTypes())->getMimeTypes($extension);
+
+        return $mimeTypes[0] ?? self::FALLBACK_MIME_TYPE;
+    }
+}

--- a/tests/Unit/Support/FilePayloadTest.php
+++ b/tests/Unit/Support/FilePayloadTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Exceptions\FileNotReadableException;
+use Pest\Browser\Exceptions\FileTooLargeException;
+use Pest\Browser\Support\FilePayload;
+
+/**
+ * Create a temporary file with the given contents and extension.
+ */
+function temporaryFile(string $contents, string $extension = ''): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'pest_payload');
+
+    if ($extension !== '') {
+        unlink($path);
+        $path .= '.'.$extension;
+    }
+
+    file_put_contents($path, $contents);
+
+    return $path;
+}
+
+test('sends the file by value instead of by path', function (): void {
+    $path = temporaryFile('hello world', 'txt');
+
+    $payload = FilePayload::fromPath($path)->toArray();
+
+    expect($payload)->toHaveKeys(['name', 'mimeType', 'buffer'])
+        ->and($payload)->not->toHaveKey('localPaths')
+        ->and($payload['buffer'])->not->toBe($path);
+
+    unlink($path);
+});
+
+test('encodes the buffer as base64', function (): void {
+    $path = temporaryFile('hello world', 'txt');
+
+    $payload = FilePayload::fromPath($path)->toArray();
+
+    expect($payload['buffer'])->toBe(base64_encode('hello world'))
+        ->and(base64_decode($payload['buffer'], true))->toBe('hello world');
+
+    unlink($path);
+});
+
+test('preserves binary contents without corruption', function (): void {
+    $contents = '';
+    for ($byte = 0; $byte < 256; $byte++) {
+        $contents .= pack('C', $byte);
+    }
+    $contents .= "\x00\xC3\x28\xFF\xFE invalid utf-8 \r\n ";
+
+    $path = temporaryFile($contents, 'bin');
+
+    $payload = FilePayload::fromPath($path)->toArray();
+    $decoded = (string) base64_decode($payload['buffer'], true);
+
+    expect(hash('sha256', $decoded))->toBe(hash('sha256', $contents))
+        ->and($decoded)->toBe($contents);
+
+    unlink($path);
+});
+
+test('uses the file name rather than the full path', function (): void {
+    $path = temporaryFile('contents', 'txt');
+
+    expect(FilePayload::fromPath($path)->toArray()['name'])->toBe(basename($path));
+
+    unlink($path);
+});
+
+test('guesses the mime type from the extension', function (): void {
+    $path = temporaryFile('{}', 'json');
+
+    expect(FilePayload::fromPath($path)->toArray()['mimeType'])->toBe('application/json');
+
+    unlink($path);
+});
+
+test('falls back to a generic mime type for unknown extensions', function (): void {
+    $path = temporaryFile('contents', 'unknownext');
+
+    expect(FilePayload::fromPath($path)->toArray()['mimeType'])->toBe('application/octet-stream');
+
+    unlink($path);
+});
+
+test('falls back to a generic mime type when there is no extension', function (): void {
+    $path = temporaryFile('contents');
+
+    expect(FilePayload::fromPath($path)->toArray()['mimeType'])->toBe('application/octet-stream');
+
+    unlink($path);
+});
+
+test('fails when the file does not exist', function (): void {
+    FilePayload::fromPath('/this/path/does/not/exist.txt');
+})->throws(FileNotReadableException::class);
+
+test('fails when the path is a directory', function (): void {
+    FilePayload::fromPath(sys_get_temp_dir());
+})->throws(FileNotReadableException::class);
+
+test('fails when the file exceeds the playwright payload limit', function (): void {
+    $path = temporaryFile('');
+
+    $handle = fopen($path, 'wb');
+    fseek($handle, 50 * 1024 * 1024);
+    fwrite($handle, 'x');
+    fclose($handle);
+
+    try {
+        expect(fn (): array => FilePayload::fromPath($path)->toArray())
+            ->toThrow(FileTooLargeException::class);
+    } finally {
+        unlink($path);
+    }
+});


### PR DESCRIPTION
## Problem

`attach()` fails on Playwright 1.61.0 and above:

```
localPaths are not allowed when the client is not local
```

`Locator::setInputFiles()` sends the attached file's *local path*:

```php
$params = ['localPaths' => [$path]];
```

Playwright 1.61.0 added a server-side guard in [`fileUploadUtils.ts`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/fileUploadUtils.ts):

```ts
if (localPaths && !frame.attribution.playwright.options.isClientCollocatedWithServer)
  throw new Error('localPaths are not allowed when the client is not local');
```

`isClientCollocatedWithServer: true` is set **only** by `inprocess.ts` and `cli/driver.ts` (stdio). Every server path — `createPlaywright({ isServer: true })` — leaves it falsy. This plugin drives `playwright run-server` over a websocket, so the flag is never set and `localPaths` is rejected **always** — regardless of machine, filesystem or host. It is not a remote-only edge case.

### Reproducing it in this repository

`package.json` pins `^1.59.1`, and 1.59.1/1.60.0 have neither the flag nor the error string — which is why `tests/Browser/Webpage/AttachTest.php` is currently green. Installing the version the caret already permits is enough to break it:

```
npm i -D playwright@1.61.1
vendor/bin/pest tests/Browser/Webpage/AttachTest.php
```

```
FAILED  Tests\Browser\Webpage\AttachTest > it may attach a file to a file input
  localPaths are not allowed when the client is not local
FAILED  Tests\Browser\Webpage\AttachTest > it may attach a file to a file input using an id selector
  localPaths are not allowed when the client is not local

Tests: 2 failed
```

With this patch, both pass again on 1.61.1.

## What this changes

Files are sent **by value** via Playwright's inline `payloads` parameter, which is accepted regardless of how the client is connected — so this fixes the 1.61 guard and works on older versions unchanged.

Two details that matter:

- **`buffer` is base64.** The protocol types it as `binary`, which over the JSON channel means base64 — the same convention this plugin already relies on when *decoding* screenshots in `Support\Screenshot::save()`. Sending raw bytes would corrupt binary uploads.
- **`mimeType` is populated** from the file extension via `Symfony\Component\Mime\MimeTypes` (already a dependency, already used in `LaravelHttpServer`). Omitted, Playwright falls back to `application/octet-stream` and the application sees a different MIME type than the user attached.

Playwright caps inline payloads at 50 MB. Exceeding it previously surfaced as an opaque protocol error; it now throws `FileTooLargeException` naming the file and the limit. Missing or unreadable files throw `FileNotReadableException` rather than failing deeper in the protocol.

The logic lives in a small `Support\FilePayload` value object so it is directly testable, keeping `Locator` thin. `attach()`'s public signature is unchanged.

## Tests

`tests/Unit/Support/FilePayloadTest.php` — 10 tests covering the payload shape (`name`/`mimeType`/`buffer`, never `localPaths`), base64 encoding, MIME guessing and its fallbacks, and both failure modes. These are version-independent, so they hold the fix in place on the currently pinned Playwright.

The important one is **content integrity**: a file containing all 256 byte values plus invalid UTF-8 sequences and trailing whitespace round-trips with a matching SHA-256. That guards the encoding step against the same class of corruption fixed in #236.

`tests/Browser/Webpage/AttachTest.php` is unchanged and passes on both 1.59.1 and 1.61.1.

## Note: the Playwright pin

I have deliberately **not** touched `package.json` or `package-lock.json` here, but it is worth flagging: the pin is already `^1.59.1`, which admits 1.61.x. Only `package-lock.json` holds this at 1.59.1, and CI uses `npm ci` — so CI will keep passing either way and will *not* exercise the failing case above. Any contributor running a plain `npm i`, or a Dependabot lock bump, hits the break.

If you would like CI to actually cover this, the lockfile needs bumping to 1.61.x — happy to add that commit, but I did not want to fold a dependency decision into a bugfix PR.

## Note on scope — this is one of two blockers

Getting an upload all the way into a Laravel app needs a second, independent fix: `LaravelHttpServer::handleRequest()` parses only `application/x-www-form-urlencoded` and passes `[] // @TODO files...` to `Request::create()`, so a `multipart/form-data` submission arrives with neither fields nor files. **That half is already solved by #200** (approved, widely confirmed) — this PR deliberately does not duplicate it, and the two touch disjoint files (`Locator.php` vs `LaravelHttpServer.php`).

I verified the pair locally by merging this branch onto #200 and asserting that an attached file reaches `$request->file()` with matching name, size and SHA-256, alongside a sibling text field. It passes with both and fails with either alone. That end-to-end test is not included here because it would fail on `4.x` until #200 lands — happy to contribute it to #200 instead.

Related: #131 also replaces `localPaths` with a buffer, but as a side-note inside a larger feature (currently conflicting) and without base64 encoding or a MIME type. #232 (multi-file `attach()`) is orthogonal and composes with this.
