### PR TITLE
[5.x] Raise Amp body size limit to allow large JSON request bodies

### DIFF
--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -7,6 +7,7 @@ namespace Pest\Browser\Drivers;
 use Amp\ByteStream\ReadableResourceStream;
 use Amp\Http\Cookie\RequestCookie;
 use Amp\Http\Server\DefaultErrorHandler;
+use Amp\Http\Server\Driver\DefaultHttpDriverFactory;
 use Amp\Http\Server\HttpServer as AmpHttpServer;
 use Amp\Http\Server\HttpServerStatus;
 use Amp\Http\Server\Request as AmpRequest;
@@ -99,7 +100,16 @@ final class LaravelHttpServer implements HttpServer
             return;
         }
 
-        $this->socket = $server = SocketHttpServer::createForDirectAccess(new NullLogger());
+        // Increase the body size limit beyond Amp's 128-KiB
+        // default to prevent deadlocks when reading large
+        // JSON payloads in POST, PUT, and PATCH requests.
+        $this->socket = $server = SocketHttpServer::createForDirectAccess(
+            logger: $logger = new NullLogger(),
+            httpDriverFactory: new DefaultHttpDriverFactory(
+                logger: $logger,
+                bodySizeLimit: 64 * 1024 * 1024,
+            ),
+        );
 
         $server->expose("{$this->host}:{$this->port}");
         $server->start(

--- a/tests/Browser/Visit/LargeBodyTest.php
+++ b/tests/Browser/Visit/LargeBodyTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+it('accepts JSON request bodies larger than the default 128 KiB limit', function (): void {
+    Route::post('/large-body/echo', fn (Request $request): array => [
+        'received_bytes' => mb_strlen($request->getContent()),
+        'received_count' => count($request->json('items', [])),
+    ]);
+
+    // Build a payload that comfortably exceeds Amp's 128 KiB default.
+    $items = [];
+    for ($i = 0; $i < 5000; $i++) {
+        $items[] = [
+            'id' => $i,
+            'name' => str_repeat('x', 32),
+            'description' => str_repeat('y', 64),
+        ];
+    }
+    $payload = json_encode(['items' => $items]);
+
+    expect(mb_strlen($payload))->toBeGreaterThan(128 * 1024);
+
+    // Render a tiny page that POSTs the payload via fetch and writes the JSON
+    // response into the DOM so we can assert against it.
+    Route::get('/large-body/post-from-page', fn (): string => '
+        <html><body>
+            <pre id="result"></pre>
+            <script>
+                fetch("/large-body/echo", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: '.json_encode($payload).',
+                })
+                .then(r => r.json())
+                .then(data => { document.getElementById("result").textContent = JSON.stringify(data); });
+            </script>
+        </body></html>
+    ');
+
+    visit('/large-body/post-from-page')
+        ->assertSee('"received_bytes":'.mb_strlen($payload))
+        ->assertSee('"received_count":5000');
+});


### PR DESCRIPTION
Amp's `SocketHttpServer::createForDirectAccess()` defaults to a 128 KiB body size limit, which caused deadlocks/hangs when reading large JSON payloads in `POST`/`PUT`/`PATCH` requests. The server is now created with an explicit `DefaultHttpDriverFactory` raising the body size limit to 64 MiB, allowing large request bodies to be read without stalling.