### PR TITLE
fix: guard each screenshot directory the way the parent is guarded

### DIFF
--- a/src/Support/Screenshot.php
+++ b/src/Support/Screenshot.php
@@ -72,6 +72,10 @@ final class Screenshot
             self::dir().'/ImageDiffView',
             self::dir(),
         ] as $dir) {
+            if (! is_dir($dir)) {
+                continue;
+            }
+
             $files = glob($dir.'/*');
 
             if (is_array($files)) {


### PR DESCRIPTION
`Screenshot::cleanup()` guards the parent directory with `is_dir()` and then calls `rmdir()` on
three children without one. Two of those — `Sliders` and `ImageDiffView` — belong to the
visual-diff features, so an ordinary run never creates them.

The `@` silences the message, but PHPUnit still **records** a suppressed diagnostic as a
*Test-Runner-Triggered PHP Warning*. A suite running with `failOnWarning="true"` therefore exits
non-zero while every test passes:

```
Test Runner Triggered 2 PHP Warnings
  src/Support/Screenshot.php:83  rmdir(...): No such file or directory
8 passed, exit code 1
```

### Why the existing guard does not catch it

`glob()` on a missing directory answers with an **empty array**, not `false`. So `is_array($files)`
is true, the unlink loop runs over nothing, and control reaches the `rmdir()` that warns.

### Why it is easy to miss

`cleanup()` early-returns while the screenshots directory does not exist. So the **first** run in a
fresh tree is green and only the **second** one warns — the first run creates the directory that
makes the next one warn. CI that checks out a clean workspace per run never sees it; running the
browser suite twice in a row locally reproduces it every time.

### The change

Each directory is guarded the way the parent already is. It is additive and cannot alter behaviour
for a directory that exists — the loop body is unchanged for those.

### Verified, both arms

On PHP 8.5 with `failOnWarning="true"`, running the browser suite twice in a row:

| | first run | second run |
|---|---|---|
| before | exit 0, 8 passed | **exit 1**, 2 runner-triggered warnings, 8 passed |
| after | exit 0, 8 passed | exit 0, 0 warnings, 8 passed |

### Note

#229 also touches this file (configurable screenshot directory). The two do not overlap in intent —
this one only adds the missing guard inside the existing loop — but whichever lands second will want
a trivial rebase.
