### PR TITLE
fix: detect visit() when wrapped in another function call

### DIFF
--- a/src/Support/BrowserTestIdentifier.php
+++ b/src/Support/BrowserTestIdentifier.php
@@ -92,7 +92,7 @@ final readonly class BrowserTestIdentifier
                     return true;
                 }
 
-                return $tokens[$i - 1][0] === T_WHITESPACE;
+                return $tokens[$i - 1][0] === T_WHITESPACE || $tokens[$i - 1] === '(';
             }
         }
 

--- a/tests/Unit/Support/BrowserTestIdentifierTest.php
+++ b/tests/Unit/Support/BrowserTestIdentifierTest.php
@@ -58,6 +58,24 @@ it('detects \visit() with a URL argument', function (): void {
     expect(callUsesFunction($closure, 'visit'))->toBeTrue();
 });
 
+// visit detection — wrapped in another function call
+
+it('detects visit() wrapped in another function call', function (): void {
+    $closure = function (): void {
+        acknowledgeEnvironment(visit('/'));
+    };
+
+    expect(callUsesFunction($closure, 'visit'))->toBeTrue();
+});
+
+it('detects \visit() wrapped in another function call', function (): void {
+    $closure = function (): void {
+        acknowledgeEnvironment(\visit('/'));
+    };
+
+    expect(callUsesFunction($closure, 'visit'))->toBeTrue();
+});
+
 // visit detection — Livewire
 
 it('detects Livewire::visit()', function (): void {


### PR DESCRIPTION
## Summary

`BrowserTestIdentifier::usesFunction()` requires the token immediately preceding `visit(` (or `\visit(`) to be whitespace to classify a test as a browser test:

```php
return $tokens[$i - 1][0] === T_WHITESPACE;
```

This misses the common pattern of wrapping `visit()` in another function call, e.g.:

```php
it('opens the dialog', function () {
    someHelper(visit('/'))->click('Add new')->assertSee('New item');
});
```

Here the token right before `visit` is `(`, not whitespace, so `isBrowserTest()` returns `false`. The test is then never registered as a browser test, Playwright never starts, and `visit()` still executes — failing instantly with a WebSocket-not-connected error instead of running as intended.

We hit this in production with a project-wide helper (`acknowledgeEnvironment(visit(...))` — clicks through a "testing environment" interstitial before proceeding) used across ~50 test files, all silently never running as real browser tests.

## Fix

Also accept `(` as a valid token preceding `visit`:

```php
return $tokens[$i - 1][0] === T_WHITESPACE || $tokens[$i - 1] === '(';
```

Covers both the plain and fully-qualified (`\visit(`) cases, since the fully-qualified name token check already runs before this line.

## Test plan

- [x] Added two regression cases to `tests/Unit/Support/BrowserTestIdentifierTest.php`: `visit()` and `\visit()` wrapped in another function call.
- [x] Verified via a standalone reflection-based script (existing test file's own test closures contain literal `visit(` tokens, which trips the plugin's own detector and requires a real Playwright install to execute through `pest`) that all existing cases (plain `visit()`, `\visit()`, `Livewire::visit()`, method-call `$page->visit()`, string literal, wrapped in another call) resolve correctly with this change — no regressions.