### PR TITLE
fix: pass null to ReflectionProperty::setValue() for static Assert::$count

### DIFF
--- a/src/Execution.php
+++ b/src/Execution.php
@@ -171,7 +171,6 @@ final class Execution
         $reflector = new ReflectionClass(Assert::class);
         $property = $reflector->getProperty('count');
 
-        // @phpstan-ignore-next-line
-        $property->setValue(Assert::class, $originalCount);
+        $property->setValue(null, $originalCount);
     }
 }


### PR DESCRIPTION
Forward-port of #244 to `5.x`. That PR targets `4.x` only, and its author offered to port it here — this is that port. Happy to close either if you would rather take one.

### The problem

`Execution::resetAssertions()` passes `Assert::class` as the first argument to `ReflectionProperty::setValue()`. `Assert::$count` is static, and PHP 8.3 deprecates any first argument that is not `null` or an object:

```
Calling ReflectionProperty::setValue() with a 1st argument which is not null or an object is deprecated
```

It fires whenever an assertion retries, so it attaches to an arbitrary test — usually a slow one — and labels it `DEPRECATED` while the run still exits 0. On PHP 9 the call stops working altogether.

### Why `null` and not the single-argument form

`setValue($value)` looks like the tidier fix, but it is deprecated too on 8.4. Measured on PHP 8.4.23:

| call | result |
|---|---|
| `setValue(Assert::class, $n)` | `Calling ReflectionProperty::setValue() with a 1st argument which is not null or an object is deprecated` |
| `setValue(null, $n)` | clean |
| `setValue($n)` | `Calling ReflectionProperty::setValue() with a single argument is deprecated` |

So `null` as the first argument is the only spelling that raises nothing.

### Why the ignore comment goes too

`phpstan.neon` sets `reportUnmatchedIgnoredErrors: true`, so leaving `// @phpstan-ignore-next-line` on the corrected call fails the build. `composer test:types` is green with it removed (level max, `--memory-limit=2G`; the default 128M crashes a parallel worker on this machine).

### Checked

- `composer test:types` — no errors.
- `composer test:lint` — `rector --dry-run` reports `src/Support/Screenshot.php:42`, which reproduces identically on unmodified `5.x`. Not from this change.
- Applied to `v5.0.1` in a real project's browser suite: the `DEPRECATED` label disappears and the run is otherwise identical — 53 passed, 106 assertions, before and after.