### PR TITLE
feat: hand the application the files of a multipart request

### DIFF
--- a/src/Drivers/LaravelHttpServer.php
+++ b/src/Drivers/LaravelHttpServer.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Testing\Concerns\WithoutExceptionHandlingHandler;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Uri;
 use Pest\Browser\Contracts\HttpServer;
@@ -241,8 +242,12 @@ final class LaravelHttpServer implements HttpServer
         $method = mb_strtoupper($request->getMethod());
         $rawBody = (string) $request->getBody();
         $parameters = [];
+        $files = [];
         if ($method !== 'GET' && str_starts_with(mb_strtolower($contentType), 'application/x-www-form-urlencoded')) {
             parse_str($rawBody, $parameters);
+        }
+        if ($method !== 'GET' && preg_match('/^multipart\/form-data;.*boundary="?([^";]+)"?/i', $contentType, $boundary) === 1) {
+            [$parameters, $files] = $this->parseMultipartBody($rawBody, $boundary[1]);
         }
         $cookies = array_map(fn (RequestCookie $cookie): string => urldecode($cookie->getValue()), $request->getCookies());
         $cookies = array_merge($cookies, test()->prepareCookiesForRequest()); // @phpstan-ignore-line
@@ -254,7 +259,7 @@ final class LaravelHttpServer implements HttpServer
             $method,
             $parameters,
             $cookies,
-            [], // @TODO files...
+            $files,
             $serverVariables,
             $rawBody
         );
@@ -279,6 +284,7 @@ final class LaravelHttpServer implements HttpServer
             $response = $kernel->handle($laravelRequest = Request::createFromBase($symfonyRequest));
         } catch (Throwable $e) {
             $this->lastThrowable = $e;
+            $this->removeUploads($files);
 
             throw $e;
         } finally {
@@ -286,6 +292,9 @@ final class LaravelHttpServer implements HttpServer
         }
 
         $kernel->terminate($laravelRequest, $response);
+
+        // PHP removes the temporary files at shutdown, after terminate: a listener reading an upload there still finds it.
+        $this->removeUploads($files);
 
         if (property_exists($response, 'exception') && $response->exception !== null) {
             assert($response->exception instanceof Throwable);
@@ -358,5 +367,63 @@ final class LaravelHttpServer implements HttpServer
         }
 
         return str_replace($this->originalAssetUrl, $this->url(), $content);
+    }
+
+    /**
+     * Remove the temporary files of the uploads.
+     *
+     * @param  array<string, UploadedFile>  $files
+     */
+    private function removeUploads(array $files): void
+    {
+        foreach ($files as $file) {
+            @unlink($file->getPathname());
+        }
+    }
+
+    /**
+     * Reads a multipart body the way PHP does for a real upload: the fields
+     * into the parameters, each file into a temporary file wrapped in an
+     * upload in test mode (there is no real upload for `is_uploaded_file()`
+     * to recognise here). Two parts with the same name keep the last file,
+     * and a nested name such as `files[avatar]` stays flat where PHP would
+     * nest it.
+     *
+     * @return array{0: array<int|string, mixed>, 1: array<string, UploadedFile>}
+     */
+    private function parseMultipartBody(string $body, string $boundary): array
+    {
+        $fields = '';
+        $files = [];
+
+        foreach (explode("--{$boundary}", $body) as $part) {
+            $part = mb_ltrim($part, "\r\n");
+            if ($part === '' || str_starts_with($part, '--')) {
+                continue;
+            }
+
+            [$rawHeaders, $content] = array_pad(explode("\r\n\r\n", $part, 2), 2, '');
+            $content = preg_replace('/\r\n$/', '', $content) ?? $content;
+            if (preg_match('/;\s*name="([^"]*)"/', $rawHeaders, $name) !== 1) {
+                continue;
+            }
+
+            if (preg_match('/filename="([^"]*)"/', $rawHeaders, $fileName) === 1) {
+                $path = (string) tempnam(sys_get_temp_dir(), 'pest-upload-');
+                file_put_contents($path, $content);
+                $mimeType = preg_match('/Content-Type:\s*([^\r\n]+)/i', $rawHeaders, $type) === 1 ? mb_trim($type[1]) : null;
+                $files[$name[1]] = new UploadedFile($path, $fileName[1], $mimeType, null, true);
+
+                continue;
+            }
+
+            // Encoded then parsed as a query string, so that `items[]` and `a[b]` nest as they would.
+            $fields .= ($fields === '' ? '' : '&').rawurlencode($name[1]).'='.rawurlencode($content);
+        }
+
+        $parameters = [];
+        parse_str($fields, $parameters);
+
+        return [$parameters, $files];
     }
 }

--- a/tests/Browser/Webpage/UploadTest.php
+++ b/tests/Browser/Webpage/UploadTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+it('hands the application the files and the fields of a multipart form', function (): void {
+    Route::get('/', fn (): string => '
+        <form method="post" action="/upload" enctype="multipart/form-data">
+            <input type="text" name="label" value="my avatar">
+            <input type="text" name="tags[]" value="one">
+            <input type="text" name="tags[]" value="two">
+            <input type="file" id="avatar" name="avatar">
+            <button type="submit">Upload</button>
+        </form>
+    ');
+    Route::post('/upload', function (Request $request): string {
+        $file = $request->file('avatar');
+
+        return sprintf(
+            'received %s (%d bytes, %s) labelled "%s" with tags %s, valid: %s',
+            $file->getClientOriginalName(),
+            $file->getSize(),
+            (string) file_get_contents($file->getPathname()),
+            $request->input('label'),
+            implode('+', $request->input('tags')),
+            $file->isValid() ? 'yes' : 'no',
+        );
+    });
+
+    $tempFile = tempnam(sys_get_temp_dir(), 'test');
+    file_put_contents($tempFile, 'test content');
+
+    $page = visit('/');
+    $page->attach('#avatar', $tempFile)
+        ->click('Upload')
+        ->assertSee(sprintf('received %s (12 bytes, test content) labelled "my avatar" with tags one+two, valid: yes', basename($tempFile)));
+
+    unlink($tempFile);
+});


### PR DESCRIPTION
## What

The in-process Laravel server builds the request from the raw body and leaves the uploaded files aside (`Request::create(..., [], // @TODO files...`). A form submitted from the browser with `enctype="multipart/form-data"` therefore reaches the application without its files, and a `required` file field answers with a validation error.

This reads a multipart body the way PHP does for a real upload: the fields go into the request parameters (nested names such as `tags[]` included), each file goes into a temporary file wrapped in an `Illuminate\Http\UploadedFile` in test mode, and the temporary files are removed once the kernel has terminated the request.

## Why `Illuminate\Http\UploadedFile` in test mode

Laravel keeps an instance of its own class untouched when it converts the request's files, while a Symfony instance is converted again without the test flag, and `isValid()` then fails on `is_uploaded_file()` since nothing was really uploaded through PHP.

## Test

`tests/Browser/Webpage/UploadTest.php` submits a multipart form with a text field, an array field and a file, and asserts the application received the file with its name, size and content, valid, along with the fields.

## Notes

- Only `multipart/form-data` bodies are parsed; `application/x-www-form-urlencoded` keeps its `parse_str` path.
- Found while writing browser tests for a Laravel application whose first step is a PDF upload; the same fix is applied there as a test-only middleware until this lands.
