### PR TITLE
fix: flush queued cookies between requests in LaravelHttpServer

### DIFF
--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -274,10 +274,7 @@ final class LaravelHttpServer implements HttpServer
 
         $debug = config('app.debug');
 
-        // Cookies queued through the CookieJar singleton are attached to a response by the
-        // AddQueuedCookiesToResponse middleware but never removed from the jar. FPM discards the jar
-        // with the process and Octane flushes it per request; this server reuses one container for
-        // every request of a test, so a cookie queued once would be re-sent on every later response.
+        // The container is reused, so flush stale queued cookies (FPM/Octane start fresh).
         app()->make(CookieJar::class)->flushQueuedCookies();
 
         try {

--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -15,6 +15,7 @@ use Amp\Http\Server\Response;
 use Amp\Http\Server\SocketHttpServer;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Cookie\CookieJar;
 use Illuminate\Foundation\Testing\Concerns\WithoutExceptionHandlingHandler;
 use Illuminate\Http\Request;
 use Illuminate\Routing\UrlGenerator;
@@ -272,6 +273,12 @@ final class LaravelHttpServer implements HttpServer
         }
 
         $debug = config('app.debug');
+
+        // Cookies queued through the CookieJar singleton are attached to a response by the
+        // AddQueuedCookiesToResponse middleware but never removed from the jar. FPM discards the jar
+        // with the process and Octane flushes it per request; this server reuses one container for
+        // every request of a test, so a cookie queued once would be re-sent on every later response.
+        app()->make(CookieJar::class)->flushQueuedCookies();
 
         try {
             config(['app.debug' => false]);

--- a/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
+++ b/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
@@ -64,10 +64,7 @@ it('includes server variables set in the test', function (): void {
 });
 
 it('does not re-send a cookie queued in an earlier request', function (): void {
-    // AddQueuedCookiesToResponse attaches every cookie in the CookieJar singleton but never
-    // removes it. FPM drops the jar with the process and Octane flushes it per request; this
-    // server reuses one container for all requests of a test, so without a flush a cookie queued
-    // by the first request would be re-sent on every later response.
+    // Without flush the second response would re-send the queued cookie.
     Route::get('/queue-cookie', function (): string {
         Cookie::queue('queued-probe', 'first-request', 5);
 

--- a/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
+++ b/tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php
@@ -2,7 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
 
 use function Pest\Laravel\withServerVariables;
 use function Pest\Laravel\withUnencryptedCookie;
@@ -56,4 +61,31 @@ it('includes server variables set in the test', function (): void {
     withServerVariables(['test-server-key' => 'test value']);
     visit('/server-variables')
         ->assertSee('"test-server-key":"test value"');
+});
+
+it('does not re-send a cookie queued in an earlier request', function (): void {
+    // AddQueuedCookiesToResponse attaches every cookie in the CookieJar singleton but never
+    // removes it. FPM drops the jar with the process and Octane flushes it per request; this
+    // server reuses one container for all requests of a test, so without a flush a cookie queued
+    // by the first request would be re-sent on every later response.
+    Route::get('/queue-cookie', function (): string {
+        Cookie::queue('queued-probe', 'first-request', 5);
+
+        return 'queued';
+    })->middleware(AddQueuedCookiesToResponse::class);
+    Route::get('/no-cookie', fn (): string => 'plain')->middleware(AddQueuedCookiesToResponse::class);
+
+    $queued = [];
+    Event::listen(RequestHandled::class, function (RequestHandled $event) use (&$queued): void {
+        foreach ($event->response->headers->getCookies() as $cookie) {
+            if ($cookie->getName() === 'queued-probe') {
+                $queued[] = $event->request->path();
+            }
+        }
+    });
+
+    visit('/queue-cookie')->assertSee('queued');
+    visit('/no-cookie')->assertSee('plain');
+
+    expect($queued)->toBe(['queue-cookie']);
 });


### PR DESCRIPTION
## Problem

`LaravelHttpServer` serves every request of a browser test from one long-lived container. Cookies queued through `Cookie::queue()` land in the `CookieJar` singleton, and `AddQueuedCookiesToResponse` attaches **every** queued cookie to a response but never removes it from the jar. Nothing else does either:

- **FPM** discards the jar with the process;
- **Octane** flushes it between requests;
- the in-process test server keeps it for the whole test.

So a cookie queued by the first request is re-sent on every later response of the same test, including responses of routes that never queued anything.

## Impact

A browser test cannot verify *which* response hands a cookie to the browser, and a cookie a page deliberately queues once (for example a first-party attribution cookie written on the first page after consent) shows up on every Livewire/XHR response afterwards. It also masks application bugs: code that forgets to queue a cookie on a later page still "works" in the test because the stale queue is replayed. We hit this while testing a consent-dependent cookie hand-over in a Laravel app: the assertion "exactly one response carried the cookie" saw five.

## Fix

Flush the jar before handling each request, next to the existing `forgetScopedInstances()` (same per-request lifecycle FPM and Octane provide):

```php
app()->make(CookieJar::class)->flushQueuedCookies();
```

## Test

`it does not re-send a cookie queued in an earlier request` records the `Set-Cookie` headers of two requests through `RequestHandled`: the first route queues a cookie, the second does not. On the unfixed source the cookie appears on both responses (`['queue-cookie', 'no-cookie']`); with the fix only on the first.

Run: `vendor/bin/pest tests/Unit/Drivers/Laravel/LaravelHttpServerTest.php` (6 passed).
