### PR TITLE
fix: stop the playwright server process and keep body-less responses off keep-alive connections

### DIFF
--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -305,9 +305,22 @@ final class LaravelHttpServer implements HttpServer
             }
         }
 
+        $headers = $response->headers->all();
+
+        if ($response->isInformational() || $response->isEmpty()) {
+            // Symfony strips Content-Length from 1xx/204/304 responses and amphp
+            // chunk-encodes any HTTP/1.1 response without one, which appends a
+            // terminating chunk to a response that must not carry a body. Browsers
+            // consider such a response complete after the headers, so the stray
+            // bytes corrupt the next request on the same keep-alive connection.
+            unset($headers['transfer-encoding']);
+            $headers['content-length'] = ['0'];
+            $content = '';
+        }
+
         return new Response(
             $response->getStatusCode(),
-            $response->headers->all(), // @phpstan-ignore-line
+            $headers, // @phpstan-ignore-line
             $content,
         );
     }

--- a/src/Playwright/Servers/PlaywrightNpmServer.php
+++ b/src/Playwright/Servers/PlaywrightNpmServer.php
@@ -60,7 +60,10 @@ final class PlaywrightNpmServer implements PlaywrightServer
             return;
         }
 
-        $this->systemProcess = SystemProcess::fromShellCommandline(sprintf(
+        // `exec` makes the shell replace itself with node, so stop() signals the
+        // server itself. Without it, PHP's `sh -c` wrapper receives the signal and
+        // node is re-parented to PID 1 together with the browsers it launched.
+        $this->systemProcess = SystemProcess::fromShellCommandline($this->execPrefix().sprintf(
             $this->command,
             $this->host,
             $this->port,
@@ -94,7 +97,9 @@ final class PlaywrightNpmServer implements PlaywrightServer
     public function stop(): void
     {
         if ($this->systemProcess instanceof SystemProcess && $this->isRunning()) {
-            $this->systemProcess->stop(timeout: 0.1);
+            // Give node a moment to close its browsers on SIGTERM before Symfony
+            // escalates to SIGKILL; the browsers exit on their own once node is gone.
+            $this->systemProcess->stop(timeout: 2.0);
         }
 
         $this->systemProcess = null;
@@ -162,6 +167,14 @@ final class PlaywrightNpmServer implements PlaywrightServer
         if (version_compare($version, self::PLAYWRIGHT_VERSION, '<')) {
             throw new PlaywrightOutdatedException();
         }
+    }
+
+    /**
+     * The shell prefix that hands the process its own PID (POSIX only).
+     */
+    private function execPrefix(): string
+    {
+        return DIRECTORY_SEPARATOR === '/' ? 'exec ' : '';
     }
 
     /**

--- a/tests/Browser/Server/BodylessResponseTest.php
+++ b/tests/Browser/Server/BodylessResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Route;
+
+it('serves the next request on a keep-alive connection after a body-less response', function (int $status): void {
+    Route::post('/beacon', fn (): Response => new Response('', $status));
+
+    Route::get('/after-beacon.js', fn (): Response => new Response('window.afterBeaconLoaded = true;', 200, [
+        'Content-Type' => 'text/javascript',
+    ]));
+
+    Route::get('/', fn (): string => <<<'HTML'
+        <html>
+        <body>
+        <script>
+            fetch('/beacon', {method: 'POST', keepalive: true}).then(() => {
+                const script = document.createElement('script');
+                script.src = '/after-beacon.js';
+                script.onerror = () => { window.afterBeaconFailed = true; };
+                document.body.appendChild(script);
+            });
+        </script>
+        </body>
+        </html>
+        HTML);
+
+    visit('/')->assertScript('window.afterBeaconLoaded === true || window.afterBeaconFailed === true');
+
+    visit('/')->assertScript('window.afterBeaconLoaded === true');
+})->with([204, 304])->repeat(3);

--- a/tests/Unit/Playwright/Servers/PlaywrightNpmServerTest.php
+++ b/tests/Unit/Playwright/Servers/PlaywrightNpmServerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Playwright\Servers\AlreadyStartedPlaywrightServer;
+use Pest\Browser\Playwright\Servers\PlaywrightNpmServer;
+use Pest\Browser\Support\PackageJsonDirectory;
+use Pest\Browser\Support\Port;
+
+it('stops the node process it started instead of leaving it behind', function (): void {
+    $port = Port::find();
+
+    $server = PlaywrightNpmServer::create(
+        PackageJsonDirectory::find(),
+        '.'.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR.'.bin'.DIRECTORY_SEPARATOR.'playwright run-server --host %s --port %d --mode launchServer',
+        '127.0.0.1',
+        $port,
+        'Listening on',
+    );
+
+    $server->start();
+
+    try {
+        $pid = (int) new ReflectionProperty($server, 'systemProcess')->getValue($server)->getPid();
+        $commandLine = str_replace("\0", ' ', (string) file_get_contents("/proc/{$pid}/cmdline"));
+
+        expect($commandLine)->toStartWith('node ')
+            ->and($commandLine)->toContain("--port {$port}");
+    } finally {
+        $server->stop();
+        AlreadyStartedPlaywrightServer::markAsStopped();
+    }
+
+    $survivors = [];
+
+    foreach (glob('/proc/[0-9]*', GLOB_NOSORT) ?: [] as $directory) {
+        $candidate = str_replace("\0", ' ', (string) @file_get_contents($directory.'/cmdline'));
+
+        if (str_contains($candidate, "run-server --host 127.0.0.1 --port {$port} ")) {
+            $survivors[] = basename($directory);
+        }
+    }
+
+    expect($survivors)->toBe([]);
+})->skipOnWindows()->skipOnMac();


### PR DESCRIPTION
Two independent server-process bugs that together made browser suites flaky on Linux. Both were traced on a real project (Laravel 13, Debian 13 in a container, Playwright 1.62.1) and are reproduced by the two tests added here; each test fails on `5.x` and passes with the change. Supersedes #169 and #211 (both target `4.x`).

## 1. `playwright run-server` outlives the run

`PlaywrightNpmServer::start()` uses `Process::fromShellCommandline()` without an `exec` prefix. PHP's `proc_open` runs the string as `sh -c "…"`, and dash (Debian's `/bin/sh`) forks `node` as a child instead of replacing itself, so `stop()` only ever signals the shell:

| how the server is started | process tree | after `stop()` |
|---|---|---|
| current (`sh -c ./node_modules/.bin/playwright run-server …`) | `sh` → `node` | `sh` exits, `node` re-parented to PID 1, keeps running with its browsers |
| with `exec ` | `node` is the direct child | `node` exits, browsers exit with it |

Every browser run leaked one server plus a headless Chromium tree; after a day of local runs a host held 65 of them (about 8 GB) and had swapped 50 GB. `#169` fixes the same thing by passing an array command (Symfony adds `exec` itself in that case); this PR keeps the shell command line and adds the prefix on POSIX, which also keeps the relative `./node_modules/.bin/playwright` resolution unchanged. `stop()` now gives node 2 s to close its browsers before Symfony escalates to SIGKILL, which is what #211 asked for.

Test: `tests/Unit/Playwright/Servers/PlaywrightNpmServerTest.php` starts a server through the class, asserts the process it owns is `node …` (not `sh -c …`), and asserts that nothing listening on that port survives `stop()`. Skipped on macOS/Windows because it reads `/proc`.

## 2. Body-less responses corrupt keep-alive connections

`LaravelHttpServer` hands Symfony's headers to amphp unchanged. Symfony strips `Content-Length` from 1xx/204/304 responses, and amphp's `Http1Driver` chunk-encodes every HTTP/1.1 response that has no `Content-Length`, so a `response()->noContent()` goes out as

```
HTTP/1.1 204 No Content
transfer-encoding: chunked

0\r\n\r\n
```

RFC 7230 §3.3 forbids a body (and `Transfer-Encoding`) on 204/304. Chromium treats the response as complete after the headers and returns the socket to its pool with the five stray bytes unread; the next request on that socket fails with `net::ERR_INVALID_HTTP_RESPONSE` (captured with `--log-net-log`). In the real project the casualty was the Livewire runtime script after a `POST …/impression → 204` beacon, so pages silently never booted and only the assertions that depended on JavaScript failed, intermittently, depending on which socket Chromium picked.

`handleRequest()` now sends informational and empty responses with `Content-Length: 0` and no body, which is what every production web server does. amphp itself should special-case 204/304 the way it already special-cases HEAD (reported separately), but the plugin should not depend on that.

Test: `tests/Browser/Server/BodylessResponseTest.php` posts to a 204/304 route with `keepalive` and then loads a script; without the fix the script request fails on the reused connection.

## Checks

- `vendor/bin/pest tests/Unit/Playwright/Servers/PlaywrightNpmServerTest.php tests/Browser/Server/BodylessResponseTest.php`: fail on `5.x`, 7 passed with the change
- full `vendor/bin/pest` on Linux: see comment below
- `phpstan`: no errors; `rector` and `pint` clean for the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
