### PR TITLE
fix: pass null to ReflectionProperty::setValue() for static Assert::$count

### DIFF
--- a/src/Execution.php
+++ b/src/Execution.php
@@ -171,7 +171,6 @@ final class Execution
         $reflector = new ReflectionClass(Assert::class);
         $property = $reflector->getProperty('count');
 
-        // @phpstan-ignore-next-line
-        $property->setValue(Assert::class, $originalCount);
+        $property->setValue(null, $originalCount);
     }
 }


### PR DESCRIPTION
Running browser tests on PHP 8.3+ emits, on essentially every assertion retry:

> Calling ReflectionProperty::setValue() with a 1st argument which is not null or an object is deprecated

It comes from `Execution::resetAssertions()`. `Assert::$count` is a **static** property, so under PHP 8.3 the first argument to `setValue()` must be `null` (or an object); passing the class-string `Assert::class` triggers the deprecation. On Firefox nearly every test retries once, so runs get flooded with the notice (tests still pass, but every test is labelled deprecated).

**Fix:** pass `null`, the canonical form for a static property - no behaviour change. The `@phpstan-ignore-next-line` is dropped since the call is now valid.

The same line exists on `5.x` and is affected identically, if you'd like it forward-ported.
