### PR TITLE
Add slow motion support for easy debugging

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -86,6 +86,16 @@ final readonly class Configuration
     }
 
     /**
+     * Slows down each browser action by the given number of milliseconds.
+     */
+    public function slowMo(int $milliseconds = Playwright::DEFAULT_SLOW_MO): self
+    {
+        Playwright::setSlowMo($milliseconds);
+
+        return $this;
+    }
+
+    /**
      * Sets the browsers userAgent.
      */
     public function userAgent(string $userAgent): self

--- a/src/Playwright/Client.php
+++ b/src/Playwright/Client.php
@@ -53,6 +53,7 @@ final class Client
 
             $launchOptions = json_encode([
                 'headless' => Playwright::isHeadless(),
+                'slowMo' => Playwright::slowMo(),
                 'ignoreHTTPSErrors' => true,
                 'bypassCSP' => true,
             ]);

--- a/src/Playwright/Playwright.php
+++ b/src/Playwright/Playwright.php
@@ -13,6 +13,12 @@ use Pest\Browser\Enums\ColorScheme;
 final class Playwright
 {
     /**
+     * The default slow-motion delay, in milliseconds, used when `--slow-mo` is
+     * passed without a value.
+     */
+    public const int DEFAULT_SLOW_MO = 500;
+
+    /**
      * Browser types
      *
      * @var array<string, BrowserFactory>
@@ -48,6 +54,11 @@ final class Playwright
      * The timeout in milliseconds.
      */
     private static int $timeout = 5_000;
+
+    /**
+     * The delay, in milliseconds, applied before each browser action.
+     */
+    private static int $slowMo = 0;
 
     /**
      * The default userAgent.
@@ -129,6 +140,22 @@ final class Playwright
     public static function timeout(): int
     {
         return self::$timeout;
+    }
+
+    /**
+     * Set the delay, in milliseconds, applied before each browser action.
+     */
+    public static function setSlowMo(int $milliseconds): void
+    {
+        self::$slowMo = $milliseconds;
+    }
+
+    /**
+     * Get the delay, in milliseconds, applied before each browser action.
+     */
+    public static function slowMo(): int
+    {
+        return self::$slowMo;
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -121,19 +121,17 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
         if ($this->hasArgument('--slow-mo', $arguments)) {
             $index = array_search('--slow-mo', $arguments, true);
 
-            // `--slow-mo` may be passed bare (uses a sensible default) or with an
-            // explicit millisecond value: `--slow-mo 250`.
-            if ($index !== false && isset($arguments[$index + 1]) && is_numeric($arguments[$index + 1])) {
-                Playwright::setSlowMo((int) $arguments[$index + 1]);
+            $value = $index === false
+                ? $this->popArgumentValue('--slow-mo', $arguments)
+                : $arguments[$index + 1] ?? null;
 
-                unset($arguments[$index], $arguments[$index + 1]);
-            } else {
-                Playwright::setSlowMo(Playwright::DEFAULT_SLOW_MO);
-
-                unset($arguments[$index]);
+            if ($index !== false && is_numeric($value)) {
+                unset($arguments[$index + 1]);
             }
 
-            $arguments = array_values($arguments);
+            Playwright::setSlowMo(is_numeric($value) ? (int) $value : Playwright::DEFAULT_SLOW_MO);
+
+            $arguments = $this->popArgument('--slow-mo', $arguments);
         }
 
         $this->validateNonSupportedParallelFeatures();
@@ -199,6 +197,12 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
         if (Playwright::shouldDebugAssertions()) {
             throw new OptionNotSupportedInParallelException(
                 'Debugging assertions is not supported when running tests in parallel.',
+            );
+        }
+
+        if (Playwright::slowMo() > 0) {
+            throw new OptionNotSupportedInParallelException(
+                'Running tests in slow motion is not supported when running tests in parallel.',
             );
         }
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -118,6 +118,24 @@ final class Plugin implements Bootable, HandlesArguments, Terminable // @pest-ar
             $arguments = array_values($arguments);
         }
 
+        if ($this->hasArgument('--slow-mo', $arguments)) {
+            $index = array_search('--slow-mo', $arguments, true);
+
+            // `--slow-mo` may be passed bare (uses a sensible default) or with an
+            // explicit millisecond value: `--slow-mo 250`.
+            if ($index !== false && isset($arguments[$index + 1]) && is_numeric($arguments[$index + 1])) {
+                Playwright::setSlowMo((int) $arguments[$index + 1]);
+
+                unset($arguments[$index], $arguments[$index + 1]);
+            } else {
+                Playwright::setSlowMo(Playwright::DEFAULT_SLOW_MO);
+
+                unset($arguments[$index]);
+            }
+
+            $arguments = array_values($arguments);
+        }
+
         $this->validateNonSupportedParallelFeatures();
 
         return $arguments;

--- a/tests/Unit/Configuration/SlowMoConfigurationTest.php
+++ b/tests/Unit/Configuration/SlowMoConfigurationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Configuration;
+use Pest\Browser\Playwright\Playwright;
+
+beforeEach(function (): void {
+    // Reset Playwright state before each test
+    Playwright::setSlowMo(0);
+});
+
+it('defaults slow motion to zero', function (): void {
+    expect(Playwright::slowMo())->toBe(0);
+});
+
+it('can set slow motion via configuration', function (): void {
+    $config = new Configuration();
+
+    $result = $config->slowMo(250);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::slowMo())->toBe(250);
+});
+
+it('uses a sensible default when no value is given', function (): void {
+    $config = new Configuration();
+
+    $config->slowMo();
+
+    expect(Playwright::slowMo())->toBe(Playwright::DEFAULT_SLOW_MO);
+});
+
+it('follows fluent interface pattern', function (): void {
+    $config = new Configuration();
+
+    $result = $config
+        ->slowMo(500)
+        ->timeout(10000);
+
+    expect($result)->toBeInstanceOf(Configuration::class);
+    expect(Playwright::slowMo())->toBe(500);
+});
+
+it('stores slow motion in Playwright global state', function (): void {
+    expect(Playwright::slowMo())->toBe(0);
+
+    Playwright::setSlowMo(1000);
+
+    expect(Playwright::slowMo())->toBe(1000);
+});

--- a/tests/Unit/Plugin/SlowMoPluginTest.php
+++ b/tests/Unit/Plugin/SlowMoPluginTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Playwright\Playwright;
+use Pest\Browser\Plugin;
+
+beforeEach(function (): void {
+    Playwright::setSlowMo(0);
+});
+
+it('leaves slow motion off when the argument is absent', function (): void {
+    $arguments = new Plugin()->handleArguments(['tests/Unit/ExampleTest.php']);
+
+    expect(Playwright::slowMo())->toBe(0)
+        ->and($arguments)->toBe(['tests/Unit/ExampleTest.php']);
+});
+
+it('uses the default when passed bare', function (): void {
+    $arguments = new Plugin()->handleArguments(['tests/Unit/ExampleTest.php', '--slow-mo']);
+
+    expect(Playwright::slowMo())->toBe(Playwright::DEFAULT_SLOW_MO)
+        ->and($arguments)->toBe(['tests/Unit/ExampleTest.php']);
+});
+
+it('reads the value from the following argument', function (): void {
+    $arguments = new Plugin()->handleArguments(['tests/Unit/ExampleTest.php', '--slow-mo', '250']);
+
+    expect(Playwright::slowMo())->toBe(250)
+        ->and($arguments)->toBe(['tests/Unit/ExampleTest.php']);
+});
+
+it('reads the value from the same argument', function (): void {
+    $arguments = new Plugin()->handleArguments(['tests/Unit/ExampleTest.php', '--slow-mo=250']);
+
+    expect(Playwright::slowMo())->toBe(250)
+        ->and($arguments)->toBe(['tests/Unit/ExampleTest.php']);
+});
+
+it('keeps a following argument that is not a number', function (): void {
+    $arguments = new Plugin()->handleArguments(['--slow-mo', 'tests/Unit/ExampleTest.php']);
+
+    expect(Playwright::slowMo())->toBe(Playwright::DEFAULT_SLOW_MO)
+        ->and($arguments)->toBe(['tests/Unit/ExampleTest.php']);
+});
+
+it('falls back to the default when the same-argument value is not a number', function (): void {
+    $arguments = new Plugin()->handleArguments(['tests/Unit/ExampleTest.php', '--slow-mo=fast']);
+
+    expect(Playwright::slowMo())->toBe(Playwright::DEFAULT_SLOW_MO)
+        ->and($arguments)->toBe(['tests/Unit/ExampleTest.php']);
+});


### PR DESCRIPTION
Playwright has a `slowMo` launch option that delays each interaction, which is what you want when you are watching a headed run to check that a test does the right things in the right order. 

At Spatie, we're using more AI to generate browser tests. This way we can run individual tests with `--slow-mo` and tests tend to play out like they would with real users, who slow down between clicking on buttons, links and interacting with elements on the website.

Currently, Pest's browser plugin does not expose this Playwright flag, and a hacky workaround is required to get this to work today.

I looked at prior PRs and found #230, which was created for Pest 4. I've ported this PR and improved for Pest 5. 

It adds a `--slow-mo` flag, optionally with a value in milliseconds, and `pest()->browser()->slowMo(250)`. I've credited the original author of that PR in my first commit, but I've made adjustments in the second that make the argument parsing etc. more in line with the rest of the code of the project.

This PR also refuses slow motion under `--parallel`, next to headed mode, screenshot diffing and debug assertions. Slow motion is only really useful when you can watch a run, and headed mode is already refused there, so the combination just makes things slower.