### PR TITLE
feat: support system-installed browsers via channel and executable path

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -46,6 +46,27 @@ final readonly class Configuration
     }
 
     /**
+     * Uses a system-installed branded browser via its Playwright channel,
+     * e.g. "chrome", "chrome-beta", "msedge" or "msedge-dev".
+     */
+    public function usingChannel(string $channel): self
+    {
+        Playwright::setChannel($channel);
+
+        return $this;
+    }
+
+    /**
+     * Uses the browser executable at the given path, e.g. "/usr/bin/firefox".
+     */
+    public function usingExecutablePath(string $executablePath): self
+    {
+        Playwright::setExecutablePath($executablePath);
+
+        return $this;
+    }
+
+    /**
      * Sets the theme to light mode.
      */
     public function inLightMode(): self

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Browser;
 
+use InvalidArgumentException;
 use Pest\Browser\Enums\BrowserType;
 use Pest\Browser\Enums\ColorScheme;
 use Pest\Browser\Playwright\Playwright;
@@ -46,21 +47,37 @@ final readonly class Configuration
     }
 
     /**
-     * Uses a system-installed branded browser via its Playwright channel,
-     * e.g. "chrome", "chrome-beta", "msedge" or "msedge-dev".
+     * Uses a system-installed branded Chromium browser via its Playwright channel.
+     *
+     * Supported channels are "chrome", "chrome-beta", "chrome-dev",
+     * "chrome-canary", "msedge", "msedge-beta", "msedge-dev" and
+     * "msedge-canary".
+     *
+     * Channels are only supported for Chromium-family browsers (Google Chrome
+     * and Microsoft Edge) and cannot be combined with usingExecutablePath().
      */
     public function usingChannel(string $channel): self
     {
+        $this->ensureExecutablePathIsNotSet();
+
         Playwright::setChannel($channel);
 
         return $this;
     }
 
     /**
-     * Uses the browser executable at the given path, e.g. "/usr/bin/firefox".
+     * Uses the browser executable at the given path.
+     *
+     * Note that Playwright only supports Chromium-family binaries via an
+     * executable path. Branded Firefox and Safari builds are not supported,
+     * since Playwright relies on patched builds of those browsers.
+     *
+     * This cannot be combined with usingChannel().
      */
     public function usingExecutablePath(string $executablePath): self
     {
+        $this->ensureChannelIsNotSet();
+
         Playwright::setExecutablePath($executablePath);
 
         return $this;
@@ -144,5 +161,25 @@ final readonly class Configuration
         Playwright::setShouldDiffOnScreenshotAssertions();
 
         return $this;
+    }
+
+    /**
+     * Ensures that no channel has been configured yet.
+     */
+    private function ensureChannelIsNotSet(): void
+    {
+        if (Playwright::channel() !== null) {
+            throw new InvalidArgumentException('The "channel" and "executablePath" options are mutually exclusive.');
+        }
+    }
+
+    /**
+     * Ensures that no executable path has been configured yet.
+     */
+    private function ensureExecutablePathIsNotSet(): void
+    {
+        if (Playwright::executablePath() !== null) {
+            throw new InvalidArgumentException('The "channel" and "executablePath" options are mutually exclusive.');
+        }
     }
 }

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -44,6 +44,35 @@ final class Client
     }
 
     /**
+     * The launch options forwarded to the Playwright server.
+     *
+     * @return array<string, mixed>
+     */
+    public static function launchOptions(): array
+    {
+        return array_filter([
+            'headless' => Playwright::isHeadless(),
+            'ignoreHTTPSErrors' => true,
+            'bypassCSP' => true,
+            'channel' => Playwright::channel(),
+            'executablePath' => Playwright::executablePath(),
+        ], fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * Builds the connection query string for the given browser and launch options.
+     *
+     * @param  array<string, mixed>  $launchOptions
+     */
+    public static function connectionQuery(string $browser, array $launchOptions): string
+    {
+        return http_build_query([
+            'browser' => $browser,
+            'launch-options' => json_encode($launchOptions),
+        ]);
+    }
+
+    /**
      * Connects to the Playwright server.
      */
     public function connectTo(string $url): void
@@ -51,16 +80,8 @@ final class Client
         if (! $this->websocketConnection instanceof WebsocketConnection) {
             $browser = Playwright::defaultBrowserType()->toPlaywrightName();
 
-            $launchOptions = json_encode(array_filter([
-                'headless' => Playwright::isHeadless(),
-                'ignoreHTTPSErrors' => true,
-                'bypassCSP' => true,
-                'channel' => Playwright::channel(),
-                'executablePath' => Playwright::executablePath(),
-            ], fn (mixed $value): bool => $value !== null));
-
             $this->websocketConnection = connect(
-                "ws://$url?browser=$browser&launch-options=$launchOptions",
+                'ws://'.$url.'?'.self::connectionQuery($browser, self::launchOptions()),
             );
         }
     }

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -51,11 +51,13 @@ final class Client
         if (! $this->websocketConnection instanceof WebsocketConnection) {
             $browser = Playwright::defaultBrowserType()->toPlaywrightName();
 
-            $launchOptions = json_encode([
+            $launchOptions = json_encode(array_filter([
                 'headless' => Playwright::isHeadless(),
                 'ignoreHTTPSErrors' => true,
                 'bypassCSP' => true,
-            ]);
+                'channel' => Playwright::channel(),
+                'executablePath' => Playwright::executablePath(),
+            ], fn (mixed $value): bool => $value !== null));
 
             $this->websocketConnection = connect(
                 "ws://$url?browser=$browser&launch-options=$launchOptions",

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -60,6 +60,16 @@ final class Playwright
     private static ?string $host = null;
 
     /**
+     * The browser channel to use, e.g. "chrome" or "msedge".
+     */
+    private static ?string $channel = null;
+
+    /**
+     * The path to a browser executable to use.
+     */
+    private static ?string $executablePath = null;
+
+    /**
      * Get a browser factory for the given browser type.
      */
     public static function browser(BrowserType $browserType): BrowserFactory
@@ -153,6 +163,38 @@ final class Playwright
     public static function host(): ?string
     {
         return self::$host;
+    }
+
+    /**
+     * Set the browser channel to use.
+     */
+    public static function setChannel(?string $channel): void
+    {
+        self::$channel = $channel;
+    }
+
+    /**
+     * Get the browser channel to use.
+     */
+    public static function channel(): ?string
+    {
+        return self::$channel;
+    }
+
+    /**
+     * Set the browser executable path to use.
+     */
+    public static function setExecutablePath(?string $executablePath): void
+    {
+        self::$executablePath = $executablePath;
+    }
+
+    /**
+     * Get the browser executable path to use.
+     */
+    public static function executablePath(): ?string
+    {
+        return self::$executablePath;
     }
 
     /**

--- a/src/ServerManager.php
+++ b/src/ServerManager.php
@@ -62,9 +62,15 @@ final class ServerManager
         $port = Port::find();
         $host = Playwright::host() ?? self::DEFAULT_HOST;
 
+        $command = '.'.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR.'.bin'.DIRECTORY_SEPARATOR.'playwright run-server --host %s --port %d --mode launchServer';
+
+        if (Playwright::executablePath() !== null) {
+            $command .= ' --unsafe';
+        }
+
         $this->playwright ??= PlaywrightNpmServer::create(
             PackageJsonDirectory::find(),
-            '.'.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR.'.bin'.DIRECTORY_SEPARATOR.'playwright run-server --host %s --port %d --mode launchServer',
+            $command,
             $host,
             $port,
             'Listening on',

--- a/tests/Unit/Configuration/SystemBrowserConfigurationTest.php
+++ b/tests/Unit/Configuration/SystemBrowserConfigurationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use InvalidArgumentException;
 use Pest\Browser\Configuration;
 use Pest\Browser\Playwright\Playwright;
 
@@ -23,10 +24,10 @@ it('can set a system browser channel via configuration', function (): void {
 it('can set a browser executable path via configuration', function (): void {
     $config = new Configuration();
 
-    $result = $config->usingExecutablePath('/usr/bin/firefox');
+    $result = $config->usingExecutablePath('/usr/bin/google-chrome');
 
     expect($result)->toBeInstanceOf(Configuration::class);
-    expect(Playwright::executablePath())->toBe('/usr/bin/firefox');
+    expect(Playwright::executablePath())->toBe('/usr/bin/google-chrome');
 });
 
 it('defaults channel and executable path to null', function (): void {
@@ -39,14 +40,40 @@ it('supports fluent chaining with other configuration options', function (): voi
 
     $result = $config
         ->usingChannel('msedge')
-        ->usingExecutablePath('/usr/bin/msedge')
         ->headed()
         ->timeout(10000);
 
     expect($result)->toBeInstanceOf(Configuration::class);
     expect(Playwright::channel())->toBe('msedge');
-    expect(Playwright::executablePath())->toBe('/usr/bin/msedge');
 });
+
+it('supports fluent chaining of an executable path with other options', function (): void {
+    $config = new Configuration();
+
+    $result = $config
+        ->usingExecutablePath('/usr/bin/google-chrome')
+        ->headed()
+        ->timeout(10000);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::executablePath())->toBe('/usr/bin/google-chrome');
+});
+
+it('throws when combining a channel with an executable path', function (): void {
+    $config = new Configuration();
+
+    $config->usingChannel('chrome');
+
+    $config->usingExecutablePath('/usr/bin/google-chrome');
+})->throws(InvalidArgumentException::class);
+
+it('throws when combining an executable path with a channel', function (): void {
+    $config = new Configuration();
+
+    $config->usingExecutablePath('/usr/bin/google-chrome');
+
+    $config->usingChannel('chrome');
+})->throws(InvalidArgumentException::class);
 
 it('can override channel and executable path multiple times', function (): void {
     Playwright::setChannel('chrome');
@@ -55,8 +82,8 @@ it('can override channel and executable path multiple times', function (): void 
     Playwright::setChannel('msedge');
     expect(Playwright::channel())->toBe('msedge');
 
-    Playwright::setExecutablePath('/usr/bin/firefox');
-    expect(Playwright::executablePath())->toBe('/usr/bin/firefox');
+    Playwright::setExecutablePath('/usr/bin/google-chrome');
+    expect(Playwright::executablePath())->toBe('/usr/bin/google-chrome');
 
     Playwright::setExecutablePath(null);
     expect(Playwright::executablePath())->toBeNull();

--- a/tests/Unit/Configuration/SystemBrowserConfigurationTest.php
+++ b/tests/Unit/Configuration/SystemBrowserConfigurationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Configuration;
+use Pest\Browser\Playwright\Playwright;
+
+beforeEach(function (): void {
+    // Reset Playwright state before each test
+    Playwright::setChannel(null);
+    Playwright::setExecutablePath(null);
+});
+
+it('can set a system browser channel via configuration', function (): void {
+    $config = new Configuration();
+
+    $result = $config->usingChannel('chrome');
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::channel())->toBe('chrome');
+});
+
+it('can set a browser executable path via configuration', function (): void {
+    $config = new Configuration();
+
+    $result = $config->usingExecutablePath('/usr/bin/firefox');
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::executablePath())->toBe('/usr/bin/firefox');
+});
+
+it('defaults channel and executable path to null', function (): void {
+    expect(Playwright::channel())->toBeNull();
+    expect(Playwright::executablePath())->toBeNull();
+});
+
+it('supports fluent chaining with other configuration options', function (): void {
+    $config = new Configuration();
+
+    $result = $config
+        ->usingChannel('msedge')
+        ->usingExecutablePath('/usr/bin/msedge')
+        ->headed()
+        ->timeout(10000);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::channel())->toBe('msedge');
+    expect(Playwright::executablePath())->toBe('/usr/bin/msedge');
+});
+
+it('can override channel and executable path multiple times', function (): void {
+    Playwright::setChannel('chrome');
+    expect(Playwright::channel())->toBe('chrome');
+
+    Playwright::setChannel('msedge');
+    expect(Playwright::channel())->toBe('msedge');
+
+    Playwright::setExecutablePath('/usr/bin/firefox');
+    expect(Playwright::executablePath())->toBe('/usr/bin/firefox');
+
+    Playwright::setExecutablePath(null);
+    expect(Playwright::executablePath())->toBeNull();
+});

--- a/tests/Unit/Playwright/ClientTest.php
+++ b/tests/Unit/Playwright/ClientTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Playwright\Client;
+use Pest\Browser\Playwright\Playwright;
+
+beforeEach(function (): void {
+    // Reset Playwright state before each test
+    Playwright::setChannel(null);
+    Playwright::setExecutablePath(null);
+});
+
+it('builds launch options without null values', function (): void {
+    $options = Client::launchOptions();
+
+    expect($options)->toHaveKeys(['headless', 'ignoreHTTPSErrors', 'bypassCSP']);
+    expect($options)->not->toHaveKeys(['channel', 'executablePath']);
+});
+
+it('keeps headless disabled when running headed', function (): void {
+    Playwright::headed();
+
+    expect(Client::launchOptions()['headless'])->toBeFalse();
+});
+
+it('includes the configured channel in the launch options', function (): void {
+    Playwright::setChannel('chrome');
+
+    expect(Client::launchOptions()['channel'])->toBe('chrome');
+});
+
+it('includes the configured executable path in the launch options', function (): void {
+    Playwright::setExecutablePath('/usr/bin/google-chrome');
+
+    expect(Client::launchOptions()['executablePath'])->toBe('/usr/bin/google-chrome');
+});
+
+it('builds a connection query that round-trips the launch options', function (): void {
+    $launchOptions = [
+        'headless' => false,
+        'executablePath' => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    ];
+
+    $query = Client::connectionQuery('chromium', $launchOptions);
+
+    expect($query)->toContain('browser=chromium');
+    expect($query)->toContain('launch-options='.urlencode((string) json_encode($launchOptions)));
+});


### PR DESCRIPTION
## Summary

Adds two new `pest()->browser()` configuration options to launch **system-installed** browsers instead of the Playwright-bundled browsers:

```php
// Google Chrome or Microsoft Edge via Playwright's "channel" mechanism
pest()->browser()->usingChannel('chrome');

// a Chromium-family binary via its absolute path
pest()->browser()->usingExecutablePath('/usr/bin/google-chrome');
```

The supported channels match Playwright's [`#configure-browsers`](https://playwright.dev/docs/browsers#configure-browsers) docs: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.

## Motivation

No downloaded Playwright browser bundles are needed — great for environments that already have Chrome/Edge installed and want to avoid `npx playwright install`.

### Unlocks browsers on distros Playwright's installer refuses to support

Playwright's channel install scripts (`bin/reinstall_chrome_stable_linux.sh`, `bin/reinstall_msedge_*_linux.sh`) are hard-gated to Ubuntu/Debian: they source `/etc/os-release` and abort otherwise. On Linux Mint:

```
ERROR: cannot install on linuxmint distribution - only Ubuntu and Debian are supported
```

So a machine that already has Chrome installed still can't use the `chrome` channel when `npx playwright install chrome` is part of the bootstrap. This PR removes that whole step: the browser is launched **in place**, so there is no download, no distro gate, and the system installation is never touched. (On Ubuntu/Debian the Playwright installer would even `apt-get remove google-chrome` and reinstall the `.deb` — a disruptive no-op for anyone who already has Chrome.)

Verified end-to-end on Linux Mint (an unsupported distro) with the system Chrome 151: `visit(...)->screenshot(...)` emits real screenshots while `~/.cache/ms-playwright` stays empty. Same benefit on Fedora, Arch, openSUSE, etc., and in CI images that preinstall browsers.

## Implementation

- `Configuration::usingChannel(string)` and `Configuration::usingExecutablePath(string)` config methods, plus static channel/executablePath state on `Playwright`
- Both are forwarded as launch options in the Playwright client; the payload is URL-encoded (via `http_build_query`) so executable paths containing spaces or special characters round-trip correctly
- Playwright's `run-server` is started with `--unsafe` when an `executablePath` is set, because the server otherwise filters that launch option out (see `filterLaunchOptions` in playwright-core); `channel` is always accepted without `--unsafe`
- `usingChannel()` and `usingExecutablePath()` are mutually exclusive and throw an `InvalidArgumentException` if combined

## Scope

Playwright only supports **Chromium-family** binaries via channel/executablePath. Branded Firefox and Safari builds are **not** supported because Playwright relies on its own patched builds of those browsers — so `usingExecutablePath('/usr/bin/firefox')` does not work. Use the bundled Firefox (`inFirefox()`) for Firefox tests.

## Tests

- `tests/Unit/Configuration/SystemBrowserConfigurationTest.php` — channel/path configuration, fluent chaining, mutual-exclusion
- `tests/Unit/Playwright/ClientTest.php` — launch-option forwarding and connection-query encoding
- Unit + arch tests pass; Pint and PHPStan are clean

## Notes

- `channel` is the recommended approach for Chromium-based system browsers and requires no server flags.
- `executablePath` requires the `--unsafe` server mode (added conditionally).
