### PR TITLE
fix: bound Playwright requests so a lost or unanswered response cannot hang the suite

### DIFF
--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -81,7 +81,9 @@ final class Client
             'guid' => $guid,
             'method' => $method,
             'params' => ['timeout' => $this->timeout, ...$params],
-            'metadata' => $meta,
+            // Playwright reads the timeout from the metadata since 1.62.0, where an
+            // absent value means no timeout at all. Older servers read it from params.
+            'metadata' => ['timeout' => $this->timeout, ...$meta],
         ]);
 
         $this->websocketConnection->sendText($requestJson);

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Pest\Browser\Playwright;
 
+use Amp\Cancellation;
+use Amp\CancelledException;
+use Amp\TimeoutCancellation;
 use Amp\Websocket\Client\WebsocketConnection;
+use Amp\Websocket\WebsocketMessage;
 use Generator;
 use Pest\Browser\Exceptions\PlaywrightOutdatedException;
 use PHPUnit\Framework\ExpectationFailedException;
+use RuntimeException;
 
 use function Amp\Websocket\Client\connect;
 
@@ -30,6 +35,11 @@ final class Client
      * Default timeout for requests in milliseconds.
      */
     private int $timeout = 5_000;
+
+    /**
+     * Seconds allowed on top of the timeout before a request is given up on.
+     */
+    private float $requestGraceSeconds = 30.0;
 
     /**
      * Returns the current client instance.
@@ -88,8 +98,24 @@ final class Client
 
         $this->websocketConnection->sendText($requestJson);
 
+        $allowance = ($this->timeout / 1000) + $this->requestGraceSeconds;
+        $deadline = microtime(true) + $allowance;
+
+        // The cancellation bounds a request the server never answers, and the deadline
+        // bounds one that only ever receives unrelated messages. Neither covers both.
+        $cancellation = new TimeoutCancellation($allowance);
+
         while (true) {
-            $responseJson = $this->fetch($this->websocketConnection);
+            if (microtime(true) > $deadline) {
+                throw $this->unanswered($method, $allowance);
+            }
+
+            try {
+                $responseJson = $this->fetch($this->websocketConnection, $cancellation);
+            } catch (CancelledException) {
+                throw $this->unanswered($method, $allowance);
+            }
+
             /** @var array{id: string|null, params: array{add: string|null}, error: array{error: array{message: string|null}}} $response */
             $response = json_decode($responseJson, true);
 
@@ -131,10 +157,30 @@ final class Client
     }
 
     /**
+     * Builds the failure raised when a request is never answered.
+     */
+    private function unanswered(string $method, float $allowance): RuntimeException
+    {
+        return new RuntimeException(sprintf(
+            'The Playwright server did not answer [%s] within %.1f seconds.',
+            $method,
+            $allowance,
+        ));
+    }
+
+    /**
      * Fetches the response from the Playwright server.
      */
-    private function fetch(WebsocketConnection $client): string
+    private function fetch(WebsocketConnection $client, Cancellation $cancellation): string
     {
-        return (string) $client->receive()?->read();
+        $message = $client->receive($cancellation);
+
+        // Without this, the null returned once the connection closes casts to an empty
+        // string and leaves the caller waiting on a response that can never arrive.
+        if (! $message instanceof WebsocketMessage) {
+            throw new RuntimeException('The Playwright server closed the connection unexpectedly.');
+        }
+
+        return (string) $message->read($cancellation);
     }
 }

--- a/tests/Unit/Playwright/ClientTest.php
+++ b/tests/Unit/Playwright/ClientTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Amp\Websocket\Client\WebsocketConnection;
+use Amp\Websocket\WebsocketMessage;
+use Pest\Browser\Playwright\Client;
+
+it('sends the timeout as metadata so the server enforces it', function (): void {
+    $connection = $this->createStub(WebsocketConnection::class);
+
+    $sent = null;
+    $connection->method('sendText')->willReturnCallback(function (string $payload) use (&$sent): void {
+        $sent = json_decode($payload, true);
+    });
+
+    $connection->method('receive')->willReturnCallback(function () use (&$sent): WebsocketMessage {
+        return WebsocketMessage::fromText((string) json_encode(['id' => $sent['id']]));
+    });
+
+    $client = new Client();
+    $client->setTimeout(100);
+
+    new ReflectionProperty(Client::class, 'websocketConnection')->setValue($client, $connection);
+
+    iterator_to_array($client->execute('page@1', 'click'));
+
+    expect($sent['metadata']['timeout'])->toBe(100)
+        ->and($sent['params']['timeout'])->toBe(100);
+});

--- a/tests/Unit/Playwright/ClientTest.php
+++ b/tests/Unit/Playwright/ClientTest.php
@@ -6,6 +6,61 @@ use Amp\Websocket\Client\WebsocketConnection;
 use Amp\Websocket\WebsocketMessage;
 use Pest\Browser\Playwright\Client;
 
+it('reports a closed connection instead of looping on it', function (): void {
+    $connection = $this->createStub(WebsocketConnection::class);
+    $connection->method('receive')->willReturn(null);
+
+    $client = new Client();
+    $client->setTimeout(100);
+
+    new ReflectionProperty(Client::class, 'websocketConnection')->setValue($client, $connection);
+    new ReflectionProperty(Client::class, 'requestGraceSeconds')->setValue($client, 0.2);
+
+    expect(fn (): array => iterator_to_array($client->execute('page@1', 'goto')))
+        ->toThrow(RuntimeException::class, 'The Playwright server closed the connection unexpectedly.');
+});
+
+it('gives up on a request that only ever receives unrelated messages', function (): void {
+    $connection = $this->createStub(WebsocketConnection::class);
+    $connection->method('receive')->willReturnCallback(
+        fn (): WebsocketMessage => WebsocketMessage::fromText('{"guid":"page@1","method":"console"}')
+    );
+
+    $client = new Client();
+    $client->setTimeout(100);
+
+    new ReflectionProperty(Client::class, 'websocketConnection')->setValue($client, $connection);
+    new ReflectionProperty(Client::class, 'requestGraceSeconds')->setValue($client, 0.2);
+
+    expect(fn (): array => iterator_to_array($client->execute('page@1', 'goto')))
+        ->toThrow('The Playwright server did not answer [goto]');
+});
+
+it('returns the response matching the request id', function (): void {
+    $connection = $this->createStub(WebsocketConnection::class);
+
+    $sent = null;
+    $connection->method('sendText')->willReturnCallback(function (string $payload) use (&$sent): void {
+        $sent = json_decode($payload, true);
+    });
+
+    $connection->method('receive')->willReturnCallback(function () use (&$sent): WebsocketMessage {
+        return WebsocketMessage::fromText((string) json_encode([
+            'id' => $sent['id'],
+            'result' => ['value' => 'pong'],
+        ]));
+    });
+
+    $client = new Client();
+
+    new ReflectionProperty(Client::class, 'websocketConnection')->setValue($client, $connection);
+
+    $messages = iterator_to_array($client->execute('page@1', 'goto'));
+
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0]['result']['value'])->toBe('pong');
+});
+
 it('sends the timeout as metadata so the server enforces it', function (): void {
     $connection = $this->createStub(WebsocketConnection::class);
 


### PR DESCRIPTION
A browser suite currently has no failure mode for a request that is never answered — only a wedged process. No error, no timeout, no exit; CI runs until the job limit. This fixes three causes of that, all in `Playwright/Client.php`.

**1. Send the timeout as protocol metadata.** Playwright 1.62.0 (microsoft/playwright#41712) moved the timeout off each method's params onto the protocol-level `metadata`, where an absent value means *no timeout at all*. The client still sent it only in `params`, so every request to a 1.62.0 server was implicitly unbounded. That's why an action on a zero-match locator hangs forever there but fails cleanly on 1.61.1. Sending it in both places is backwards compatible and needs no version check.

Fixes pestphp/pest#1781.

**2. Treat a closed connection as an error.** `fetch()` coerced the `null` that `receive()` returns on a closed connection into `''`, which decodes to `null` — which has neither an `error` key to throw on nor an `id` key to break on. The loop then spins at ~100% CPU forever. This one isn't version specific; it reproduces identically on 1.61.1 and 1.62.0, and anything that drops the socket triggers it — a crashed browser, an OOM-killed server, a flaky runner.

Fixes pestphp/pest#1801.

**3. Bound the request as a whole.** Insurance against future protocol drift. Both bounds are needed and each covers the other's blind spot: the cancellation stops a request the server never answers, where `receive()` blocks forever; the deadline check stops one that keeps receiving unrelated messages, where `receive()` returns without ever suspending and the cancellation never gets scheduled. A per-message timeout bounds neither — messages keep arriving, they're just never the one being awaited.

### Verification

Stock Laravel 13 app, both Playwright versions. Reproduction repo: https://github.com/joshmanders/pest-plugin-browser-hang-repro

| playwright | client | zero-match action | connection closed mid-request |
| --- | --- | --- | --- |
| 1.61.1 | as shipped | `Timeout 5000ms exceeded` 10.8s | hang, 100% CPU, forever |
| 1.62.0 | as shipped | hang, 0% CPU, forever | hang, 100% CPU, forever |
| 1.61.1 | this PR | `Timeout 5000ms exceeded` 11.2s | error in 2.5s |
| 1.62.0 | this PR | `Timeout 5000ms exceeded` 10.6s | error in 2.5s |

The zero-match rows take ~10s rather than the configured 5000ms because the action goes through the assertion retry loop first — that's pestphp/pest#1755, untouched here.

This repo's suite: 359 passed on 1.62.0 under `--parallel`. Four unit tests added; I checked they fail without the fix rather than passing vacuously.

### Related, and deliberately not addressed

pestphp/pest#1759 reports a separate defect in this same loop — the `waitUntil` early-break stranding a command's response and desynchronizing later ones. I've left the break condition exactly as it was so the two changes don't collide; that issue's suggested fix applies cleanly on top of this one.

### Notes for review

- `requestGraceSeconds` is 30s on top of the request timeout, deliberately generous so a slow-but-healthy operation on a loaded CI box doesn't start failing. It's a property rather than a constant only so the tests can shrink it — happy to make it a constant and test it another way.
- `params.timeout` is kept alongside the new `metadata.timeout` so servers older than 1.62.0 keep working.

### Two things found while investigating, not fixed here

Happy to open issues or PRs for either.

- **`waitForLoadState()`, `waitForFunction()` and `waitForURL()` are silent no-ops.** `execute()` is a generator function, so its body doesn't run until iterated — these three call it and discard the result. Confirmed by logging every message written to the socket during `visit('/')->assertNoJavascriptErrors()`, which routes through `waitForLoadState('load')`: zero `waitFor*` messages. Present on `4.x` too. This bears on pestphp/pest#1650 and #1625, which attribute the `withinFrame` hang to `waitForLoadState('networkidle')` never resolving — that call currently does nothing at all, so the hang must originate in the `waitFor(['state' => 'attached'])` that follows it.
- **The persisted server address is trusted without validation.** `ServerManager::playwright()` hands parallel workers `AlreadyStartedPlaywrightServer::fromPersisted()`, which reads `.temp/playwright-server.json` without checking anything is still listening, and `markAsStopped()` only runs on a graceful stop — so a killed run leaves the file pointing at a dead port. Distinct from pestphp/pest#1754, which covers the orphaned process itself.
