### PR TITLE
feat: allow toggling the browser's offline mode

### DIFF
--- a/src/Api/Concerns/InteractsWithNetwork.php
+++ b/src/Api/Concerns/InteractsWithNetwork.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser\Api\Concerns;
+
+use Pest\Browser\Api\Webpage;
+
+/**
+ * @mixin Webpage
+ */
+trait InteractsWithNetwork
+{
+    /**
+     * Disconnects the browser from the network.
+     */
+    public function offline(): self
+    {
+        $this->page->context()->setOffline(true);
+
+        return $this;
+    }
+
+    /**
+     * Reconnects the browser to the network.
+     */
+    public function online(): self
+    {
+        $this->page->context()->setOffline(false);
+
+        return $this;
+    }
+}

--- a/src/Api/Webpage.php
+++ b/src/Api/Webpage.php
@@ -14,6 +14,7 @@ final readonly class Webpage
     use Concerns\HasWaitCapabilities,
         Concerns\InteractsWithElements,
         Concerns\InteractsWithFrames,
+        Concerns\InteractsWithNetwork,
         Concerns\InteractsWithScreen,
         Concerns\InteractsWithTab,
         Concerns\InteractsWithToolbar,

--- a/src/Playwright/Context.php
+++ b/src/Playwright/Context.php
@@ -93,6 +93,17 @@ final class Context
     }
 
     /**
+     * Toggles the browser context's offline mode.
+     */
+    public function setOffline(bool $offline): self
+    {
+        $response = $this->sendMessage('setOffline', ['offline' => $offline]);
+        $this->processVoidResponse($response);
+
+        return $this;
+    }
+
+    /**
      * Adds a script which will be evaluated.
      */
     public function addInitScript(string $script): self

--- a/tests/Browser/Webpage/OfflineTest.php
+++ b/tests/Browser/Webpage/OfflineTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+it('may take the browser offline and back online', function (): void {
+    Route::get('/', fn (): string => '
+        <div id="status">idle</div>
+        <button id="ping">Ping</button>
+        <script>
+            document.getElementById("ping").addEventListener("click", function () {
+                var status = document.getElementById("status");
+
+                status.textContent = "pending";
+
+                fetch("/ping")
+                    .then(function () { status.textContent = "reachable"; })
+                    .catch(function () { status.textContent = "unreachable"; });
+            });
+        </script>
+    ');
+
+    Route::get('/ping', fn (): string => 'pong');
+
+    visit('/')
+        ->offline()
+        ->click('#ping')
+        ->assertSeeIn('#status', 'unreachable')
+        ->online()
+        ->click('#ping')
+        ->assertSeeIn('#status', 'reachable');
+});
+
+it('may reflect the offline state on the navigator', function (): void {
+    Route::get('/', fn (): string => '
+        <div id="connection">unknown</div>
+        <script>
+            function render() {
+                document.getElementById("connection").textContent =
+                    navigator.onLine ? "online" : "offline";
+            }
+
+            window.addEventListener("online", render);
+            window.addEventListener("offline", render);
+
+            render();
+        </script>
+    ');
+
+    visit('/')
+        ->assertSeeIn('#connection', 'online')
+        ->offline()
+        ->assertSeeIn('#connection', 'offline')
+        ->online()
+        ->assertSeeIn('#connection', 'online');
+});


### PR DESCRIPTION
Adds `offline()` and `online()` to the webpage API, backed by the Playwright browser context's `setOffline` message.