### PR TITLE
fix: exclude mutating actions from the expectation retry loop

### DIFF
--- a/src/Api/AwaitableWebpage.php
+++ b/src/Api/AwaitableWebpage.php
@@ -28,8 +28,21 @@ final readonly class AwaitableWebpage
         private array $nonAwaitableMethods = [
             'assertScreenshotMatches',
             'assertNoAccessibilityIssues',
-            // Retrying this action would append the value to what was already typed.
+            // Retrying these actions would repeat their effect: a re-fired click aims at
+            // a page its first attempt already changed, a re-sent Enter submits the form
+            // again, a re-run drag starts from an element the first attempt already
+            // moved, and typing again appends to what was already typed. A single direct
+            // call gets Playwright's full actionability wait with the whole timeout
+            // budget on that one attempt.
+            'append',
+            'click',
+            'drag',
+            'keys',
+            'press',
+            'pressAndWaitFor',
+            'rightClick',
             'typeSlowly',
+            'withKeyDown',
         ],
     ) {
         //

--- a/tests/Browser/Webpage/ClickTest.php
+++ b/tests/Browser/Webpage/ClickTest.php
@@ -73,3 +73,37 @@ it('can click elements via exact match css selectors', function (string $selecto
     '[name$="test"]',
     'button[name="test"]',
 ]);
+
+it('does not re-fire a click whose first attempt is slow', function (): void {
+    Route::get('/', fn (): string => '
+        <button id="open">Open</button>
+        <div id="overlay" style="display: none; position: fixed; inset: 0; background: rgba(0, 0, 0, 0.5);">
+            <p>Dialog</p>
+        </div>
+
+        <script>
+            window.downs = 0;
+
+            document.getElementById("open").addEventListener("pointerdown", function () {
+                if (++window.downs === 1) {
+                    const until = Date.now() + 1200;
+
+                    while (Date.now() < until) {
+                        // Simulate a busy main thread, as on a loaded CI runner.
+                    }
+                }
+            });
+
+            document.getElementById("open").addEventListener("click", function () {
+                document.getElementById("overlay").style.display = "block";
+            });
+        </script>
+    ');
+
+    $page = visit('/');
+
+    $page->click('#open');
+
+    $page->assertScript('window.downs', 1);
+    $page->assertVisible('#overlay p');
+});


### PR DESCRIPTION
## What this fixes

`AwaitableWebpage::__call()` routes every page method through `Execution::waitForExpectation()`, which re-runs the whole call under a hard-coded 1s cap per attempt until the configured timeout runs out, then makes one final uncapped attempt. Every Playwright error surfaces as `ExpectationFailedException`, so a *timeout* is retried exactly like a failed assertion.

That is correct for an assertion and wrong for an action. A click changes the page it clicks. When the first attempt needs more than 1s to complete — routine on a 2-core CI runner with a heavy SPA page — the click has already fired and a dialog is open, but the attempt is judged failed. The retry then aims at a button the dialog's overlay now covers, which can never become actionable. The test spends the whole timeout plus one uncapped attempt and fails with `Timeout Nms exceeded` on a click that succeeded.

In practice this shows up as browser suites that are green locally going red on CI on a *shifting* set of tests (whichever click crossed 1s that run), and raising the timeout makes each failure take longer instead of fixing it. Related report: pestphp/pest#1511.

## The change

`typeSlowly` is already excluded from the retry loop, with the comment "Retrying this action would append the value to what was already typed." This PR extends the same treatment to the other methods that repeat their effect when re-fired:

- `click` / `rightClick` — the retry aims at a page the first attempt already changed
- `drag` — the retry starts from an element the first attempt already moved
- `keys` / `press` / `pressAndWaitFor` / `withKeyDown` — a re-sent Enter submits the form again; a multi-key sequence is replayed from the start
- `append` — the identical hazard `typeSlowly` was excluded for

Deliberately NOT excluded: the state-setting inputs (`fill`, `type`, `clear`, `check`, `uncheck`, `radio`, `select`, `attach`, `hover`), where a retry is harmless, and every assertion, where retry-until-timeout is exactly right.

The excluded branch calls the method directly, so the action gets the full configured timeout in one attempt. That is also the stronger wait: Playwright's actionability check (attached → visible → stable → receives events → enabled) runs *inside* the one call, so it waits without ever firing twice.

## Verification

The included regression test simulates a slow main thread: the button's first `pointerdown` busy-loops 1.2s, and the click shows an overlay covering the button.

- **Before this change**: the test fails — the capped first attempt is judged a timeout after the click already fired, every retry aims at the covered button, and the run ends with a timeout. The page state at failure proves the double-fire hazard: `window.downs === 1`, overlay open.
- **After this change**: the test passes in ~1s.
- Full suite: 358 passed. `pint` and `phpstan` clean.

No signatures change. Configurations with a timeout ≤ 1000ms already bypass the loop entirely, so they see no behavior change.

If you would prefer a smaller first step, `click` + `drag` alone fixes the loudest failure mode — the keyboard methods and `append` are the same hazard class, just quieter. Happy to adjust.
