### PR TITLE
fix: capture unhandled promise rejections in assertNoJavaScriptErrors

### DIFF
--- a/src/Playwright/InitScript.php
+++ b/src/Playwright/InitScript.php
@@ -43,6 +43,15 @@ final class InitScript
                     colno: e.colno
                 });
             });
+
+            window.addEventListener('unhandledrejection', (e) => {
+                window.__pestBrowser.jsErrors.push({
+                    message: e.reason instanceof Error ? e.reason.message : String(e.reason),
+                    filename: '',
+                    lineno: 0,
+                    colno: 0
+                });
+            });
             JS;
     }
 }

--- a/tests/Browser/Webpage/AssertNoJavaScriptErrorsTest.php
+++ b/tests/Browser/Webpage/AssertNoJavaScriptErrorsTest.php
@@ -26,3 +26,16 @@ it('asserts that there are javascript errors', function (): void {
 
     $page->assertNoJavaScriptErrors();
 })->throws(ExpectationFailedException::class, 'but found 1: Uncaught ReferenceError: wqd is not define');
+
+it('asserts that there are unhandled promise rejection errors', function (): void {
+    Route::get('/', fn (): string => '
+        <script>
+            Promise.reject(new Error("Unhandled promise rejection"));
+        </script>
+        <div></div>
+    ');
+
+    $page = visit('/');
+
+    $page->assertNoJavaScriptErrors();
+})->throws(ExpectationFailedException::class, 'but found 1: Unhandled promise rejection');


### PR DESCRIPTION
While writing browser tests for one of my projects, I noticed assertNoJavaScriptErrors() was passing on a page that I knew had a broken async call. Turned out InitScript.php only listens for the `error` event so if a page's only problem is an unhandled promise rejection (failed fetch, rejected dynamic import, any async error nobody caught), the assertion passes even though something actually broke. Added an `unhandledrejection` listener alongside the existing one, same push shape so nothing downstream needs to change. filename/lineno/colno are left blank for these since PromiseRejectionEvent doesn't give you that info the way ErrorEvent does. Test added to AssertNoJavaScriptErrorsTest.php following the existing pattern in that file..



(Unrelated: got one local failure on Visit/SingleUrl > it may visit external URLs, looks like a network timeout on my end, not related to this change)...