### PR TITLE
Persist the port of the server that was actually started

### DIFF
--- a/src/ServerManager.php
+++ b/src/ServerManager.php
@@ -59,21 +59,31 @@ final class ServerManager
             return AlreadyStartedPlaywrightServer::fromPersisted();
         }
 
-        $port = Port::find();
-        $host = Playwright::host() ?? self::DEFAULT_HOST;
+        // Allocating the port and persisting the description belong INSIDE the
+        // guard, with the creation they describe. `??=` already makes the server
+        // a one-off, but both lines around it ran on every call: the second call
+        // allocated a fresh port that nothing was listening on, and then
+        // persisted that port as the description of the server that IS running.
+        //
+        // Every later `visit()` reads that description, so the workers connect
+        // to a dead port.
+        if (! $this->playwright instanceof PlaywrightServer) {
+            $port = Port::find();
+            $host = Playwright::host() ?? self::DEFAULT_HOST;
 
-        $this->playwright ??= PlaywrightNpmServer::create(
-            PackageJsonDirectory::find(),
-            '.'.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR.'.bin'.DIRECTORY_SEPARATOR.'playwright run-server --host %s --port %d --mode launchServer',
-            $host,
-            $port,
-            'Listening on',
-        );
+            $this->playwright = PlaywrightNpmServer::create(
+                PackageJsonDirectory::find(),
+                '.'.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR.'.bin'.DIRECTORY_SEPARATOR.'playwright run-server --host %s --port %d --mode launchServer',
+                $host,
+                $port,
+                'Listening on',
+            );
 
-        AlreadyStartedPlaywrightServer::persist(
-            $host,
-            $port,
-        );
+            AlreadyStartedPlaywrightServer::persist(
+                $host,
+                $port,
+            );
+        }
 
         return $this->playwright;
     }


### PR DESCRIPTION
### The defect

`ServerManager::playwright()` creates the Playwright server once — `??=` sees to that — but the two lines around the assignment run on **every** call:

```php
$port = Port::find();                               // ← every call
$host = Playwright::host() ?? self::DEFAULT_HOST;

$this->playwright ??= PlaywrightNpmServer::create(   // ← first call only
    ..., $host, $port, 'Listening on',
);

AlreadyStartedPlaywrightServer::persist($host, $port);   // ← every call
```

The port lives on the server instance as a readonly property, so the server keeps the port it was created with. But the second call runs `Port::find()` again — which by definition returns a port nothing is listening on, since the running server's port is now taken — and persists *that* as the description of the server.

The server is fine. The record of where to reach it is not, and that record is what `AlreadyStartedPlaywrightServer::fromPersisted()` hands to every parallel worker.

### The measurement

Two calls to `playwright()` in one process, `start()`ed in between so the server is genuinely listening, reading `.temp/playwright-server.json` after each:

**Before**

```
call 1  returned url: 127.0.0.1:56398
call 1  persisted:    {"host":"127.0.0.1","port":56398}
call 2  returned url: 127.0.0.1:56398
call 2  persisted:    {"host":"127.0.0.1","port":56399}

same server object:   yes
persisted unchanged:  NO
persisted port 56399 listening: no (Connection refused)
```

**After**

```
call 1  returned url: 127.0.0.1:56427
call 1  persisted:    {"host":"127.0.0.1","port":56427}
call 2  returned url: 127.0.0.1:56427
call 2  persisted:    {"host":"127.0.0.1","port":56427}

same server object:   yes
persisted unchanged:  yes
persisted port 56427 listening: yes
```

The same server object is returned either way — only the persisted description moves, onto a port that refuses connections.

### The fix

Move the port allocation and the `persist()` inside the guard, so they stay with the creation they describe:

```php
if (! $this->playwright instanceof PlaywrightServer) {
    $port = Port::find();
    $host = Playwright::host() ?? self::DEFAULT_HOST;

    $this->playwright = PlaywrightNpmServer::create(/* ... */);

    AlreadyStartedPlaywrightServer::persist($host, $port);
}

return $this->playwright;
```

Nothing changes on the first call. On every later call the method now returns the same server *and* leaves its description alone. `composer lint` (rector + pint) is clean on the changed file.

### A related finding, deliberately not in this PR

While tracking this down I ran into a second issue in the same area: the persisted state file has no run identity, so two concurrent runs on one machine share it — the second overwrites the first's description, and whichever finishes first removes the file out from under the other via `markAsStopped()`.

I left it out because fixing it properly means deciding how a run is identified and what happens to a stale file, and those are design calls that belong to you rather than to a drive-by PR. Happy to open it separately with a measurement if the shape you'd want is clear — or to just leave it here as a report.
