### PR TITLE
Support Laravel 12 by allowing Symfony Process 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "amphp/websocket-client": "^2.0.2",
         "pestphp/pest": "^5.0.0",
         "pestphp/pest-plugin": "^5.0.0",
-        "symfony/process": "^8.1.0"
+        "symfony/process": "^7.4.8 || ^8.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Laravel 12 requires Symfony Process `^7.2.0`, while Pest 5 currently requires Symfony Process `^8.1.0`.

This updates Pest's constraint to `^7.4.8 || ^8.1.0`, restoring Laravel 12 compatibility while retaining Symfony Process 8 support. Symfony 7.4.8 is the minimum supported version because it is required by ParaTest.

Related main repo PR: https://github.com/pestphp/pest/pull/1772